### PR TITLE
Add medical device questions branch

### DIFF
--- a/app/controllers/coronavirus_form/additional_product_check_controller.rb
+++ b/app/controllers/coronavirus_form/additional_product_check_controller.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class CoronavirusForm::AdditionalProductCheckController < ApplicationController
+  include ActionView::Helpers::SanitizeHelper
+  include FieldValidationHelper
+
+  def show
+    render "coronavirus_form/#{PAGE}"
+  end
+
+  def submit
+    additional_product_check = sanitize(params[:additional_product_check]).presence
+
+    invalid_fields = validate_radio_field(
+      PAGE,
+      radio: additional_product_check,
+    )
+
+    if invalid_fields.any?
+      flash.now[:validation] = invalid_fields
+      render "coronavirus_form/#{PAGE}"
+    elsif session["check_answers_seen"]
+      redirect_to controller: "coronavirus_form/check_answers", action: "show"
+    elsif additional_product_check == I18n.t("coronavirus_form.additional_product_check.options.option_yes.label")
+      redirect_to controller: "coronavirus_form/product_details", action: "show"
+    else
+      redirect_to controller: "coronavirus_form/hotel_rooms", action: "show"
+    end
+  end
+
+private
+
+  PAGE = "additional_product_check"
+
+  def previous_path
+    session[:products] ||= []
+    latest_product_id = (session[:products].last || {}).dig("product_id")
+    "/coronavirus-form/product-details?product_id=#{latest_product_id}"
+  end
+end

--- a/app/controllers/coronavirus_form/manufacturer_check_controller.rb
+++ b/app/controllers/coronavirus_form/manufacturer_check_controller.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class CoronavirusForm::ManufacturerCheckController < ApplicationController
+  include ActionView::Helpers::SanitizeHelper
+  include FieldValidationHelper
+
+  def show
+    session[:manufacturer_check] = []
+    render "coronavirus_form/#{PAGE}"
+  end
+
+  def submit
+    manufacturer_check = Array(params[:manufacturer_check]).map { |item| sanitize(item).presence }.compact
+
+    session[:manufacturer_check] = manufacturer_check
+
+    invalid_fields = validate_checkbox_field(
+      PAGE,
+      values: manufacturer_check,
+      allowed_values: I18n.t("coronavirus_form.#{PAGE}.options").map { |_, item| item.dig(:label) },
+    )
+
+    if invalid_fields.any?
+      flash.now[:validation] = invalid_fields
+      render "coronavirus_form/#{PAGE}"
+    elsif session["check_answers_seen"]
+      redirect_to controller: "coronavirus_form/check_answers", action: "show"
+    else
+      redirect_to controller: "coronavirus_form/product_details", action: "show"
+    end
+  end
+
+private
+
+  PAGE = "manufacturer_check"
+
+  def previous_path
+    "/coronavirus-form/medical-equipment-type"
+  end
+end

--- a/app/controllers/coronavirus_form/medical_equipment_type_controller.rb
+++ b/app/controllers/coronavirus_form/medical_equipment_type_controller.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class CoronavirusForm::MedicalEquipmentTypeController < ApplicationController
+  include ActionView::Helpers::SanitizeHelper
+  include FieldValidationHelper
+
+  def show
+    session[:medical_equipment_type] ||= []
+    render "coronavirus_form/#{PAGE}"
+  end
+
+  def submit
+    medical_equipment_type = Array(params[:medical_equipment_type]).map { |item| sanitize(item).presence }.compact
+    medical_equipment_type_other = sanitize(params[:medical_equipment_type_other]).presence
+    session[:medical_equipment_type] = medical_equipment_type
+    session[:medical_equipment_type_other] = if selected_other?(medical_equipment_type)
+                                               medical_equipment_type_other
+                                             else
+                                               ""
+                                             end
+    invalid_fields = validate_checkbox_field(
+      PAGE,
+      values: medical_equipment_type,
+      allowed_values: I18n.t("coronavirus_form.#{PAGE}.options").map { |_, item| item.dig(:label) },
+      other: medical_equipment_type_other,
+    )
+
+    if invalid_fields.any?
+      flash.now[:validation] = invalid_fields
+      render "coronavirus_form/#{PAGE}"
+    else
+      redirect_to controller: session["check_answers_seen"] ? "coronavirus_form/check_answers" : "coronavirus_form/#{NEXT_PAGE}", action: "show"
+    end
+  end
+
+private
+
+  PAGE = "medical_equipment_type"
+  NEXT_PAGE = "manufacturer_check"
+
+  def selected_other?(medical_equipment_type)
+    medical_equipment_type.include?(
+      I18n.t("coronavirus_form.medical_equipment_type.options.other.label"),
+    )
+  end
+
+  def previous_path
+    "/coronavirus-form/medical-equipment"
+  end
+end

