### PR TITLE
Redirect user to first question if they have not answered it

### DIFF
--- a/app/controllers/coronavirus_form/additional_product_check_controller.rb
+++ b/app/controllers/coronavirus_form/additional_product_check_controller.rb
@@ -3,6 +3,9 @@
 class CoronavirusForm::AdditionalProductCheckController < ApplicationController
   include ActionView::Helpers::SanitizeHelper
   include FieldValidationHelper
+  include FormFlowHelper
+
+  before_action :check_first_question_answered, only: :show
 
   def show
     render "coronavirus_form/#{PAGE}"

--- a/app/controllers/coronavirus_form/check_answers_controller.rb
+++ b/app/controllers/coronavirus_form/check_answers_controller.rb
@@ -2,6 +2,9 @@
 
 class CoronavirusForm::CheckAnswersController < ApplicationController
   include ActionView::Helpers::SanitizeHelper
+  include FormFlowHelper
+
+  before_action :check_first_question_answered, only: :show
 
   def show
     session[:check_answers_seen] = true

--- a/app/controllers/coronavirus_form/contact_details_controller.rb
+++ b/app/controllers/coronavirus_form/contact_details_controller.rb
@@ -3,6 +3,9 @@
 class CoronavirusForm::ContactDetailsController < ApplicationController
   include ActionView::Helpers::SanitizeHelper
   include FieldValidationHelper
+  include FormFlowHelper
+
+  before_action :check_first_question_answered, only: :show
 
   REQUIRED_FIELDS = %w(name phone_number email).freeze
 

--- a/app/controllers/coronavirus_form/expert_advice_controller.rb
+++ b/app/controllers/coronavirus_form/expert_advice_controller.rb
@@ -3,6 +3,9 @@
 class CoronavirusForm::ExpertAdviceController < ApplicationController
   include ActionView::Helpers::SanitizeHelper
   include FieldValidationHelper
+  include FormFlowHelper
+
+  before_action :check_first_question_answered, only: :show
 
   def show
     session[:expert_advice] ||= []

--- a/app/controllers/coronavirus_form/hotel_rooms_controller.rb
+++ b/app/controllers/coronavirus_form/hotel_rooms_controller.rb
@@ -3,6 +3,9 @@
 class CoronavirusForm::HotelRoomsController < ApplicationController
   include ActionView::Helpers::SanitizeHelper
   include FieldValidationHelper
+  include FormFlowHelper
+
+  before_action :check_first_question_answered, only: :show
 
   def show
     render "coronavirus_form/#{PAGE}"

--- a/app/controllers/coronavirus_form/manufacturer_check_controller.rb
+++ b/app/controllers/coronavirus_form/manufacturer_check_controller.rb
@@ -3,6 +3,9 @@
 class CoronavirusForm::ManufacturerCheckController < ApplicationController
   include ActionView::Helpers::SanitizeHelper
   include FieldValidationHelper
+  include FormFlowHelper
+
+  before_action :check_first_question_answered, only: :show
 
   def show
     session[:manufacturer_check] = []

--- a/app/controllers/coronavirus_form/medical_equipment_type_controller.rb
+++ b/app/controllers/coronavirus_form/medical_equipment_type_controller.rb
@@ -3,6 +3,9 @@
 class CoronavirusForm::MedicalEquipmentTypeController < ApplicationController
   include ActionView::Helpers::SanitizeHelper
   include FieldValidationHelper
+  include FormFlowHelper
+
+  before_action :check_first_question_answered, only: :show
 
   def show
     session[:medical_equipment_type] ||= []

--- a/app/controllers/coronavirus_form/offer_care_controller.rb
+++ b/app/controllers/coronavirus_form/offer_care_controller.rb
@@ -3,6 +3,9 @@
 class CoronavirusForm::OfferCareController < ApplicationController
   include ActionView::Helpers::SanitizeHelper
   include FieldValidationHelper
+  include FormFlowHelper
+
+  before_action :check_first_question_answered, only: :show
 
   def show
     render "coronavirus_form/#{PAGE}"

