### PR TITLE
Remove /coronavirus-form from all routes

### DIFF
--- a/app/controllers/coronavirus_form/additional_product_check_controller.rb
+++ b/app/controllers/coronavirus_form/additional_product_check_controller.rb
@@ -35,6 +35,6 @@ private
   def previous_path
     session[:products] ||= []
     latest_product_id = (session[:products].last || {}).dig("product_id")
-    "/coronavirus-form/product-details?product_id=#{latest_product_id}"
+    "/product-details?product_id=#{latest_product_id}"
   end
 end

--- a/app/controllers/coronavirus_form/contact_details_controller.rb
+++ b/app/controllers/coronavirus_form/contact_details_controller.rb
@@ -52,6 +52,6 @@ private
   end
 
   def previous_path
-    coronavirus_form_business_details_path
+    business_details_path
   end
 end

--- a/app/controllers/coronavirus_form/expert_advice_controller.rb
+++ b/app/controllers/coronavirus_form/expert_advice_controller.rb
@@ -45,6 +45,6 @@ private
   end
 
   def previous_path
-    "/coronavirus-form/offer-space"
+    "/offer-space"
   end
 end

--- a/app/controllers/coronavirus_form/hotel_rooms_controller.rb
+++ b/app/controllers/coronavirus_form/hotel_rooms_controller.rb
@@ -32,6 +32,6 @@ private
   PAGE = "hotel_rooms"
 
   def previous_path
-    coronavirus_form_medical_equipment_path
+    medical_equipment_path
   end
 end

--- a/app/controllers/coronavirus_form/manufacturer_check_controller.rb
+++ b/app/controllers/coronavirus_form/manufacturer_check_controller.rb
@@ -35,6 +35,6 @@ private
   PAGE = "manufacturer_check"
 
   def previous_path
-    "/coronavirus-form/medical-equipment-type"
+    "/medical-equipment-type"
   end
 end

--- a/app/controllers/coronavirus_form/medical_equipment_type_controller.rb
+++ b/app/controllers/coronavirus_form/medical_equipment_type_controller.rb
@@ -45,6 +45,6 @@ private
   end
 
   def previous_path
-    "/coronavirus-form/medical-equipment"
+    "/medical-equipment"
   end
 end

--- a/app/controllers/coronavirus_form/offer_care_controller.rb
+++ b/app/controllers/coronavirus_form/offer_care_controller.rb
@@ -33,6 +33,6 @@ private
   NEXT_PAGE = "offer_community_support"
 
   def previous_path
-    coronavirus_form_expert_advice_path
+    expert_advice_path
   end
 end

--- a/app/controllers/coronavirus_form/offer_community_support_controller.rb
+++ b/app/controllers/coronavirus_form/offer_community_support_controller.rb
@@ -33,6 +33,6 @@ private
   NEXT_PAGE = "offer_other_support"
 
   def previous_path
-    coronavirus_form_offer_care_path
+    offer_care_path
   end
 end

--- a/app/controllers/coronavirus_form/offer_other_support_controller.rb
+++ b/app/controllers/coronavirus_form/offer_other_support_controller.rb
@@ -28,6 +28,6 @@ private
   NEXT_PAGE = "thank_you"
 
   def previous_path
-    coronavirus_form_offer_community_support_path
+    offer_community_support_path
   end
 end

--- a/app/controllers/coronavirus_form/offer_space_controller.rb
+++ b/app/controllers/coronavirus_form/offer_space_controller.rb
@@ -34,6 +34,6 @@ private
   PAGE = "offer_space"
 
   def previous_path
-    coronavirus_form_offer_transport_path
+    offer_transport_path
   end
 end

--- a/app/controllers/coronavirus_form/offer_space_type_controller.rb
+++ b/app/controllers/coronavirus_form/offer_space_type_controller.rb
@@ -47,6 +47,6 @@ private
   end
 
   def previous_path
-    coronavirus_form_offer_space_path
+    offer_space_path
   end
 end

--- a/app/controllers/coronavirus_form/offer_transport_controller.rb
+++ b/app/controllers/coronavirus_form/offer_transport_controller.rb
@@ -34,6 +34,6 @@ private
   PAGE = "offer_transport"
 
   def previous_path
-    coronavirus_form_offer_transport_path
+    offer_transport_path
   end
 end