--- a/app/controllers/coronavirus_form/product_details_controller.rb
+++ b/app/controllers/coronavirus_form/product_details_controller.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+class CoronavirusForm::ProductDetailsController < ApplicationController
+  include ActionView::Helpers::SanitizeHelper
+  include FieldValidationHelper
+
+  REQUIRED_FIELDS = %w(product_name product_cost certification_details product_postcode lead_time).freeze
+
+  def show
+    session[:products] ||= []
+    @product = find_product(params["product_id"], session[:products])
+    render "coronavirus_form/#{PAGE}"
+  end
+
+  def submit
+    @product = sanitized_product(params)
+    add_product_to_session(@product)
+
+    invalid_fields = validate_fields(@product)
+
+    if invalid_fields.any?
+      flash.now[:validation] = invalid_fields
+      render "coronavirus_form/#{PAGE}"
+    else
+      redirect_to controller: session["check_answers_seen"] ? "coronavirus_form/check_answers" : "coronavirus_form/#{NEXT_PAGE}", action: "show"
+    end
+  end
+
+private
+
+  NEXT_PAGE = "additional_product_check"
+  PAGE = "product_details"
+
+  def find_product(product_id, products)
+    products.find { |product| product["product_id"] == product_id } || {}
+  end
+
+  def validate_fields(product)
+    missing_fields = validate_missing_fields(product)
+    postcode_validation = validate_postcode("product_postcode", product["product_postcode"])
+    missing_fields + postcode_validation
+  end
+
+  def validate_missing_fields(product)
+    REQUIRED_FIELDS.each_with_object([]) do |field, invalid_fields|
+      next if product[field].present?
+
+      invalid_fields << {
+        field: field.to_s,
+        text: t("coronavirus_form.#{PAGE}.#{field}.custom_error",
+                default: t("coronavirus_form.errors.missing_mandatory_text_field",
+                           field: t("coronavirus_form.#{PAGE}.#{field}.label")).humanize),
+      }
+    end
+  end
+
+  def sanitized_product(params)
+    {
+      "product_id" => sanitize(params[:product_id]).presence || SecureRandom.uuid,
+      "product_name" => sanitize(params[:product_name]).presence,
+      "product_cost" => sanitize(params[:product_cost]).presence,
+      "certification_details" => sanitize(params[:certification_details]).presence,
+      "product_postcode" => sanitize(params[:product_postcode]).presence,
+      "product_url" => sanitize(params[:product_url]).presence,
+      "lead_time" => sanitize(params[:lead_time]).presence,
+    }
+  end
+
+  def add_product_to_session(product)
+    session[:products] ||= []
+    products = session[:products].reject do |prod|
+      prod["product_id"] == product["product_id"]
+    end
+    session[:products] = products << @product
+  end
+
+  def previous_path
+    return coronavirus_form_additional_product_path if params["product_id"]
+
+    return coronavirus_form_check_your_answers_path if session["check_answers_seen"]
+
+    coronavirus_form_are_you_a_manufacturer_path
+  end
+end

