### PR TITLE
Ship logs to splunk

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -7,6 +7,7 @@ applications:
   services:
   - govuk-coronavirus-business-volunteer-form-db
   - logit-ssl-drain
+  - splunk-ssl-drain
   env:
     GOVUK_APP_DOMAIN: cloudapps.digital
     GOVUK_WEBSITE_ROOT: www.gov.uk


### PR DESCRIPTION
I created the splunk ssl drain service by hand, using:

```
cf create-service splunk unlimited splunk-ssl-drain
```

(Having previously enabled the splunk service broker in the
govuk_development org)