--- a/app/controllers/coronavirus_form/offer_community_support_controller.rb
+++ b/app/controllers/coronavirus_form/offer_community_support_controller.rb
@@ -3,6 +3,9 @@
 class CoronavirusForm::OfferCommunitySupportController < ApplicationController
   include ActionView::Helpers::SanitizeHelper
   include FieldValidationHelper
+  include FormFlowHelper
+
+  before_action :check_first_question_answered, only: :show
 
   def show
     render "coronavirus_form/#{PAGE}"

--- a/app/controllers/coronavirus_form/offer_other_support_controller.rb
+++ b/app/controllers/coronavirus_form/offer_other_support_controller.rb
@@ -3,6 +3,9 @@
 class CoronavirusForm::OfferOtherSupportController < ApplicationController
   include ActionView::Helpers::SanitizeHelper
   include FieldValidationHelper
+  include FormFlowHelper
+
+  before_action :check_first_question_answered, only: :show
 
   def show
     render "coronavirus_form/#{PAGE}"

--- a/app/controllers/coronavirus_form/offer_space_controller.rb
+++ b/app/controllers/coronavirus_form/offer_space_controller.rb
@@ -3,6 +3,9 @@
 class CoronavirusForm::OfferSpaceController < ApplicationController
   include ActionView::Helpers::SanitizeHelper
   include FieldValidationHelper
+  include FormFlowHelper
+
+  before_action :check_first_question_answered, only: :show
 
   def show
     render "coronavirus_form/#{PAGE}"

--- a/app/controllers/coronavirus_form/offer_space_type_controller.rb
+++ b/app/controllers/coronavirus_form/offer_space_type_controller.rb
@@ -3,6 +3,9 @@
 class CoronavirusForm::OfferSpaceTypeController < ApplicationController
   include ActionView::Helpers::SanitizeHelper
   include FieldValidationHelper
+  include FormFlowHelper
+
+  before_action :check_first_question_answered, only: :show
 
   def show
     session[:offer_space_type] ||= []

--- a/app/controllers/coronavirus_form/offer_transport_controller.rb
+++ b/app/controllers/coronavirus_form/offer_transport_controller.rb
@@ -3,6 +3,9 @@
 class CoronavirusForm::OfferTransportController < ApplicationController
   include ActionView::Helpers::SanitizeHelper
   include FieldValidationHelper
+  include FormFlowHelper
+
+  before_action :check_first_question_answered, only: :show
 
   def show
     render "coronavirus_form/#{PAGE}"

--- a/app/controllers/coronavirus_form/product_details_controller.rb
+++ b/app/controllers/coronavirus_form/product_details_controller.rb
@@ -3,6 +3,9 @@
 class CoronavirusForm::ProductDetailsController < ApplicationController
   include ActionView::Helpers::SanitizeHelper
   include FieldValidationHelper
+  include FormFlowHelper
+
+  before_action :check_first_question_answered, only: :show
 
   REQUIRED_FIELDS = %w(product_name product_cost certification_details product_postcode lead_time).freeze
 

--- a/app/controllers/coronavirus_form/transport_type_controller.rb
+++ b/app/controllers/coronavirus_form/transport_type_controller.rb
@@ -3,6 +3,9 @@
 class CoronavirusForm::TransportTypeController < ApplicationController
   include ActionView::Helpers::SanitizeHelper
   include FieldValidationHelper
+  include FormFlowHelper
+
+  before_action :check_first_question_answered, only: :show
 
   def show
     session[:transport_type] ||= []

--- a/app/controllers/coronavirus_form/which_goods_controller.rb
+++ b/app/controllers/coronavirus_form/which_goods_controller.rb
@@ -3,6 +3,9 @@
 class CoronavirusForm::WhichGoodsController < ApplicationController
   include ActionView::Helpers::SanitizeHelper
   include FieldValidationHelper
+  include FormFlowHelper
+
+  before_action :check_first_question_answered, only: :show
 
   def show
     session[:which_goods] ||= []

--- a/app/controllers/coronavirus_form/which_services_controller.rb
+++ b/app/controllers/coronavirus_form/which_services_controller.rb
@@ -3,6 +3,9 @@
 class CoronavirusForm::WhichServicesController < ApplicationController
   include ActionView::Helpers::SanitizeHelper
   include FieldValidationHelper
