### PR TITLE
Add basic authentication

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,26 @@
+{
+  "name": "Coronavirus form",
+  "repository": "https://github.com/alphagov/govuk-coronavirus-business-volunteer-form",
+  "env": {
+    "GOVUK_APP_DOMAIN": {
+      "value": "www.gov.uk"
+    },
+    "GOVUK_WEBSITE_ROOT": {
+      "value": "https://www.gov.uk"
+    },
+    "BASIC_AUTH_USERNAME": {
+      "required": true
+    },
+    "BASIC_AUTH_PASSWORD": {
+      "required": true
+    },
+    "REQUIRE_BASIC_AUTH": "true"
+  },
+  "image": "heroku/ruby",
+  "buildpacks": [
+    {
+      "url": "https://github.com/heroku/heroku-buildpack-ruby"
+    }
+  ],
+  "addons": []
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+
+  if ENV["REQUIRE_BASIC_AUTH"]
+    http_basic_authenticate_with(
+      name: ENV.fetch("BASIC_AUTH_USERNAME"),
+      password: ENV.fetch("BASIC_AUTH_PASSWORD"),
+    )
+  end
+
   private
 
   helper_method :previous_path


### PR DESCRIPTION
I've added the required envvars to Heroku; it should work as normal locally.

https://trello.com/c/phr6p0iZ/32-put-review-and-staging-apps-behind-basic-auth