--- a/app/controllers/coronavirus_form/product_details_controller.rb
+++ b/app/controllers/coronavirus_form/product_details_controller.rb
@@ -75,10 +75,10 @@ private
   end
 
   def previous_path
-    return coronavirus_form_additional_product_path if params["product_id"]
+    return additional_product_path if params["product_id"]
 
-    return coronavirus_form_check_your_answers_path if session["check_answers_seen"]
+    return check_your_answers_path if session["check_answers_seen"]
 
-    coronavirus_form_are_you_a_manufacturer_path
+    are_you_a_manufacturer_path
   end
 end

--- a/app/controllers/coronavirus_form/transport_type_controller.rb
+++ b/app/controllers/coronavirus_form/transport_type_controller.rb
@@ -35,6 +35,6 @@ private
   PAGE = "transport_type"
 
   def previous_path
-    coronavirus_form_offer_transport_path
+    offer_transport_path
   end
 end

--- a/app/controllers/coronavirus_form/which_services_controller.rb
+++ b/app/controllers/coronavirus_form/which_services_controller.rb
@@ -34,6 +34,6 @@ private
   NEXT_PAGE = "thank_you"
 
   def previous_path
-    "/coronavirus-form/which-goods"
+    "/which-goods"
   end
 end

--- a/app/views/coronavirus_form/start.html.erb
+++ b/app/views/coronavirus_form/start.html.erb
@@ -9,7 +9,7 @@
 
 <%= render "govuk_publishing_components/components/button", {
   text: t("start_page.button_label"),
-  href: coronavirus_form_medical_equipment_path,
+  href: medical_equipment_path,
   start: true,
   margin_bottom: true
 } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,67 +8,67 @@ Rails.application.routes.draw do
   get "/", to: "coronavirus_form/start#show"
 
   # Question pages
-  get "/coronavirus-form/medical-equipment" => "coronavirus_form/medical_equipment#show"
-  post "/coronavirus-form/medical-equipment" => "coronavirus_form/medical_equipment#submit"
+  get "/medical-equipment" => "coronavirus_form/medical_equipment#show"
+  post "/medical-equipment" => "coronavirus_form/medical_equipment#submit"
 
-  get "/coronavirus-form/medical-equipment-type" => "coronavirus_form/medical_equipment_type#show"
-  post "/coronavirus-form/medical-equipment-type" => "coronavirus_form/medical_equipment_type#submit"
+  get "/medical-equipment-type" => "coronavirus_form/medical_equipment_type#show"
+  post "/medical-equipment-type" => "coronavirus_form/medical_equipment_type#submit"
 
-  get "/coronavirus-form/hotel-rooms" => "coronavirus_form/hotel_rooms#show"
-  post "/coronavirus-form/hotel-rooms" => "coronavirus_form/hotel_rooms#submit"
+  get "/hotel-rooms" => "coronavirus_form/hotel_rooms#show"
+  post "/hotel-rooms" => "coronavirus_form/hotel_rooms#submit"
 
-  get "/coronavirus-form/are-you-a-manufacturer" => "coronavirus_form/manufacturer_check#show"
-  post "/coronavirus-form/are-you-a-manufacturer" => "coronavirus_form/manufacturer_check#submit"
+  get "/are-you-a-manufacturer" => "coronavirus_form/manufacturer_check#show"
+  post "/are-you-a-manufacturer" => "coronavirus_form/manufacturer_check#submit"
 
-  get "/coronavirus-form/product-details" => "coronavirus_form/product_details#show"
-  post "/coronavirus-form/product-details" => "coronavirus_form/product_details#submit"
+  get "/product-details" => "coronavirus_form/product_details#show"
+  post "/product-details" => "coronavirus_form/product_details#submit"
 
-  get "/coronavirus-form/additional-product" => "coronavirus_form/additional_product_check#show"
-  post "/coronavirus-form/additional-product" => "coronavirus_form/additional_product_check#submit"
+  get "/additional-product" => "coronavirus_form/additional_product_check#show"
+  post "/additional-product" => "coronavirus_form/additional_product_check#submit"
 