--- a/app/helpers/field_validation_helper.rb
+++ b/app/helpers/field_validation_helper.rb
@@ -33,7 +33,7 @@ module FieldValidationHelper
     []
   end
 
-  def validate_checkbox_field(page, values:, allowed_values:)
+  def validate_checkbox_field(page, values:, allowed_values:, other: false)
     if values.blank? || values.empty?
       return [{ field: page.to_s,
                 text: t(
@@ -46,6 +46,14 @@ module FieldValidationHelper
       return [{ field: page.to_s,
                 text: t(
                   "coronavirus_form.#{page}.custom_select_error",
+                  default: t("coronavirus_form.errors.missing_mandatory_text_field", field: t("coronavirus_form.#{page}.title")).humanize,
+                ) }]
+    end
+
+    if other != false && other.blank? && values.include?("Other")
+      return [{ field: page.to_s,
+                text: t(
+                  "coronavirus_form.#{page}.options.other.error_message",
                   default: t("coronavirus_form.errors.missing_mandatory_text_field", field: t("coronavirus_form.#{page}.title")).humanize,
                 ) }]
     end

--- a/app/models/form_response.rb
+++ b/app/models/form_response.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 class FormResponse < ApplicationRecord
 end

--- a/app/views/coronavirus_form/additional_product_check.html.erb
+++ b/app/views/coronavirus_form/additional_product_check.html.erb
@@ -1,0 +1,34 @@
+<% content_for :title do %><%= t('coronavirus_form.additional_product_check.title') %><% end %>
+<% content_for :meta_tags do %>
+  <meta name="description" content="<%= t('coronavirus_form.additional_product_check.title') %>" />
+<% end %>
+
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", { href: previous_path } %>
+<% end %>
+
+<%= render "coronavirus_form/validation_error" %>
+<%= form_tag({},
+  "data-module": "track-coronavirus-form-business-manufacturer-check",
+  "data-question-key": "additional_product_check",
+  "id": "additional_product_check"
+) do %>
+<%= render "govuk_publishing_components/components/radio", {
+  heading: t('coronavirus_form.additional_product_check.title'),
+  is_page_heading: true,
+  name: "additional_product_check",
+  items: [
+    {
+      value: t('coronavirus_form.additional_product_check.options.option_yes.label'),
+      text: t('coronavirus_form.additional_product_check.options.option_yes.label'),
+      checked: session[:additional_product_check] == t('coronavirus_form.additional_product_check.options.option_yes.label'),
+    },
+    {
+      value: t('coronavirus_form.additional_product_check.options.option_no.label'),
+      text: t('coronavirus_form.additional_product_check.options.option_no.label'),
+      checked: session[:additional_product_check] == t('coronavirus_form.additional_product_check.options.option_no.label'),
+    },
+  ]
+} %>
+<%= render "govuk_publishing_components/components/button", text: "Save and continue", margin_bottom: true %>
+<% end %>

--- a/app/views/coronavirus_form/manufacturer_check.html.erb
+++ b/app/views/coronavirus_form/manufacturer_check.html.erb
@@ -1,0 +1,29 @@
+<% content_for :title do %><%= t('coronavirus_form.manufacturer_check.title') %><% end %>
+<% content_for :meta_tags do %>
+  <meta name="description" content="<%= t('coronavirus_form.manufacturer_check.title') %>" />
+<% end %>
+
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", { href: previous_path } %>
+<% end %>
+
+<%= render "coronavirus_form/validation_error" %>
+<%= form_tag({},
+  "data-module": "track-coronavirus-form-business-manufacturer-check",
+  "data-question-key": "manufacturer_check",
+  "id": "manufacturer_check"
+) do %>
+<%= render "govuk_publishing_components/components/checkboxes", {
+  heading: t('coronavirus_form.manufacturer_check.title'),
+  is_page_heading: true,
+  name: "manufacturer_check",
+  items: t('coronavirus_form.manufacturer_check.options').map do |_, item|
+    {
+      value:  item[:label],
+      label:  item[:label],
+      checked: session[:manufacturer_check].include?(item[:label]),
+    }
+  end
+} %>
+<%= render "govuk_publishing_components/components/button", text: "Save and continue", margin_bottom: true %>
+<% end %>

--- a/app/views/coronavirus_form/medical_equipment_type.html.erb
+++ b/app/views/coronavirus_form/medical_equipment_type.html.erb
@@ -1,0 +1,47 @@
+<% content_for :title do %><%= t('coronavirus_form.medical_equipment_type.title') %><% end %>
+<% content_for :meta_tags do %>
+  <meta name="description" content="<%= t('coronavirus_form.medical_equipment_type.title') %>" />
+<% end %>
+
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", { href: previous_path } %>
+<% end %>
+
+<%= render "coronavirus_form/validation_error" %>
+<%= form_tag({},
+  "data-module": "track-coronavirus-form-business-medical-equipment-type",
+  "data-question-key": "medical_equipment_type",
+  "id": "medical_equipment_type"
+) do %>
+<%= render "govuk_publishing_components/components/checkboxes", {
+  heading: t('coronavirus_form.medical_equipment_type.title'),
+  is_page_heading: true,
+  name: "medical_equipment_type[]",
+  items: [
+    {
+      value: t('coronavirus_form.medical_equipment_type.options.number_ppe.label'),
+      label: t('coronavirus_form.medical_equipment_type.options.number_ppe.label'),
+      checked: session[:medical_equipment_type].include?(t('coronavirus_form.medical_equipment_type.options.number_ppe.label')),
+    },
+    {
+      value: t('coronavirus_form.medical_equipment_type.options.number_testing_equipment.label'),
+      label: t('coronavirus_form.medical_equipment_type.options.number_testing_equipment.label'),
+      checked: session[:medical_equipment_type].include?(t('coronavirus_form.medical_equipment_type.options.number_testing_equipment.label')),
+    },
+    {
+      value: t('coronavirus_form.medical_equipment_type.options.other.label'),
+      label: t('coronavirus_form.medical_equipment_type.options.other.label'),
+      checked: session[:medical_equipment_type].include?(t('coronavirus_form.medical_equipment_type.options.other.label')),
+      conditional: render("govuk_publishing_components/components/input", {
+        label: {
+          text: t('coronavirus_form.medical_equipment_type.options.other.input.label'),
+        },
+        name: "medical_equipment_type_other",
+        value: session[:medical_equipment_type_other],
+        width: 10
+      })
+    },
+  ]
+} %>
+<%= render "govuk_publishing_components/components/button", text: "Save and continue", margin_bottom: true %>
+<% end %>

--- a/app/views/coronavirus_form/product_details.html.erb
+++ b/app/views/coronavirus_form/product_details.html.erb
@@ -1,0 +1,74 @@
+<% content_for :title do %><%= t('coronavirus_form.product_details.title') %><% end %>
+<% content_for :meta_tags do %>
+  <meta name="description" content="<%= t('coronavirus_form.product_details.title') %>" />
+<% end %>
+
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", { href: previous_path } %>
+<% end %>
+
+<%= render "govuk_publishing_components/components/title", {
+  title:t("coronavirus_form.product_details.title"),
+  margin_top: 0
+} %>
+
+<%= render "coronavirus_form/validation_error" %>
+<%= form_tag({},
+  "data-module": "track-coronavirus-form-business-product-details",
+  "data-question-key": "product_details",
+  "id": "product_details"
+) do %>
+<div style="display:none;">
+  <%= render "govuk_publishing_components/components/input", {
+    name: "product_id",
+    value: @product["product_id"],
+  } %>
+</div>
+<%= render "govuk_publishing_components/components/input", {
+  label: {
+    text: t('coronavirus_form.product_details.product_name.label')
+  },
+  name: "product_name",
+  value: @product["product_name"],
+} %>
+<%= render "govuk_publishing_components/components/input", {
+  label: {
+    text: t('coronavirus_form.product_details.product_cost.label'),
+  },
+  hint: t('coronavirus_form.product_details.product_cost.hint'),
+  name: "product_cost",
+  value: @product["product_cost"],
+} %>
+<%= render "govuk_publishing_components/components/input", {
+  label: {
+    text: t('coronavirus_form.product_details.certification_details.label'),
+  },
+  hint: t('coronavirus_form.product_details.certification_details.hint'),
+  name: "certification_details",
+  value: @product["certification_details"],
+} %>
+<%= render "govuk_publishing_components/components/input", {
+  label: {
+    text: t('coronavirus_form.product_details.product_postcode.label')
+  },
+  name: "product_postcode",
+  value: @product["product_postcode"],
+} %>
+<%= render "govuk_publishing_components/components/input", {
+  label: {
+    text: t('coronavirus_form.product_details.product_url.label')
+  },
+  name: "product_url",
+  value: @product["product_url"],
+} %>
+<%= render "govuk_publishing_components/components/input", {
+  label: {
+    text: t('coronavirus_form.product_details.lead_time.label')
+  },
+  name: "lead_time",
+  type: "number",
+  value: @product["lead_time"],
+  width: 10,
+} %>
+<%= render "govuk_publishing_components/components/button", text: "Save and continue", margin_bottom: true %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,7 +52,7 @@ en:
         individual:
           label: Individual
     product_details:
-      title: Tell us about the equipment that you are offering
+      title: Tell us about the equipment that you're offering
       product_name:
         label: Name of product
       product_cost:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,7 +41,7 @@ en:
       custom_select_error: Please provide details of the medical equipment you can provide
     manufacturer_check:
       title: What kind of business are you?
-      hint: Select the best way to describe your business
+      hint: Select the best way to describe your work
       options:
         manufacturer:
           label: Manufacturer

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,6 +26,54 @@ en:
           label: "Yes"
         option_no:
           label: "No"
+    medical_equipment_type:
+      title: What medical equipment can you offer?
+      options:
+        number_ppe:
+          label: "Personal protection equipment"
+        number_testing_equipment:
+          label: "Testing equipment"
+        other:
+          label: "Other"
+          input:
+            label: "Give a description"
+          error_message: Please provide details of the other medical equipment you can provide
+      custom_select_error: Please provide details of the medical equipment you can provide
+    manufacturer_check:
+      title: What kind of business are you?
+      hint: Select the best way to describe your business
+      options:
+        manufacturer:
+          label: Manufacturer
+        distributor:
+          label: Distributor
+        agent:
+          label: Agent
+        individual:
+          label: Individual
+    product_details:
+      title: Tell us about the equipment that you are offering
+      product_name:
+        label: Name of product
+      product_cost:
+        label: Cost of product
+        hint: For example, £23.99. Enter 0 if you will donate it.
+      certification_details:
+        label: Certification details
+        hint: For example, CE marking or EN standards.
+      product_postcode:
+        label: Postcode of stock location or manufacture
+      product_url:
+        label: URL of product specification document (optional)
+      lead_time:
+        label: Lead time in days
+    additional_product_check:
+      title: Can you offer another product?
+      options:
+        option_yes:
+          label: "Yes"
+        option_no:
+          label: "No"
     which_goods:
       title: What goods can your business help with?
       hint: Select the types of things you think you can help with
@@ -47,7 +95,7 @@ en:
             label: Please provide a description
         no_goods:
           label: "I can't provide goods"
-      custom_select_error: Select select which goods you can provide
+      custom_select_error: Select which goods you can provide
     which_services:
       title: What services can your business help with?
       hint: Select the types of things you think you can help with
@@ -81,6 +129,7 @@ en:
           label: "Yes"
         option_no:
           label: "No"
+      custom_select_error: Select which services you can provide
     thank_you:
       title: "Thank you for telling us how you can help"
       sub_heading: "We'll be in touch to discuss how you can help."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,15 @@ Rails.application.routes.draw do
   get "/coronavirus-form/hotel-rooms" => "coronavirus_form/hotel_rooms#show"
   post "/coronavirus-form/hotel-rooms" => "coronavirus_form/hotel_rooms#submit"
 
+  get "/coronavirus-form/are-you-a-manufacturer" => "coronavirus_form/manufacturer_check#show"
+  post "/coronavirus-form/are-you-a-manufacturer" => "coronavirus_form/manufacturer_check#submit"
+
+  get "/coronavirus-form/product-details" => "coronavirus_form/product_details#show"
+  post "/coronavirus-form/product-details" => "coronavirus_form/product_details#submit"
+
+  get "/coronavirus-form/additional-product" => "coronavirus_form/additional_product_check#show"
+  post "/coronavirus-form/additional-product" => "coronavirus_form/additional_product_check#submit"
+
   get "/coronavirus-form/which-goods" => "coronavirus_form/which_goods#show"
   post "/coronavirus-form/which-goods" => "coronavirus_form/which_goods#submit"
 

--- a/spec/controllers/coronavirus-form/additional_product_check_controller_spec.rb
+++ b/spec/controllers/coronavirus-form/additional_product_check_controller_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe CoronavirusForm::AdditionalProductCheckController, type: :controller do
+  let(:current_template) { "coronavirus_form/additional_product_check" }
+
+  describe "GET show" do
+    it "renders the form" do
+      get :show
+      expect(response).to render_template(current_template)
+    end
+  end
+
+  describe "POST submit" do
+    it "redirects to next step for yes response" do
+      post :submit, params: { additional_product_check: "Yes" }
+      expect(response).to redirect_to(coronavirus_form_product_details_path)
+    end
+
+    it "redirects to next sub-question for no response" do
+      post :submit, params: { additional_product_check: "No" }
+
+      expect(response).to redirect_to(coronavirus_form_hotel_rooms_path)
+    end
+
+    it "redirects to check your answers if check your answers previously seen" do
+      session[:check_answers_seen] = true
+      post :submit, params: { additional_product_check: "Yes" }
+
+      expect(response).to redirect_to("/coronavirus-form/check-your-answers")
+    end
+
+    it "validates any option is chosen" do
+      post :submit, params: { additional_product_check: "" }
+
+      expect(response).to render_template(current_template)
+    end
+
+    it "validates a valid option is chosen" do
+      post :submit, params: { additional_product_check: "<script></script>" }
+
+      expect(response).to render_template(current_template)
+    end
+  end
+end

--- a/spec/controllers/coronavirus-form/manufacturer_check_controller_spec.rb
+++ b/spec/controllers/coronavirus-form/manufacturer_check_controller_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe CoronavirusForm::ManufacturerCheckController, type: :controller do
+  let(:current_template) { "coronavirus_form/manufacturer_check" }
+  let(:session_key) { :manufacturer_check }
+
+  describe "GET show" do
+    it "renders the form" do
+      get :show
+      expect(response).to render_template(current_template)
+    end
+  end
+
+  describe "POST submit" do
+    let(:selected) { %w[Distributor Manufacturer] }
+
+    it "sets session variables" do
+      post :submit, params: { manufacturer_check: selected }
+
+      expect(session[session_key]).to eq selected
+    end
+
+    it "redirects to next step" do
+      post :submit, params: { manufacturer_check: selected }
+
+      expect(response).to redirect_to("/coronavirus-form/product-details")
+    end
+
+    it "redirects to check your answers if check your answers already seen" do
+      session[:check_answers_seen] = true
+      post :submit, params: { manufacturer_check: selected }
+
+      expect(response).to redirect_to("/coronavirus-form/check-your-answers")
+    end
+
+    it "validates any option is chosen" do
+      post :submit, params: { manufacturer_check: [] }
+
+      expect(response).to render_template(current_template)
+    end
+
+    it "validates a valid option is chosen" do
+      post :submit, params: {
+        manufacturer_check: [
+          "<script></script",
+          "invalid option",
+          "Medical equipment",
+        ],
+      }
+
+      expect(response).to render_template(current_template)
+    end
+  end
+end

--- a/spec/controllers/coronavirus-form/medical_equipment_type_controller_spec.rb
+++ b/spec/controllers/coronavirus-form/medical_equipment_type_controller_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe CoronavirusForm::MedicalEquipmentTypeController, type: :controller do
+  let(:current_template) { "coronavirus_form/medical_equipment_type" }
+  let(:session_key) { :medical_equipment_type }
+
+  describe "GET show" do
+    it "renders the form" do
+      get :show
+      expect(response).to render_template(current_template)
+    end
+  end
+
+  describe "POST submit" do
+    let(:selected) { ["Personal protection equipment", "Testing equipment"] }
+    it "sets session variables" do
+      post :submit, params: { medical_equipment_type: selected }
+
+      expect(session[session_key]).to eq selected
+    end
+
+    it "redirects to next step" do
+      post :submit, params: { medical_equipment_type: selected }
+
+      expect(response).to redirect_to(
+        "/coronavirus-form/are-you-a-manufacturer",
+      )
+    end
+
+    it "redirects to check your answers if check your answers already seen" do
+      session[:check_answers_seen] = true
+      post :submit, params: { medical_equipment_type: selected }
+
+      expect(response).to redirect_to("/coronavirus-form/check-your-answers")
+    end
+
+    it "validates any option is chosen" do
+      post :submit, params: { medical_equipment_type: [] }
+
+      expect(response).to render_template(current_template)
+    end
+
+    context "when Other option is selected" do
+      it "validates the Other option description is provided" do
+        post :submit, params: { medical_equipment_type: ["Other", "Personal protection equipment"] }
+
+        expect(response).to render_template(current_template)
+      end
+
+      it "adds the other option description to the session" do
+        post :submit, params: {
+          medical_equipment_type: ["Other", "Personal protection equipment"],
+          medical_equipment_type_other: "Demo text",
+        }
+
+        expect(response).to redirect_to(
+          "/coronavirus-form/are-you-a-manufacturer",
+        )
+        expect(session[session_key]).to eq ["Other", "Personal protection equipment"]
+        expect(session[:medical_equipment_type_other]).to eq "Demo text"
+      end
+    end
+
+    it "validates a valid option is chosen" do
+      post :submit, params: {
+        medical_equipment_type: ["<script></script", "invalid option", "Personal protection equipment"],
+      }
+
+      expect(response).to render_template(current_template)
+    end
+  end
+end

--- a/spec/controllers/coronavirus-form/product_details_controller_spec.rb
+++ b/spec/controllers/coronavirus-form/product_details_controller_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe CoronavirusForm::ProductDetailsController, type: :controller do
+  let(:current_template) { "coronavirus_form/product_details" }
+  let(:session_key) { :products }
+  let(:params) do
+    {
+      "product_name" => "Defibrillator",
+      "product_cost" => "£10.99",
+      "certification_details" => "CE",
+      "product_postcode" => "SW1A 2AA",
+      "product_url" => nil,
+      "lead_time" => "2",
+    }
+  end
+
+  describe "GET show" do
+    it "renders the form" do
+      get :show
+      expect(response).to render_template(current_template)
+    end
+
+    context "when there are existing products" do
+      let(:product_id) { SecureRandom.uuid }
+      let(:product) {
+        params.merge(
+          "product_id" => product_id,
+          "product_name" => "My product",
+        )
+      }
+      before :each do
+        session[session_key] = [
+          product,
+          params.merge("product_id" => SecureRandom.uuid),
+        ]
+      end
+
+      context "when editing an existing product" do
+        it "should render the existing product" do
+          get :show, params: { product_id: product_id }
+          expect(@controller.instance_variable_get(:@product)).to eq(product)
+        end
+      end
+
+      context "when adding an additional product" do
+        it "should not render an existing product" do
+          get :show
+          expect(@controller.instance_variable_get(:@product)).to eq({})
+        end
+      end
+
+      context "when providing an unknown product_id" do
+        it "should not render an existing product" do
+          get :show, params: { product_id: SecureRandom.uuid }
+          expect(@controller.instance_variable_get(:@product)).to eq({})
+        end
+      end
+    end
+  end
+
+  describe "POST submit" do
+    it "sets session variables" do
+      post :submit, params: params
+
+      uuid_regex = /\A[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z/i.freeze
+
+      expect(session[session_key].last).to include params
+      expect(session[session_key].last["product_id"]).to match uuid_regex
+    end
+
+    context "there are existing products" do
+      let(:product_id) { SecureRandom.uuid }
+      let(:product) {
+        params.merge(
+          "product_id" => product_id,
+          "product_name" => "My product",
+        )
+      }
+      let(:product_2) {
+        params.merge("product_id" => SecureRandom.uuid)
+      }
+
+      before :each do
+        session[session_key] = [product, product_2]
+      end
+
+      context "when editing an existing product" do
+        let(:new_product) { product.merge("product_name" => "New name") }
+        it "edits the existing the existing product" do
+          post :submit, params: new_product
+          expect(session[session_key]).to contain_exactly(new_product, product_2)
+          expect(response).to redirect_to(coronavirus_form_additional_product_path)
+        end
+      end
+
+      context "when adding a new product" do
+        let(:new_product) {
+          product.except("product_id").merge("product_name" => "New product")
+        }
+        it "edits the existing the existing product" do
+          post :submit, params: new_product
+          expect(session[session_key]).to include(product, product_2)
+          expect(session[session_key].last).to include(new_product)
+          expect(response).to redirect_to(coronavirus_form_additional_product_path)
+        end
+      end
+    end
+
+    it "redirects to next step when given valid product details" do
+      post :submit, params: params
+
+      expect(response).to redirect_to(coronavirus_form_additional_product_path)
+    end
+
+    it "redirects to check your answers if check your answers previously seen" do
+      session[:check_answers_seen] = true
+      post :submit, params: params
+
+      expect(response).to redirect_to(coronavirus_form_check_your_answers_path)
+    end
+
+    described_class::REQUIRED_FIELDS.each do |field|
+      it "requires that key #{field} be provided" do
+        post :submit, params: params.except(field)
+
+        expect(response).to render_template(current_template)
+      end
+    end
+
+    it "validates valid text is provided" do
+      post :submit, params: params.merge({ "product_postcode": "<script></script>" })
+
+      expect(response).to render_template(current_template)
+    end
+  end
+end


### PR DESCRIPTION
This adds four questions that a user will see if they select "Yes" in response to the question "Do you have medical equipment to offer?"

There is additional logic on the product details controller, since a user can enter multiple products if they click "Yes" in response to the following question "Do you have additional products to offer?"

We need to be able to edit these products at the end, so they are assigned IDs which will enable users to modify particular products.

There is no limit on the number of products a user can add. If we move to using a db-backed store we should set a limit.

This includes questions 1.1 - 1.4, and should link to question 2.

https://trello.com/c/D5f7hMXB/20-implement-question-11
https://trello.com/c/IPPrV38W/21-implement-question-12
https://trello.com/c/JInhtpQr/22-implement-question-13
https://trello.com/c/6BzzBbZf/41-implement-question-14-can-you-offer-another-product