### PR TITLE
Ship logs to logit

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -6,6 +6,7 @@ applications:
   instances: 5
   services:
   - govuk-coronavirus-business-volunteer-form-db
+  - logit-ssl-drain
   env:
     GOVUK_APP_DOMAIN: cloudapps.digital
     GOVUK_WEBSITE_ROOT: www.gov.uk


### PR DESCRIPTION
I set this user provided service up manually in the staging space. It's
shipping to the (also manually created) "GOV.UK Staging Corona Forms" logit
stack.

I was following the docs here:

https://docs.cloud.service.gov.uk/monitoring_apps.html#set-up-the-logit-log-management-service

We might need to do some bits in the application to get it to print logs
in a way that's easy to index, but we can cross that bridge a bit later.