### PR TITLE
Update paths following change to routes

### DIFF
--- a/app/controllers/coronavirus_form/hotel_rooms_controller.rb
+++ b/app/controllers/coronavirus_form/hotel_rooms_controller.rb
@@ -32,6 +32,6 @@ private
   PAGE = "hotel_rooms"
 
   def previous_path
-    coronavirus_form_do_you_have_medical_equipment_to_offer_path
+    coronavirus_form_medical_equipment_path
   end
 end

--- a/app/controllers/coronavirus_form/offer_food_controller.rb
+++ b/app/controllers/coronavirus_form/offer_food_controller.rb
@@ -32,6 +32,6 @@ private
   PAGE = "offer_food"
 
   def previous_path
-    coronavirus_form_do_you_have_offer_food_to_offer_path
+    coronavirus_form_hotel_rooms_path
   end
 end

--- a/app/views/coronavirus_form/start.html.erb
+++ b/app/views/coronavirus_form/start.html.erb
@@ -9,7 +9,7 @@
 
 <%= render "govuk_publishing_components/components/button", {
   text: t("start_page.button_label"),
-  href: coronavirus_form_do_you_have_medical_equipment_to_offer_path,
+  href: coronavirus_form_medical_equipment_path,
   start: true,
   rel: "external"
 } %>


### PR DESCRIPTION
A number of routes had their names changed, but the corresponding paths were not updated in the app.  This makes that change.