+  include FormFlowHelper
+
+  before_action :check_first_question_answered, only: :show
 
   def show
     session[:which_services] ||= []

--- a/app/helpers/form_flow_helper.rb
+++ b/app/helpers/form_flow_helper.rb
@@ -1,0 +1,13 @@
+module FormFlowHelper
+  FIRST_QUESTION = "medical_equipment".freeze
+
+  def check_first_question_answered
+    redirect_to controller: "coronavirus_form/#{FIRST_QUESTION}", action: "show" unless first_question_answered?
+  end
+
+private
+
+  def first_question_answered?
+    session[FIRST_QUESTION].present?
+  end
+end

--- a/spec/controllers/coronavirus_form/additional_product_check_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/additional_product_check_controller_spec.rb
@@ -6,9 +6,18 @@ RSpec.describe CoronavirusForm::AdditionalProductCheckController, type: :control
   let(:current_template) { "coronavirus_form/additional_product_check" }
 
   describe "GET show" do
-    it "renders the form" do
+    it "renders the form when first question answered" do
+      session["medical_equipment"] = "Yes"
       get :show
       expect(response).to render_template(current_template)
+    end
+
+    it "redirects to first question when first question not answered" do
+      get :show
+      expect(response).to redirect_to({
+        controller: "medical_equipment",
+        action: "show",
+      })
     end
   end
 

--- a/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
@@ -6,9 +6,18 @@ RSpec.describe CoronavirusForm::CheckAnswersController, type: :controller do
   let(:current_template) { "coronavirus_form/check_answers" }
 
   describe "GET show" do
-    it "renders the form" do
+    it "renders the form when first question answered" do
+      session["medical_equipment"] = "Yes"
       get :show
       expect(response).to render_template(current_template)
+    end
+
+    it "redirects to first question when first question not answered" do
+      get :show
+      expect(response).to redirect_to({
+        controller: "medical_equipment",
+        action: "show",
+      })
     end
   end
 

--- a/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
@@ -7,9 +7,18 @@ RSpec.describe CoronavirusForm::ContactDetailsController, type: :controller do
   let(:session_key) { :contact_details }
 
   describe "GET show" do
-    it "renders the form" do
+    it "renders the form when first question answered" do
+      session["medical_equipment"] = "Yes"
       get :show
       expect(response).to render_template(current_template)
+    end
+
+    it "redirects to first question when first question not answered" do
+      get :show
+      expect(response).to redirect_to({
+        controller: "medical_equipment",
+        action: "show",
+      })
     end
   end
 

--- a/spec/controllers/coronavirus_form/expert_advice_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/expert_advice_controller_spec.rb
@@ -7,9 +7,18 @@ RSpec.describe CoronavirusForm::ExpertAdviceController, type: :controller do
   let(:session_key) { :expert_advice }
 
   describe "GET show" do
-    it "renders the form" do
+    it "renders the form when first question answered" do
+      session["medical_equipment"] = "Yes"
       get :show
       expect(response).to render_template(current_template)
+    end
+
+    it "redirects to first question when first question not answered" do
+      get :show
+      expect(response).to redirect_to({
+        controller: "medical_equipment",
+        action: "show",
+      })
     end
   end
 

--- a/spec/controllers/coronavirus_form/hotel_rooms_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/hotel_rooms_controller_spec.rb
@@ -7,9 +7,18 @@ RSpec.describe CoronavirusForm::HotelRoomsController, type: :controller do
   let(:session_key) { :hotel_rooms }
 
   describe "GET show" do
-    it "renders the form" do
+    it "renders the form when first question answered" do
+      session["medical_equipment"] = "Yes"
       get :show
       expect(response).to render_template(current_template)
+    end
+
+    it "redirects to first question when first question not answered" do
+      get :show
+      expect(response).to redirect_to({
+        controller: "medical_equipment",
+        action: "show",
+      })
     end
   end
 

--- a/spec/controllers/coronavirus_form/manufacturer_check_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/manufacturer_check_controller_spec.rb
@@ -7,9 +7,18 @@ RSpec.describe CoronavirusForm::ManufacturerCheckController, type: :controller d
   let(:session_key) { :manufacturer_check }
 
   describe "GET show" do
