### PR TITLE
Make routes for form pages consistent

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,14 +8,14 @@ Rails.application.routes.draw do
   get "/", to: "coronavirus_form/start#show"
 
   # Question pages
-  get "/coronavirus-form/do-you-have-medical-equipment-to-offer" => "coronavirus_form/medical_equipment#show"
-  post "/coronavirus-form/do-you-have-medical-equipment-to-offer" => "coronavirus_form/medical_equipment#submit"
+  get "/coronavirus-form/medical-equipment" => "coronavirus_form/medical_equipment#show"
+  post "/coronavirus-form/medical-equipment" => "coronavirus_form/medical_equipment#submit"
 
-  get "/coronavirus-form/what-kind-of-medical-equipment" => "coronavirus_form/medical_equipment_type#show"
-  post "/coronavirus-form/what-kind-of-medical-equipment" => "coronavirus_form/medical_equipment_type#submit"
+  get "/coronavirus-form/medical-equipment-type" => "coronavirus_form/medical_equipment_type#show"
+  post "/coronavirus-form/medical-equipment-type" => "coronavirus_form/medical_equipment_type#submit"
 
-  get "/coronavirus-form/do-you-have-hotel-rooms-to-offer" => "coronavirus_form/hotel_rooms#show"
-  post "/coronavirus-form/do-you-have-hotel-rooms-to-offer" => "coronavirus_form/hotel_rooms#submit"
+  get "/coronavirus-form/hotel-rooms" => "coronavirus_form/hotel_rooms#show"
+  post "/coronavirus-form/hotel-rooms" => "coronavirus_form/hotel_rooms#submit"
 
   get "/coronavirus-form/which-goods" => "coronavirus_form/which_goods#show"
   post "/coronavirus-form/which-goods" => "coronavirus_form/which_goods#submit"

--- a/spec/controllers/coronavirus-form/medical_equipment_controller_spec.rb
+++ b/spec/controllers/coronavirus-form/medical_equipment_controller_spec.rb
@@ -23,20 +23,20 @@ RSpec.describe CoronavirusForm::MedicalEquipmentController, type: :controller do
     it "redirects to next step for yes response" do
       post :submit, params: { medical_equipment: "Yes" }
 
-      expect(response).to redirect_to("/coronavirus-form/what-kind-of-medical-equipment")
+      expect(response).to redirect_to(coronavirus_form_medical_equipment_type_path)
     end
 
     it "redirects to next sub-question for no response" do
       post :submit, params: { medical_equipment: "No" }
 
-      expect(response).to redirect_to("/coronavirus-form/do-you-have-hotel-rooms-to-offer")
+      expect(response).to redirect_to(coronavirus_form_hotel_rooms_path)
     end
 
     it "redirects to check your answers if check your answers previously seen" do
       session[:check_answers_seen] = true
       post :submit, params: { medical_equipment: "Yes" }
 
-      expect(response).to redirect_to("/coronavirus-form/check-your-answers")
+      expect(response).to redirect_to(coronavirus_form_check_your_answers_path)
     end
 
     it "validates any option is chosen" do


### PR DESCRIPTION
We started to have some verbose slugs, and other non-verbose slugs.  Updating to ensure all routes have a consistent naming (i.e. less verbose).