### PR TITLE
Migration to add table for storing form responses

### DIFF
--- a/db/migrate/20200320105826_create_form_responses.rb
+++ b/db/migrate/20200320105826_create_form_responses.rb
@@ -1,0 +1,8 @@
+class CreateFormResponses < ActiveRecord::Migration[6.0]
+  def change
+    create_table :form_responses do |t|
+      t.jsonb :form_response, default: {}, null: false
+      t.datetime :created_at, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,7 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2020_03_20_105826) do
+
   # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
+  enable_extension "plpgsql"
+
+  create_table "form_responses", force: :cascade do |t|
+    t.jsonb "form_response", default: {}, null: false
+    t.datetime "created_at", null: false
+  end
+
 end


### PR DESCRIPTION
We need to store form responses from users.  Adding a basic migration to store the submission timestamps and form response (as a JSON representation).  Using JSON will allow the questions to remain fluid without needing to change the database schema.

Trello card: https://trello.com/c/4tLmMu1n