### PR TITLE
Update "Can you offer expert advice?" question

### DIFF
--- a/app/controllers/coronavirus_form/expert_advice_type_controller.rb
+++ b/app/controllers/coronavirus_form/expert_advice_type_controller.rb
@@ -5,24 +5,24 @@ class CoronavirusForm::ExpertAdviceTypeController < ApplicationController
   include FieldValidationHelper
 
   def show
-    session[:expert_advice] ||= []
+    session[:expert_advice_type] ||= []
     render "coronavirus_form/#{PAGE}"
   end
 
   def submit
-    expert_advice = Array(params[:expert_advice]).map { |item| sanitize(item).presence }.compact
-    expert_advice_other = sanitize(params[:expert_advice_other]).presence
-    session[:expert_advice_type] = expert_advice
-    session[:expert_advice_other] = if selected_other?(expert_advice)
-                                      expert_advice_other
-                                    else
-                                      ""
-                                    end
+    expert_advice_type = Array(params[:expert_advice_type]).map { |item| sanitize(item).presence }.compact
+    expert_advice_type_other = sanitize(params[:expert_advice_type_other]).presence
+    session[:expert_advice_type] = expert_advice_type
+    session[:expert_advice_type_other] = if selected_other?(expert_advice_type)
+                                           expert_advice_type_other
+                                         else
+                                           ""
+                                         end
     invalid_fields = validate_checkbox_field(
       PAGE,
-      values: expert_advice,
+      values: expert_advice_type,
       allowed_values: I18n.t("coronavirus_form.#{PAGE}.options").map { |_, item| item.dig(:label) },
-      other: expert_advice_other,
+      other: expert_advice_type_other,
     )
 
     if invalid_fields.any?
@@ -38,8 +38,8 @@ private
   PAGE = "expert_advice_type"
   NEXT_PAGE = "offer_care"
 