-  get "/coronavirus-form/which-goods" => "coronavirus_form/which_goods#show"
-  post "/coronavirus-form/which-goods" => "coronavirus_form/which_goods#submit"
+  get "/which-goods" => "coronavirus_form/which_goods#show"
+  post "/which-goods" => "coronavirus_form/which_goods#submit"
 
-  get "/coronavirus-form/which-services" => "coronavirus_form/which_services#show"
-  post "/coronavirus-form/which-services" => "coronavirus_form/which_services#submit"
+  get "/which-services" => "coronavirus_form/which_services#show"
+  post "/which-services" => "coronavirus_form/which_services#submit"
 
-  get "/coronavirus-form/offer-transport" => "coronavirus_form/offer_transport#show"
-  post "/coronavirus-form/offer-transport" => "coronavirus_form/offer_transport#submit"
+  get "/offer-transport" => "coronavirus_form/offer_transport#show"
+  post "/offer-transport" => "coronavirus_form/offer_transport#submit"
 
-  get "/coronavirus-form/offer-space" => "coronavirus_form/offer_space#show"
-  post "/coronavirus-form/offer-space" => "coronavirus_form/offer_space#submit"
+  get "/offer-space" => "coronavirus_form/offer_space#show"
+  post "/offer-space" => "coronavirus_form/offer_space#submit"
 
-  get "/coronavirus-form/what-kind-of-space" => "coronavirus_form/offer_space_type#show"
-  post "/coronavirus-form/what-kind-of-space" => "coronavirus_form/offer_space_type#submit"
+  get "/what-kind-of-space" => "coronavirus_form/offer_space_type#show"
+  post "/what-kind-of-space" => "coronavirus_form/offer_space_type#submit"
 
-  get "/coronavirus-form/expert-advice" => "coronavirus_form/expert_advice#show"
-  post "/coronavirus-form/expert-advice" => "coronavirus_form/expert_advice#submit"
+  get "/expert-advice" => "coronavirus_form/expert_advice#show"
+  post "/expert-advice" => "coronavirus_form/expert_advice#submit"
 
-  get "/coronavirus-form/what-kind-of-transport" => "coronavirus_form/transport_type#show"
-  post "/coronavirus-form/what-kind-of-transport" => "coronavirus_form/transport_type#submit"
+  get "/what-kind-of-transport" => "coronavirus_form/transport_type#show"
+  post "/what-kind-of-transport" => "coronavirus_form/transport_type#submit"
 
-  get "/coronavirus-form/offer-care" => "coronavirus_form/offer_care#show"
-  post "/coronavirus-form/offer-care" => "coronavirus_form/offer_care#submit"
+  get "/offer-care" => "coronavirus_form/offer_care#show"
+  post "/offer-care" => "coronavirus_form/offer_care#submit"
 
-  get "/coronavirus-form/offer-community-support" => "coronavirus_form/offer_community_support#show"
-  post "/coronavirus-form/offer-community-support" => "coronavirus_form/offer_community_support#submit"
+  get "/offer-community-support" => "coronavirus_form/offer_community_support#show"
+  post "/offer-community-support" => "coronavirus_form/offer_community_support#submit"
 
   # Question 10
-  get "/coronavirus-form/offer-other-support" => "coronavirus_form/offer_other_support#show"
-  post "/coronavirus-form/offer-other-support" => "coronavirus_form/offer_other_support#submit"
+  get "/offer-other-support" => "coronavirus_form/offer_other_support#show"
+  post "/offer-other-support" => "coronavirus_form/offer_other_support#submit"
 
   # Question 11
-  get "/coronavirus-form/business-details" => "coronavirus_form/business_details#show"
-  post "/coronavirus-form/business-details" => "coronavirus_form/business_details#submit"
+  get "/business-details" => "coronavirus_form/business_details#show"
+  post "/business-details" => "coronavirus_form/business_details#submit"
 
   # Question 12
-  get "/coronavirus-form/contact-details" => "coronavirus_form/contact_details#show"
-  post "/coronavirus-form/contact-details" => "coronavirus_form/contact_details#submit"
+  get "/contact-details" => "coronavirus_form/contact_details#show"
+  post "/contact-details" => "coronavirus_form/contact_details#submit"
 
   # Check answers page
