### PR TITLE
Run migrations in Procfile

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,3 +1,2 @@
 tmp
-Procfile
 vendor

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec puma -t 5:5 -p ${PORT:-5000} -e ${RACK_ENV:-development}
+web: rake db:migrate && bin/rails server

--- a/config/database.yml
+++ b/config/database.yml
@@ -16,5 +16,4 @@ test:
 
 production:
   <<: *default
-  database: coronavirus_form_production
   url: <%= ENV["DATABASE_URL"]%>


### PR DESCRIPTION
This will make the migrations happen in PaaS. Note we're not using
db:setup here because the DB already exists in PaaS, so we don't need to
create it. Also we've removed the db name from the config because DB
names are auto-generated by PaaS.