-  def selected_other?(expert_advice)
-    expert_advice.include?(
+  def selected_other?(expert_advice_type)
+    expert_advice_type.include?(
       I18n.t("coronavirus_form.#{PAGE}.options.other.label"),
     )
   end

--- a/app/controllers/coronavirus_form/expert_advice_type_controller.rb
+++ b/app/controllers/coronavirus_form/expert_advice_type_controller.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class CoronavirusForm::ExpertAdviceTypeController < ApplicationController
+  include ActionView::Helpers::SanitizeHelper
+  include FieldValidationHelper
+
+  def show
+    session[:expert_advice] ||= []
+    render "coronavirus_form/#{PAGE}"
+  end
+
+  def submit
+    expert_advice = Array(params[:expert_advice]).map { |item| sanitize(item).presence }.compact
+    expert_advice_other = sanitize(params[:expert_advice_other]).presence
+    session[:expert_advice_type] = expert_advice
+    session[:expert_advice_other] = if selected_other?(expert_advice)
+                                      expert_advice_other
+                                    else
+                                      ""
+                                    end
+    invalid_fields = validate_checkbox_field(
+      PAGE,
+      values: expert_advice,
+      allowed_values: I18n.t("coronavirus_form.#{PAGE}.options").map { |_, item| item.dig(:label) },
+      other: expert_advice_other,
+    )
+
+    if invalid_fields.any?
+      flash.now[:validation] = invalid_fields
+      render "coronavirus_form/#{PAGE}"
+    else
+      redirect_to controller: session["check_answers_seen"] ? "coronavirus_form/check_answers" : "coronavirus_form/#{NEXT_PAGE}", action: "show"
+    end
+  end
+
+private
+
+  PAGE = "expert_advice_type"
+  NEXT_PAGE = "offer_care"
+
+  def selected_other?(expert_advice)
+    expert_advice.include?(
+      I18n.t("coronavirus_form.#{PAGE}.options.other.label"),
+    )
+  end
+
+  def previous_path
+    "/coronavirus-form/offer-space"
+  end
+end

--- a/app/views/coronavirus_form/expert_advice.html.erb
+++ b/app/views/coronavirus_form/expert_advice.html.erb
@@ -17,6 +17,7 @@
   is_page_heading: true,
   name: "expert_advice",
   error_message: error_items('expert_advice'),
+  hint: t('coronavirus_form.expert_advice.hint'),
   items: t('coronavirus_form.expert_advice.options').map do |_, item|
     {
       value: item[:label],

--- a/app/views/coronavirus_form/expert_advice.html.erb
+++ b/app/views/coronavirus_form/expert_advice.html.erb
@@ -1,67 +1,29 @@
 <% content_for :title do %><%= t('coronavirus_form.expert_advice.title') %><% end %>
-    <% content_for :meta_tags do %>
-      <meta name="description" content="<%= t('coronavirus_form.expert_advice.title') %>" />
-    <% end %>
+<% content_for :meta_tags do %>
+  <meta name="description" content="<%= t('coronavirus_form.expert_advice.title') %>" />
+<% end %>
 
-    <% content_for :back_link do %>
-      <%= render "govuk_publishing_components/components/back_link", { href: previous_path } %>
-    <% end %>
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", { href: previous_path } %>
+<% end %>
 
-    <%= form_tag({},
-      "data-module": "track-coronavirus-form-business-medical-equipment-type",
-      "data-question-key": "expert_advice",
-      "id": "expert_advice"
-    ) do %>
-    <%= render "govuk_publishing_components/components/checkboxes", {
-      heading: t('coronavirus_form.expert_advice.title'),
-      is_page_heading: true,
-      name: "expert_advice[]",
-      error: error_items('expert_advice'),
-      items: [
-        {
-          value: t('coronavirus_form.expert_advice.options.medical.label'),
-          label: t('coronavirus_form.expert_advice.options.medical.label'),
-          checked: session[:expert_advice].include?(t('coronavirus_form.expert_advice.options.medical.label')),
-        },
-        {
-          value: t('coronavirus_form.expert_advice.options.engineering.label'),
-          label: t('coronavirus_form.expert_advice.options.engineering.label'),
-          checked: session[:expert_advice].include?(t('coronavirus_form.expert_advice.options.engineering.label')),
-        },
-        {
-          value: t('coronavirus_form.expert_advice.options.construction.label'),
-          label: t('coronavirus_form.expert_advice.options.construction.label'),
-          checked: session[:expert_advice].include?(t('coronavirus_form.expert_advice.options.construction.label')),
-        },
-        {
-          value: t('coronavirus_form.expert_advice.options.project_management.label'),
-          label: t('coronavirus_form.expert_advice.options.project_management.label'),
-          checked: session[:expert_advice].include?(t('coronavirus_form.expert_advice.options.project_management.label')),
-        },
-        {
-          value: t('coronavirus_form.expert_advice.options.it.label'),
-          label: t('coronavirus_form.expert_advice.options.it.label'),
-          checked: session[:expert_advice].include?(t('coronavirus_form.expert_advice.options.it.label')),
-        },
-        {
-          value: t('coronavirus_form.expert_advice.options.manufacturing.label'),
-          label: t('coronavirus_form.expert_advice.options.manufacturing.label'),
-          checked: session[:expert_advice].include?(t('coronavirus_form.expert_advice.options.manufacturing.label')),
-        },
-        {
-          value: t('coronavirus_form.expert_advice.options.other.label'),
-          label: t('coronavirus_form.expert_advice.options.other.label'),
-          checked: session[:expert_advice].include?(t('coronavirus_form.expert_advice.options.other.label')),
-          conditional: render("govuk_publishing_components/components/input", {
-            label: {
-              text: t('coronavirus_form.expert_advice.options.other.input.label'),
-            },
-            name: "expert_advice_other",
-            value: session[:expert_advice_other],
-            width: 50
-          })
-        },
-      ]
-    } %>
-    <%= render "govuk_publishing_components/components/button", text: "Save and continue", margin_bottom: true %>
-    <% end %>
+<%= form_tag({},
+  "data-module": "track-coronavirus-form-business-expert-advice",
+  "data-question-key": "expert_advice",
+  "id": "expert_advice"
+) do %>
+<%= render "govuk_publishing_components/components/radio", {
+  heading: t('coronavirus_form.expert_advice.title'),
+  is_page_heading: true,
+  name: "expert_advice",
+  error_message: error_items('expert_advice'),
+  items: t('coronavirus_form.expert_advice.options').map do |_, item|
+    {
+      value: item[:label],
+      text: item[:label],
+      checked: session[:expert_advice] == item[:label],
+    }
+  end
+} %>
+<%= render "govuk_publishing_components/components/button", text: "Save and continue", margin_bottom: true %>
+<% end %>

--- a/app/views/coronavirus_form/expert_advice_type.html.erb
+++ b/app/views/coronavirus_form/expert_advice_type.html.erb
@@ -53,7 +53,7 @@
           value: t("coronavirus_form.expert_advice_type.options.other.label"),
           label: t("coronavirus_form.expert_advice_type.options.other.label"),
           checked: session[:expert_advice].include?(t("coronavirus_form.expert_advice_type.options.other.label")),
-          conditional: render("govuk_publishing_components/components/input", {
+          conditional: render("govuk_publishing_components/components/textarea", {
             label: {
               text: t("coronavirus_form.expert_advice_type.options.other.input.label"),
             },

--- a/app/views/coronavirus_form/expert_advice_type.html.erb
+++ b/app/views/coronavirus_form/expert_advice_type.html.erb
@@ -10,7 +10,7 @@
     <%= form_tag({},
       "data-module": "track-coronavirus-form-business-medical-equipment-type",
       "data-question-key": "expert_advice",
-      "id": "expert_advice"
+      "id": "expert_advice_type"
     ) do %>
     <%= render "govuk_publishing_components/components/checkboxes", {
       heading: t("coronavirus_form.expert_advice_type.title"),

--- a/app/views/coronavirus_form/expert_advice_type.html.erb
+++ b/app/views/coronavirus_form/expert_advice_type.html.erb
@@ -1,0 +1,68 @@
+<% content_for :title do %><%= t("coronavirus_form.expert_advice_type.title") %><% end %>
+    <% content_for :meta_tags do %>
+      <meta name="description" content="<%= t("coronavirus_form.expert_advice_type.title") %>" />
+    <% end %>
+
+    <% content_for :back_link do %>
+      <%= render "govuk_publishing_components/components/back_link", { href: previous_path } %>
+    <% end %>
+
+    <%= form_tag({},
+      "data-module": "track-coronavirus-form-business-medical-equipment-type",
+      "data-question-key": "expert_advice",
+      "id": "expert_advice"
+    ) do %>
+    <%= render "govuk_publishing_components/components/checkboxes", {
+      heading: t("coronavirus_form.expert_advice_type.title"),
+      hint_text: t("coronavirus_form.expert_advice_type.hint"),
+      is_page_heading: true,
+      name: "expert_advice[]",
+      error: error_items("expert_advice"),
+      items: [
+        {
+          value: t("coronavirus_form.expert_advice_type.options.medical.label"),
+          label: t("coronavirus_form.expert_advice_type.options.medical.label"),
+          checked: session[:expert_advice].include?(t("coronavirus_form.expert_advice_type.options.medical.label")),
+        },
+        {
+          value: t("coronavirus_form.expert_advice_type.options.engineering.label"),
+          label: t("coronavirus_form.expert_advice_type.options.engineering.label"),
+          checked: session[:expert_advice].include?(t("coronavirus_form.expert_advice_type.options.engineering.label")),
+        },
+        {
+          value: t("coronavirus_form.expert_advice_type.options.construction.label"),
+          label: t("coronavirus_form.expert_advice_type.options.construction.label"),
+          checked: session[:expert_advice].include?(t("coronavirus_form.expert_advice_type.options.construction.label")),
+        },
+        {
+          value: t("coronavirus_form.expert_advice_type.options.project_management.label"),
+          label: t("coronavirus_form.expert_advice_type.options.project_management.label"),
+          checked: session[:expert_advice].include?(t("coronavirus_form.expert_advice_type.options.project_management.label")),
+        },
+        {
+          value: t("coronavirus_form.expert_advice_type.options.it.label"),
+          label: t("coronavirus_form.expert_advice_type.options.it.label"),
+          checked: session[:expert_advice].include?(t("coronavirus_form.expert_advice_type.options.it.label")),
+        },
+        {
+          value: t("coronavirus_form.expert_advice_type.options.manufacturing.label"),
+          label: t("coronavirus_form.expert_advice_type.options.manufacturing.label"),
+          checked: session[:expert_advice].include?(t("coronavirus_form.expert_advice_type.options.manufacturing.label")),
+        },
+        {
+          value: t("coronavirus_form.expert_advice_type.options.other.label"),
+          label: t("coronavirus_form.expert_advice_type.options.other.label"),
+          checked: session[:expert_advice].include?(t("coronavirus_form.expert_advice_type.options.other.label")),
+          conditional: render("govuk_publishing_components/components/input", {
+            label: {
+              text: t("coronavirus_form.expert_advice_type.options.other.input.label"),
+            },
+            name: "expert_advice_other",
+            value: session[:expert_advice_other],
+            width: 50
+          })
+        },
+      ]
+    } %>
+    <%= render "govuk_publishing_components/components/button", text: "Save and continue", margin_bottom: true %>
+    <% end %>

--- a/app/views/coronavirus_form/expert_advice_type.html.erb
+++ b/app/views/coronavirus_form/expert_advice_type.html.erb
@@ -9,57 +9,57 @@
 
     <%= form_tag({},
       "data-module": "track-coronavirus-form-business-medical-equipment-type",
-      "data-question-key": "expert_advice",
+      "data-question-key": "expert_advice_type",
       "id": "expert_advice_type"
     ) do %>
     <%= render "govuk_publishing_components/components/checkboxes", {
       heading: t("coronavirus_form.expert_advice_type.title"),
       hint_text: t("coronavirus_form.expert_advice_type.hint"),
       is_page_heading: true,
-      name: "expert_advice[]",
-      error: error_items("expert_advice"),
+      name: "expert_advice_type[]",
+      error: error_items("expert_advice_type"),
       items: [
         {
           value: t("coronavirus_form.expert_advice_type.options.medical.label"),
           label: t("coronavirus_form.expert_advice_type.options.medical.label"),
-          checked: session[:expert_advice].include?(t("coronavirus_form.expert_advice_type.options.medical.label")),
+          checked: session[:expert_advice_type].include?(t("coronavirus_form.expert_advice_type.options.medical.label")),
         },
         {
           value: t("coronavirus_form.expert_advice_type.options.engineering.label"),
           label: t("coronavirus_form.expert_advice_type.options.engineering.label"),
-          checked: session[:expert_advice].include?(t("coronavirus_form.expert_advice_type.options.engineering.label")),
+          checked: session[:expert_advice_type].include?(t("coronavirus_form.expert_advice_type.options.engineering.label")),
         },
         {
           value: t("coronavirus_form.expert_advice_type.options.construction.label"),
           label: t("coronavirus_form.expert_advice_type.options.construction.label"),
-          checked: session[:expert_advice].include?(t("coronavirus_form.expert_advice_type.options.construction.label")),
+          checked: session[:expert_advice_type].include?(t("coronavirus_form.expert_advice_type.options.construction.label")),
         },
         {
           value: t("coronavirus_form.expert_advice_type.options.project_management.label"),
           label: t("coronavirus_form.expert_advice_type.options.project_management.label"),
-          checked: session[:expert_advice].include?(t("coronavirus_form.expert_advice_type.options.project_management.label")),
+          checked: session[:expert_advice_type].include?(t("coronavirus_form.expert_advice_type.options.project_management.label")),
         },
         {
           value: t("coronavirus_form.expert_advice_type.options.it.label"),
           label: t("coronavirus_form.expert_advice_type.options.it.label"),
-          checked: session[:expert_advice].include?(t("coronavirus_form.expert_advice_type.options.it.label")),
+          checked: session[:expert_advice_type].include?(t("coronavirus_form.expert_advice_type.options.it.label")),
         },
         {
           value: t("coronavirus_form.expert_advice_type.options.manufacturing.label"),
           label: t("coronavirus_form.expert_advice_type.options.manufacturing.label"),
-          checked: session[:expert_advice].include?(t("coronavirus_form.expert_advice_type.options.manufacturing.label")),
+          checked: session[:expert_advice_type].include?(t("coronavirus_form.expert_advice_type.options.manufacturing.label")),
         },
         {
           value: t("coronavirus_form.expert_advice_type.options.other.label"),
           label: t("coronavirus_form.expert_advice_type.options.other.label"),
-          checked: session[:expert_advice].include?(t("coronavirus_form.expert_advice_type.options.other.label")),
+          checked: session[:expert_advice_type].include?(t("coronavirus_form.expert_advice_type.options.other.label")),
           conditional: render("govuk_publishing_components/components/textarea", {
             label: {
               text: t("coronavirus_form.expert_advice_type.options.other.input.label"),
             },
-            name: "expert_advice_other",
-            value: session[:expert_advice_other],
-            width: 50
+            name: "expert_advice_type_other",
+            error_message: error_items("expert_advice_type_other"),
+            value: session[:expert_advice_type_other],
           })
         },
       ]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -188,13 +188,23 @@ en:
           label: "Moving goods"
       custom_select_error: Select what kind of transport can you offer
     expert_advice:
-      title: Can you offer expert advice?
-      hint: Select the types of expertise or consultancy experience you have
+      title: "Can you offer expert advice?"
+      hint: "For example, consultancy experience or expertise in a specific sector."
+      options:
+        option_yes:
+          label: "Yes"
+        option_no:
+          label: "No"
+    expert_advice_type:
+      title: "What kind of expert advice can you offer?"
+      hint: "Select the types of expertise or consultancy experience you have"
       options:
         medical:
           label: "Medical expertise"
         engineering:
           label: "Engineering expertise"
+        communications:
+          label: "Communications expertise"
         construction:
           label: "Construction expertise"
         project_management:
@@ -207,8 +217,8 @@ en:
           label: "Other"
           input:
             label: "Give a description"
-          error_message: Enter the best way to describe the type of expertise you have
-      custom_select_error: Select the best way to describe your expertise or consultancy experience
+          error_message: "Enter the best way to describe the type of expertise you have"
+      custom_select_error: "Select the best way to describe your expertise or consultancy experience"
     offer_care:
       title: Can you offer social care or childcare?
       hint: For example, nursing or assistance to other people.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,9 @@ Rails.application.routes.draw do
   get "/expert-advice" => "coronavirus_form/expert_advice#show"
   post "/expert-advice" => "coronavirus_form/expert_advice#submit"
 
+  get "/expert-advice-type" => "coronavirus_form/expert_advice_type#show"
+  post "/expert-advice-type" => "coronavirus_form/expert_advice_type#submit"
+
   get "/what-kind-of-transport" => "coronavirus_form/transport_type#show"
   post "/what-kind-of-transport" => "coronavirus_form/transport_type#submit"
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,12 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_200_320_105_826) do
-  # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
+ActiveRecord::Schema.define(version: 2020_03_20_105826) do
 
-  create_table 'form_responses', force: :cascade do |t|
-    t.jsonb 'form_response', default: {}, null: false
-    t.datetime 'created_at', null: false
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "form_responses", force: :cascade do |t|
+    t.jsonb "form_response", default: {}, null: false
+    t.datetime "created_at", null: false
   end
+
 end

--- a/spec/controllers/coronavirus_form/expert_advice_type_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/expert_advice_type_controller_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe CoronavirusForm::ExpertAdviceTypeController, type: :controller do
+  let(:current_template) { "coronavirus_form/expert_advice_type" }
+  let(:session_key) { :expert_advice_type }
+
+  describe "GET show" do
+    it "renders the form" do
+      get :show
+      expect(response).to render_template(current_template)
+    end
+  end
+
+  describe "POST submit" do
+    let(:options) do
+      I18n.t("coronavirus_form.expert_advice_type.options").map { |_, item| item[:label] }
+    end
+    let(:selected) { options.first(2) }
+    it "sets session variables" do
+      post :submit, params: { expert_advice: selected }
+
+      expect(session[session_key]).to eq selected
+    end
+
+    it "redirects to next step" do
+      post :submit, params: { expert_advice: selected }
+
+      expect(response).to redirect_to(offer_care_path)
+    end
+
+    it "redirects to check your answers if check your answers already seen" do
+      session[:check_answers_seen] = true
+      post :submit, params: { expert_advice: selected }
+
+      expect(response).to redirect_to(check_your_answers_path)
+    end
+
+    it "validates any option is chosen" do
+      post :submit, params: { expert_advice: [] }
+
+      expect(response).to render_template(current_template)
+    end
+
+    context "when Other option is selected" do
+      it "validates the Other option description is provided" do
+        post :submit, params: { expert_advice: %w[Other] }
+
+        expect(response).to render_template(current_template)
+      end
+
+      it "adds the other option description to the session" do
+        post :submit, params: {
+          expert_advice: %w[Other] + selected,
+          expert_advice_other: "Demo text",
+        }
+
+        expect(session[session_key]).to eq %w[Other] + selected
+        expect(session[:expert_advice_other]).to eq "Demo text"
+        expect(response).to redirect_to(offer_care_path)
+      end
+    end
+
+    it "validates a valid option is chosen" do
+      post :submit, params: {
+        expert_advice: ["<script></script", "invalid option"],
+      }
+
+      expect(response).to render_template(current_template)
+    end
+
+    it "validates only valid options are chosen" do
+      post :submit, params: {
+        expert_advice: ["<script></script", "invalid option"] + selected,
+      }
+
+      expect(response).to render_template(current_template)
+    end
+  end
+end

--- a/spec/controllers/coronavirus_form/expert_advice_type_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/expert_advice_type_controller_spec.rb
@@ -19,52 +19,52 @@ RSpec.describe CoronavirusForm::ExpertAdviceTypeController, type: :controller do
     end
     let(:selected) { options.first(2) }
     it "sets session variables" do
-      post :submit, params: { expert_advice: selected }
+      post :submit, params: { expert_advice_type: selected }
 
       expect(session[session_key]).to eq selected
     end
 
     it "redirects to next step" do
-      post :submit, params: { expert_advice: selected }
+      post :submit, params: { expert_advice_type: selected }
 
       expect(response).to redirect_to(offer_care_path)
     end
 
     it "redirects to check your answers if check your answers already seen" do
       session[:check_answers_seen] = true
-      post :submit, params: { expert_advice: selected }
+      post :submit, params: { expert_advice_type: selected }
 
       expect(response).to redirect_to(check_your_answers_path)
     end
 
     it "validates any option is chosen" do
-      post :submit, params: { expert_advice: [] }
+      post :submit, params: { expert_advice_type: [] }
 
       expect(response).to render_template(current_template)
     end
 
     context "when Other option is selected" do
       it "validates the Other option description is provided" do
-        post :submit, params: { expert_advice: %w[Other] }
+        post :submit, params: { expert_advice_type: %w[Other] }
 
         expect(response).to render_template(current_template)
       end
 
       it "adds the other option description to the session" do
         post :submit, params: {
-          expert_advice: %w[Other] + selected,
-          expert_advice_other: "Demo text",
+          expert_advice_type: %w[Other] + selected,
+          expert_advice_type_other: "Demo text",
         }
 
         expect(session[session_key]).to eq %w[Other] + selected
-        expect(session[:expert_advice_other]).to eq "Demo text"
+        expect(session[:expert_advice_type_other]).to eq "Demo text"
         expect(response).to redirect_to(offer_care_path)
       end
     end
 
     it "validates a valid option is chosen" do
       post :submit, params: {
-        expert_advice: ["<script></script", "invalid option"],
+        expert_advice_type: ["<script></script", "invalid option"],
       }
 
       expect(response).to render_template(current_template)
@@ -72,7 +72,7 @@ RSpec.describe CoronavirusForm::ExpertAdviceTypeController, type: :controller do
 
     it "validates only valid options are chosen" do
       post :submit, params: {
-        expert_advice: ["<script></script", "invalid option"] + selected,
+        expert_advice_type: ["<script></script", "invalid option"] + selected,
       }
 
       expect(response).to render_template(current_template)


### PR DESCRIPTION
Changes the question to a 'Yes'/'No' response.  If user selects 'Yes', they are taken to an additional question asking specifically the types of advice they can offer.

<img width="1000" alt="Screenshot 2020-03-23 at 15 06 42" src="https://user-images.githubusercontent.com/6329861/77331361-879bd180-6d18-11ea-83a1-56b635a6e825.png">
<img width="769" alt="Screenshot 2020-03-23 at 15 10 34" src="https://user-images.githubusercontent.com/6329861/77331366-89659500-6d18-11ea-83c4-c966be53d5c1.png">

Trello card: https://trello.com/c/HCXOxjTm