-  get "/coronavirus-form/check-your-answers" => "coronavirus_form/check_answers#show"
-  post "/coronavirus-form/check-your-answers" => "coronavirus_form/check_answers#submit"
+  get "/check-your-answers" => "coronavirus_form/check_answers#show"
+  post "/check-your-answers" => "coronavirus_form/check_answers#submit"
 
   # Final page
-  get "/coronavirus-form/thank-you" => "coronavirus_form/thank_you#show"
+  get "/thank-you" => "coronavirus_form/thank_you#show"
 end

--- a/spec/controllers/coronavirus_form/additional_product_check_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/additional_product_check_controller_spec.rb
@@ -15,20 +15,20 @@ RSpec.describe CoronavirusForm::AdditionalProductCheckController, type: :control
   describe "POST submit" do
     it "redirects to next step for yes response" do
       post :submit, params: { additional_product_check: "Yes" }
-      expect(response).to redirect_to(coronavirus_form_product_details_path)
+      expect(response).to redirect_to(product_details_path)
     end
 
     it "redirects to next sub-question for no response" do
       post :submit, params: { additional_product_check: "No" }
 
-      expect(response).to redirect_to(coronavirus_form_hotel_rooms_path)
+      expect(response).to redirect_to(hotel_rooms_path)
     end
 
     it "redirects to check your answers if check your answers previously seen" do
       session[:check_answers_seen] = true
       post :submit, params: { additional_product_check: "Yes" }
 
-      expect(response).to redirect_to("/coronavirus-form/check-your-answers")
+      expect(response).to redirect_to("/check-your-answers")
     end
 
     it "validates any option is chosen" do

--- a/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
@@ -40,14 +40,14 @@ RSpec.describe CoronavirusForm::ContactDetailsController, type: :controller do
     it "redirects to next step when all required fields are provided" do
       post :submit, params: params
 
-      expect(response).to redirect_to(coronavirus_form_check_your_answers_path)
+      expect(response).to redirect_to(check_your_answers_path)
     end
 
     it "does not require role" do
       post :submit, params: params.except("role")
 
       expect(session[session_key]).to eq contact_details.merge("role" => nil)
-      expect(response).to redirect_to(coronavirus_form_check_your_answers_path)
+      expect(response).to redirect_to(check_your_answers_path)
     end
 
     described_class::REQUIRED_FIELDS.each do |field|

--- a/spec/controllers/coronavirus_form/expert_advice_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/expert_advice_controller_spec.rb
@@ -27,14 +27,14 @@ RSpec.describe CoronavirusForm::ExpertAdviceController, type: :controller do
     it "redirects to next step" do
       post :submit, params: { expert_advice: selected }
 
-      expect(response).to redirect_to(coronavirus_form_offer_care_path)
+      expect(response).to redirect_to(offer_care_path)
     end
 
     it "redirects to check your answers if check your answers already seen" do
       session[:check_answers_seen] = true
       post :submit, params: { expert_advice: selected }
 
-      expect(response).to redirect_to(coronavirus_form_check_your_answers_path)
+      expect(response).to redirect_to(check_your_answers_path)
     end
 
     it "validates any option is chosen" do
@@ -58,7 +58,7 @@ RSpec.describe CoronavirusForm::ExpertAdviceController, type: :controller do
 
         expect(session[session_key]).to eq %w[Other] + selected
         expect(session[:expert_advice_other]).to eq "Demo text"
-        expect(response).to redirect_to(coronavirus_form_offer_care_path)
+        expect(response).to redirect_to(offer_care_path)
       end
     end
 

--- a/spec/controllers/coronavirus_form/hotel_rooms_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/hotel_rooms_controller_spec.rb
@@ -26,14 +26,14 @@ RSpec.describe CoronavirusForm::HotelRoomsController, type: :controller do
 
     it "redirects to next step for a permitted response" do
       post :submit, params: { hotel_rooms: selected }
-      expect(response).to redirect_to(coronavirus_form_offer_transport_path)
+      expect(response).to redirect_to(offer_transport_path)
     end
 
     it "redirects to check your answers if check your answers previously seen" do
       session[:check_answers_seen] = true
       post :submit, params: { hotel_rooms: selected }
 
-      expect(response).to redirect_to(coronavirus_form_check_your_answers_path)
+      expect(response).to redirect_to(check_your_answers_path)
     end
 
     it "validates any option is chosen" do