-    it "renders the form" do
+    it "renders the form when first question answered" do
+      session["medical_equipment"] = "Yes"
       get :show
       expect(response).to render_template(current_template)
+    end
+
+    it "redirects to first question when first question not answered" do
+      get :show
+      expect(response).to redirect_to({
+        controller: "medical_equipment",
+        action: "show",
+      })
     end
   end
 

--- a/spec/controllers/coronavirus_form/medical_equipment_type_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/medical_equipment_type_controller_spec.rb
@@ -7,9 +7,18 @@ RSpec.describe CoronavirusForm::MedicalEquipmentTypeController, type: :controlle
   let(:session_key) { :medical_equipment_type }
 
   describe "GET show" do
-    it "renders the form" do
+    it "renders the form when first question answered" do
+      session["medical_equipment"] = "Yes"
       get :show
       expect(response).to render_template(current_template)
+    end
+
+    it "redirects to first question when first question not answered" do
+      get :show
+      expect(response).to redirect_to({
+        controller: "medical_equipment",
+        action: "show",
+      })
     end
   end
 

--- a/spec/controllers/coronavirus_form/offer_care_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/offer_care_controller_spec.rb
@@ -7,9 +7,18 @@ RSpec.describe CoronavirusForm::OfferCareController, type: :controller do
   let(:session_key) { :offer_care }
 
   describe "GET show" do
-    it "renders the form" do
+    it "renders the form when first question answered" do
+      session["medical_equipment"] = "Yes"
       get :show
       expect(response).to render_template(current_template)
+    end
+
+    it "redirects to first question when first question not answered" do
+      get :show
+      expect(response).to redirect_to({
+        controller: "medical_equipment",
+        action: "show",
+      })
     end
   end
 

--- a/spec/controllers/coronavirus_form/offer_community_support_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/offer_community_support_controller_spec.rb
@@ -7,9 +7,18 @@ RSpec.describe CoronavirusForm::OfferCommunitySupportController, type: :controll
   let(:session_key) { :offer_community_support }
 
   describe "GET show" do
-    it "renders the form" do
+    it "renders the form when first question answered" do
+      session["medical_equipment"] = "Yes"
       get :show
       expect(response).to render_template(current_template)
+    end
+
+    it "redirects to first question when first question not answered" do
+      get :show
+      expect(response).to redirect_to({
+        controller: "medical_equipment",
+        action: "show",
+      })
     end
   end
 

--- a/spec/controllers/coronavirus_form/offer_other_support_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/offer_other_support_controller_spec.rb
@@ -7,9 +7,18 @@ RSpec.describe CoronavirusForm::OfferOtherSupportController, type: :controller d
   let(:session_key) { :offer_other_support }
 
   describe "GET show" do
-    it "renders the form" do
+    it "renders the form when first question answered" do
+      session["medical_equipment"] = "Yes"
       get :show
       expect(response).to render_template(current_template)
+    end
+
+    it "redirects to first question when first question not answered" do
+      get :show
+      expect(response).to redirect_to({
+        controller: "medical_equipment",
+        action: "show",
+      })
     end
   end
 

--- a/spec/controllers/coronavirus_form/offer_space_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/offer_space_controller_spec.rb
@@ -7,9 +7,18 @@ RSpec.describe CoronavirusForm::OfferSpaceController, type: :controller do
   let(:session_key) { :offer_space }
 
   describe "GET show" do
-    it "renders the form" do
+    it "renders the form when first question answered" do
+      session["medical_equipment"] = "Yes"
       get :show
       expect(response).to render_template(current_template)
+    end
+
+    it "redirects to first question when first question not answered" do
+      get :show
+      expect(response).to redirect_to({
+        controller: "medical_equipment",
+        action: "show",
+      })
     end
   end
 

--- a/spec/controllers/coronavirus_form/offer_space_type_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/offer_space_type_controller_spec.rb
@@ -7,9 +7,18 @@ RSpec.describe CoronavirusForm::OfferSpaceTypeController, type: :controller do
   let(:session_key) { :offer_space_type }
 
   describe "GET show" do
