### PR TITLE
Update medical_equipment_type view

### DIFF
--- a/app/views/coronavirus_form/medical_equipment_type.html.erb
+++ b/app/views/coronavirus_form/medical_equipment_type.html.erb
@@ -32,13 +32,12 @@
       value: t('coronavirus_form.medical_equipment_type.options.other.label'),
       label: t('coronavirus_form.medical_equipment_type.options.other.label'),
       checked: session[:medical_equipment_type].include?(t('coronavirus_form.medical_equipment_type.options.other.label')),
-      conditional: render("govuk_publishing_components/components/input", {
+      conditional: render("govuk_publishing_components/components/textarea", {
         label: {
           text: t('coronavirus_form.medical_equipment_type.options.other.input.label'),
         },
         name: "medical_equipment_type_other",
-        value: session[:medical_equipment_type_other],
-        width: 10
+        value: session[:medical_equipment_type_other]
       })
     },
   ]


### PR DESCRIPTION
Use textarea for 'other' field.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

![localhost_5000_medical-equipment-type (1)](https://user-images.githubusercontent.com/788096/77343261-5546a000-6d29-11ea-828d-bdb1e781d7a3.png)


</td><td valign="top">

![localhost_5000_medical-equipment-type](https://user-images.githubusercontent.com/788096/77343275-5a0b5400-6d29-11ea-9b89-bd329f93cd40.png)


</td></tr>
</table>

[Trello card](https://trello.com/c/qBWY4WTS)