--- a/spec/controllers/coronavirus_form/manufacturer_check_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/manufacturer_check_controller_spec.rb
@@ -25,14 +25,14 @@ RSpec.describe CoronavirusForm::ManufacturerCheckController, type: :controller d
     it "redirects to next step" do
       post :submit, params: { manufacturer_check: selected }
 
-      expect(response).to redirect_to("/coronavirus-form/product-details")
+      expect(response).to redirect_to("/product-details")
     end
 
     it "redirects to check your answers if check your answers already seen" do
       session[:check_answers_seen] = true
       post :submit, params: { manufacturer_check: selected }
 
-      expect(response).to redirect_to("/coronavirus-form/check-your-answers")
+      expect(response).to redirect_to("/check-your-answers")
     end
 
     it "validates any option is chosen" do

--- a/spec/controllers/coronavirus_form/medical_equipment_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/medical_equipment_controller_spec.rb
@@ -23,20 +23,20 @@ RSpec.describe CoronavirusForm::MedicalEquipmentController, type: :controller do
     it "redirects to next step for yes response" do
       post :submit, params: { medical_equipment: "Yes" }
 
-      expect(response).to redirect_to(coronavirus_form_medical_equipment_type_path)
+      expect(response).to redirect_to(medical_equipment_type_path)
     end
 
     it "redirects to next sub-question for no response" do
       post :submit, params: { medical_equipment: "No" }
 
-      expect(response).to redirect_to(coronavirus_form_hotel_rooms_path)
+      expect(response).to redirect_to(hotel_rooms_path)
     end
 
     it "redirects to check your answers if check your answers previously seen" do
       session[:check_answers_seen] = true
       post :submit, params: { medical_equipment: "Yes" }
 
-      expect(response).to redirect_to(coronavirus_form_check_your_answers_path)
+      expect(response).to redirect_to(check_your_answers_path)
     end
 
     it "validates any option is chosen" do

--- a/spec/controllers/coronavirus_form/medical_equipment_type_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/medical_equipment_type_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe CoronavirusForm::MedicalEquipmentTypeController, type: :controlle
       post :submit, params: { medical_equipment_type: selected }
 
       expect(response).to redirect_to(
-        "/coronavirus-form/are-you-a-manufacturer",
+        "/are-you-a-manufacturer",
       )
     end
 
@@ -33,7 +33,7 @@ RSpec.describe CoronavirusForm::MedicalEquipmentTypeController, type: :controlle
       session[:check_answers_seen] = true
       post :submit, params: { medical_equipment_type: selected }
 
-      expect(response).to redirect_to(coronavirus_form_check_your_answers_path)
+      expect(response).to redirect_to(check_your_answers_path)
     end
 
     it "validates any option is chosen" do
@@ -56,7 +56,7 @@ RSpec.describe CoronavirusForm::MedicalEquipmentTypeController, type: :controlle
         }
 
         expect(response).to redirect_to(
-          "/coronavirus-form/are-you-a-manufacturer",
+          "/are-you-a-manufacturer",
         )
         expect(session[session_key]).to eq ["Other", "Personal protection equipment"]
         expect(session[:medical_equipment_type_other]).to eq "Demo text"

--- a/spec/controllers/coronavirus_form/offer_care_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/offer_care_controller_spec.rb
@@ -26,17 +26,17 @@ RSpec.describe CoronavirusForm::OfferCareController, type: :controller do
       session[:check_answers_seen] = true
       post :submit, params: { offer_care: selected_yes }
 
-      expect(response).to redirect_to(coronavirus_form_check_your_answers_path)
+      expect(response).to redirect_to(check_your_answers_path)
     end
 
     it "redirects to next step for a Yes response" do
       post :submit, params: { offer_care: selected_yes }
-      expect(response).to redirect_to(coronavirus_form_offer_community_support_path)
+      expect(response).to redirect_to(offer_community_support_path)
     end
 
     it "redirects to next step for a No response" do
       post :submit, params: { offer_care: selected_no }
-      expect(response).to redirect_to(coronavirus_form_offer_community_support_path)
+      expect(response).to redirect_to(offer_community_support_path)
     end
 
     it "validates any option is chosen" do

--- a/spec/controllers/coronavirus_form/offer_community_support_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/offer_community_support_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe CoronavirusForm::OfferCommunitySupportController, type: :controll
       session[:check_answers_seen] = true
       post :submit, params: { offer_community_support: selected_yes }
 
