### PR TITLE
Deploy to GOV.UK PaaS with concourse

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,3 @@
+tmp
+Procfile
+vendor

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ end
 
 group :test do
   gem 'simplecov', '~> 0.16'
+  gem 'therubyracer', '~> 0.12'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,7 @@ GEM
     jaro_winkler (1.5.4)
     kgio (2.11.3)
     kramdown (2.1.0)
+    libv8 (3.16.14.19)
     link_header (0.0.8)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -184,6 +185,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    ref (2.0.0)
     request_store (1.5.0)
       rack (>= 1.4)
     rest-client (2.1.0)
@@ -255,6 +257,9 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     statsd-ruby (1.4.0)
+    therubyracer (0.12.3)
+      libv8 (~> 3.16.14.15)
+      ref
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -290,6 +295,7 @@ DEPENDENCIES
   rspec-rails (~> 3)
   rubocop-govuk
   simplecov (~> 0.16)
+  therubyracer (~> 0.12)
   uglifier (~> 4.2)
 
 RUBY VERSION

--- a/README.md
+++ b/README.md
@@ -30,3 +30,13 @@ Clone the app and run `bundle` locally.  You will need Postgres installed in ord
 ### Running the tests
 
     bundle exec rake
+
+## Deployment pipeline
+
+Every commit to master is deployed to GOV.UK PaaS by
+[this concourse pipeline](https://cd.gds-reliability.engineering/teams/govuk-tools/pipelines/govuk-coronavirus-business-volunteer-form),
+which is configured in [concourse/pipeline.yml](concourse/pipeline.yml).
+
+The concourse pipeline has credentials for the `govuk-forms-deployer` user in
+GOV.UK PaaS. This user has the SpaceDeveloper role, so it can `cf push` the application.
+

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -11,7 +11,7 @@ resources:
     icon: github-circle
     source:
       uri: https://github.com/alphagov/govuk-coronavirus-business-volunteer-form
-      branch: techops-ify
+      branch: master
 
 jobs:
   - name: run-specs

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -1,0 +1,100 @@
+---
+resource_types:
+  - name: cf-cli
+    type: docker-image
+    source:
+      repository: nulldriver/cf-cli-resource
+
+resources:
+  - name: govuk-coronavirus-business-volunteer-form
+    type: git
+    icon: github-circle
+    source:
+      uri: https://github.com/alphagov/govuk-coronavirus-business-volunteer-form
+      branch: techops-ify
+
+jobs:
+  - name: run-specs
+    plan:
+      - get: govuk-coronavirus-business-volunteer-form
+        trigger: true
+      - task: run-specs
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: ruby
+              tag: '2.6.5'
+          inputs:
+            - name: govuk-coronavirus-business-volunteer-form
+              path: src
+          caches:
+            - path: vendor/bundle
+          run:
+            dir: src
+            path: sh
+            args:
+              - '-c'
+              - |
+                set -eu
+
+                bundle install --path ../vendor/bundle
+                bundle exec rake spec
+
+  - name: deploy-to-staging
+    serial: true
+    plan:
+      - get: govuk-coronavirus-business-volunteer-form
+        passed: [run-specs]
+        trigger: true
+      - task: paas-staging
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/cf-cli
+              tag: latest
+          inputs:
+            - name: govuk-coronavirus-business-volunteer-form
+              path: src
+          params:
+            CF_API: https://api.cloud.service.gov.uk
+            CF_USERNAME: ((paas-username))
+            CF_PASSWORD: ((paas-password))
+            CF_ORG: govuk_development
+            CF_SPACE: staging
+          run:
+            dir: src
+            path: sh
+            args:
+              - '-c'
+              - |
+                set -eu
+
+                cf api "$CF_API"
+                cf auth
+                cf t -o "$CF_ORG" -s "$CF_SPACE"
+                cf v3-create-app govuk-coronavirus-business-volunteer-form || true
+                cf v3-apply-manifest -f manifest.yml
+                cf v3-zdt-push govuk-coronavirus-business-volunteer-form --wait-for-deploy-complete --no-route
+                cf map-route govuk-coronavirus-business-volunteer-form cloudapps.digital --hostname govuk-coronavirus-business-volunteer-form-stg
+
+  - name: smoke-test-staging
+    plan:
+      - get: govuk-coronavirus-business-volunteer-form
+        trigger: true
+        passed: [deploy-to-staging]
+      - task: smoke-test
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/curl-ssl
+          run:
+            # TODO we can come up with a more thorough test than this
+            path: curl
+            args: ['--fail', '--head', '--silent', 'https://govuk-coronavirus-business-volunteer-form-stg.cloudapps.digital/']
+

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,12 @@
+---
+applications:
+- name: govuk-coronavirus-business-volunteer-form
+  buildpack: ruby_buildpack
+  memory: 1G
+  instances: 5
+  services:
+  - govuk-coronavirus-business-volunteer-form-db
+  env:
+    GOVUK_APP_DOMAIN: cloudapps.digital
+    GOVUK_WEBSITE_ROOT: www.gov.uk
+


### PR DESCRIPTION
This adds a manifest.yml to tell cloud foundry how to deploy the application,
and a concourse pipeline to run the tests and trigger the deployment.

I've already set up a postgres database (manually) in the staging space.