-    it "renders the form" do
+    it "renders the form when first question answered" do
+      session["medical_equipment"] = "Yes"
       get :show
       expect(response).to render_template(current_template)
+    end
+
+    it "redirects to first question when first question not answered" do
+      get :show
+      expect(response).to redirect_to({
+        controller: "medical_equipment",
+        action: "show",
+      })
     end
   end
 

--- a/spec/controllers/coronavirus_form/offer_transport_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/offer_transport_controller_spec.rb
@@ -7,9 +7,18 @@ RSpec.describe CoronavirusForm::OfferTransportController, type: :controller do
   let(:session_key) { :offer_transport }
 
   describe "GET show" do
-    it "renders the form" do
+    it "renders the form when first question answered" do
+      session["medical_equipment"] = "Yes"
       get :show
       expect(response).to render_template(current_template)
+    end
+
+    it "redirects to first question when first question not answered" do
+      get :show
+      expect(response).to redirect_to({
+        controller: "medical_equipment",
+        action: "show",
+      })
     end
   end
 

--- a/spec/controllers/coronavirus_form/product_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/product_details_controller_spec.rb
@@ -17,9 +17,18 @@ RSpec.describe CoronavirusForm::ProductDetailsController, type: :controller do
   end
 
   describe "GET show" do
-    it "renders the form" do
+    it "renders the form when first question answered" do
+      session["medical_equipment"] = "Yes"
       get :show
       expect(response).to render_template(current_template)
+    end
+
+    it "redirects to first question when first question not answered" do
+      get :show
+      expect(response).to redirect_to({
+        controller: "medical_equipment",
+        action: "show",
+      })
     end
 
     context "when there are existing products" do
@@ -31,6 +40,7 @@ RSpec.describe CoronavirusForm::ProductDetailsController, type: :controller do
         )
       }
       before :each do
+        session["medical_equipment"] = "Yes"
         session[session_key] = [
           product,
           params.merge("product_id" => SecureRandom.uuid),

--- a/spec/controllers/coronavirus_form/transport_type_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/transport_type_controller_spec.rb
@@ -7,9 +7,18 @@ RSpec.describe CoronavirusForm::TransportTypeController, type: :controller do
   let(:session_key) { :transport_type }
 
   describe "GET show" do
-    it "renders the form" do
+    it "renders the form when first question answered" do
+      session["medical_equipment"] = "Yes"
       get :show
       expect(response).to render_template(current_template)
+    end
+
+    it "redirects to first question when first question not answered" do
+      get :show
+      expect(response).to redirect_to({
+        controller: "medical_equipment",
+        action: "show",
+      })
     end
   end
 

--- a/spec/controllers/coronavirus_form/which_goods_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/which_goods_controller_spec.rb
@@ -7,9 +7,18 @@ RSpec.describe CoronavirusForm::WhichGoodsController, type: :controller do
   let(:session_key) { :which_goods }
 
   describe "GET show" do
-    it "renders the form" do
+    it "renders the form when first question answered" do
+      session["medical_equipment"] = "Yes"
       get :show
       expect(response).to render_template(current_template)
+    end
+
+    it "redirects to first question when first question not answered" do
+      get :show
+      expect(response).to redirect_to({
+        controller: "medical_equipment",
+        action: "show",
+      })
     end
   end
 

--- a/spec/controllers/coronavirus_form/which_services_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/which_services_controller_spec.rb
@@ -7,9 +7,18 @@ RSpec.describe CoronavirusForm::WhichServicesController, type: :controller do
   let(:session_key) { :which_services }
 
   describe "GET show" do
-    it "renders the form" do
+    it "renders the form when first question answered" do
+      session["medical_equipment"] = "Yes"
       get :show
       expect(response).to render_template(current_template)
+    end
+
+    it "redirects to first question when first question not answered" do
+      get :show
+      expect(response).to redirect_to({
+        controller: "medical_equipment",
+        action: "show",
+      })
     end
   end
 


### PR DESCRIPTION
This will force users who come in through the URL of an intermediate question to return to the start of the form.

Trello card: https://trello.com/c/ZsjDHDv2