-      expect(response).to redirect_to(coronavirus_form_check_your_answers_path)
+      expect(response).to redirect_to(check_your_answers_path)
     end
 
     it "validates any option is chosen" do

--- a/spec/controllers/coronavirus_form/offer_other_support_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/offer_other_support_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe CoronavirusForm::OfferOtherSupportController, type: :controller d
       session[:check_answers_seen] = true
       post :submit, params: { offer_other_support: text_response }
 
-      expect(response).to redirect_to(coronavirus_form_check_your_answers_path)
+      expect(response).to redirect_to(check_your_answers_path)
     end
   end
 end

--- a/spec/controllers/coronavirus_form/offer_space_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/offer_space_controller_spec.rb
@@ -26,19 +26,19 @@ RSpec.describe CoronavirusForm::OfferSpaceController, type: :controller do
 
     it "redirects to next step for a 'No' response" do
       post :submit, params: { offer_space: "No" }
-      expect(response).to redirect_to(coronavirus_form_expert_advice_path)
+      expect(response).to redirect_to(expert_advice_path)
     end
 
     it "redirects to next step for a 'Yes' response" do
       post :submit, params: { offer_space: "Yes" }
-      expect(response).to redirect_to(coronavirus_form_what_kind_of_space_path)
+      expect(response).to redirect_to(what_kind_of_space_path)
     end
 
     it "redirects to check your answers if check your answers previously seen" do
       session[:check_answers_seen] = true
       post :submit, params: { offer_space: selected }
 
-      expect(response).to redirect_to(coronavirus_form_check_your_answers_path)
+      expect(response).to redirect_to(check_your_answers_path)
     end
 
     it "validates any option is chosen" do

--- a/spec/controllers/coronavirus_form/offer_space_type_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/offer_space_type_controller_spec.rb
@@ -24,14 +24,14 @@ RSpec.describe CoronavirusForm::OfferSpaceTypeController, type: :controller do
     it "redirects to next step" do
       post :submit, params: { offer_space_type: selected }
 
-      expect(response).to redirect_to(coronavirus_form_expert_advice_path)
+      expect(response).to redirect_to(expert_advice_path)
     end
 
     it "redirects to check your answers if check your answers already seen" do
       session[:check_answers_seen] = true
       post :submit, params: { offer_space_type: selected }
 
-      expect(response).to redirect_to("/coronavirus-form/check-your-answers")
+      expect(response).to redirect_to("/check-your-answers")
     end
 
     context "when Other option is selected" do
@@ -47,7 +47,7 @@ RSpec.describe CoronavirusForm::OfferSpaceTypeController, type: :controller do
           offer_space_type_other: "A really big garden.",
         }
 
-        expect(response).to redirect_to(coronavirus_form_expert_advice_path)
+        expect(response).to redirect_to(expert_advice_path)
         expect(session[session_key]).to eq ["Other", "Office space"]
         expect(session[:offer_space_type_other]).to eq "A really big garden."
       end
@@ -69,7 +69,7 @@ RSpec.describe CoronavirusForm::OfferSpaceTypeController, type: :controller do
       session[:check_answers_seen] = true
       post :submit, params: { offer_space_type: selected }
 
-      expect(response).to redirect_to(coronavirus_form_check_your_answers_path)
+      expect(response).to redirect_to(check_your_answers_path)
     end
   end
 end

--- a/spec/controllers/coronavirus_form/offer_transport_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/offer_transport_controller_spec.rb
@@ -24,19 +24,19 @@ RSpec.describe CoronavirusForm::OfferTransportController, type: :controller do
 
     it "redirects to next step for a YES response" do
       post :submit, params: { offer_transport: selected_yes }
-      expect(response).to redirect_to(coronavirus_form_what_kind_of_transport_path)
+      expect(response).to redirect_to(what_kind_of_transport_path)
     end
 
     it "redirects to next step for a NO response" do
       post :submit, params: { offer_transport: selected_no }
-      expect(response).to redirect_to(coronavirus_form_offer_space_path)
+      expect(response).to redirect_to(offer_space_path)
     end
 
     it "redirects to check your answers if check your answers previously seen" do
       session[:check_answers_seen] = true
       post :submit, params: { offer_transport: [selected_yes, selected_no].sample }
 
