### PR TITLE
Get possible responses from i18n file (for question 1)

### DIFF
--- a/app/views/coronavirus_form/medical_equipment.html.erb
+++ b/app/views/coronavirus_form/medical_equipment.html.erb
@@ -17,18 +17,13 @@
   heading: t('coronavirus_form.medical_equipment.title'),
   is_page_heading: true,
   name: "medical_equipment",
-  items: [
+  items: t('coronavirus_form.medical_equipment.options').map do |_, item|
     {
-      value: t('coronavirus_form.medical_equipment.options.option_yes.label'),
-      text: t('coronavirus_form.medical_equipment.options.option_yes.label'),
-      checked: session[:medical_equipment] == t('coronavirus_form.medical_equipment.options.option_yes.label'),
-    },
-    {
-      value: t('coronavirus_form.medical_equipment.options.option_no.label'),
-      text: t('coronavirus_form.medical_equipment.options.option_no.label'),
-      checked: session[:medical_equipment] == t('coronavirus_form.medical_equipment.options.option_no.label'),
-    },
-  ]
+      value: item[:label],
+      text: item[:label],
+      checked: session[:medical_equipment] == item[:label],
+    }
+  end
 } %>
 <%= render "govuk_publishing_components/components/button", text: "Save and continue", margin_bottom: true %>
 <% end %>


### PR DESCRIPTION
Removing the hardcoding of specific response options and simply loading all the options included in the i18n YAML file for this question will make it simpler to change the questions/answers.