-      expect(response).to redirect_to(coronavirus_form_check_your_answers_path)
+      expect(response).to redirect_to(check_your_answers_path)
     end
 
     it "validates any option is chosen" do

--- a/spec/controllers/coronavirus_form/product_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/product_details_controller_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe CoronavirusForm::ProductDetailsController, type: :controller do
         it "edits the existing the existing product" do
           post :submit, params: new_product
           expect(session[session_key]).to contain_exactly(new_product, product_2)
-          expect(response).to redirect_to(coronavirus_form_additional_product_path)
+          expect(response).to redirect_to(additional_product_path)
         end
       end
 
@@ -103,7 +103,7 @@ RSpec.describe CoronavirusForm::ProductDetailsController, type: :controller do
           post :submit, params: new_product
           expect(session[session_key]).to include(product, product_2)
           expect(session[session_key].last).to include(new_product)
-          expect(response).to redirect_to(coronavirus_form_additional_product_path)
+          expect(response).to redirect_to(additional_product_path)
         end
       end
     end
@@ -111,14 +111,14 @@ RSpec.describe CoronavirusForm::ProductDetailsController, type: :controller do
     it "redirects to next step when given valid product details" do
       post :submit, params: params
 
-      expect(response).to redirect_to(coronavirus_form_additional_product_path)
+      expect(response).to redirect_to(additional_product_path)
     end
 
     it "redirects to check your answers if check your answers previously seen" do
       session[:check_answers_seen] = true
       post :submit, params: params
 
-      expect(response).to redirect_to(coronavirus_form_check_your_answers_path)
+      expect(response).to redirect_to(check_your_answers_path)
     end
 
     described_class::REQUIRED_FIELDS.each do |field|

--- a/spec/controllers/coronavirus_form/transport_type_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/transport_type_controller_spec.rb
@@ -28,14 +28,14 @@ RSpec.describe CoronavirusForm::TransportTypeController, type: :controller do
     it "redirects to next step" do
       post :submit, params: { transport_type: selected }
 
-      expect(response).to redirect_to(coronavirus_form_offer_space_path)
+      expect(response).to redirect_to(offer_space_path)
     end
 
     it "redirects to check your answers if check your answers previously seen" do
       session[:check_answers_seen] = true
       post :submit, params: { transport_type: selected }
 
-      expect(response).to redirect_to("/coronavirus-form/check-your-answers")
+      expect(response).to redirect_to("/check-your-answers")
     end
 
     it "validates any option is chosen" do

--- a/spec/controllers/coronavirus_form/which_goods_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/which_goods_controller_spec.rb
@@ -25,14 +25,14 @@ RSpec.describe CoronavirusForm::WhichGoodsController, type: :controller do
     it "redirects to next step" do
       post :submit, params: { which_goods: selected }
 
-      expect(response).to redirect_to("/coronavirus-form/which-services")
+      expect(response).to redirect_to("/which-services")
     end
 
     it "redirects to check your answers if check your answers previously seen" do
       session[:check_answers_seen] = true
       post :submit, params: { which_goods: selected }
 
-      expect(response).to redirect_to("/coronavirus-form/check-your-answers")
+      expect(response).to redirect_to("/check-your-answers")
     end
 
     it "validates any option is chosen" do

--- a/spec/controllers/coronavirus_form/which_services_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/which_services_controller_spec.rb
@@ -25,14 +25,14 @@ RSpec.describe CoronavirusForm::WhichServicesController, type: :controller do
     it "redirects to next step" do
       post :submit, params: { which_services: selected }
 
-      expect(response).to redirect_to("/coronavirus-form/thank-you")
+      expect(response).to redirect_to("/thank-you")
     end
 
     it "redirects to check your answers if check your answers previously seen" do
       session[:check_answers_seen] = true
       post :submit, params: { which_services: selected }
 
-      expect(response).to redirect_to("/coronavirus-form/check-your-answers")
+      expect(response).to redirect_to("/check-your-answers")
     end
 
     it "validates any option is chosen" do


### PR DESCRIPTION
Form questions will now be served from the root.  This matches https://github.com/alphagov/govuk-coronavirus-vulnerable-people-form/pull/101.