### PR TITLE
Question 9 update: Allow users to progress with empty input

### DIFF
--- a/app/controllers/coronavirus_form/offer_other_support_controller.rb
+++ b/app/controllers/coronavirus_form/offer_other_support_controller.rb
@@ -18,17 +18,15 @@ class CoronavirusForm::OfferOtherSupportController < ApplicationController
 
     if session["check_answers_seen"]
       redirect_to controller: "coronavirus_form/check_answers", action: "show"
-    elsif !session[:offer_other_support].nil?
-      redirect_to controller: "coronavirus_form/#{NEXT_PAGE}", action: "show"
     else
-      redirect_to controller: "coronavirus_form/#{PAGE}", action: "show"
+      redirect_to controller: "coronavirus_form/#{NEXT_PAGE}", action: "show"
     end
   end
 
 private
 
   PAGE = "offer_other_support"
-  NEXT_PAGE = "thank_you"
+  NEXT_PAGE = "business_details"
 
   def previous_path
     offer_community_support_path

--- a/spec/controllers/coronavirus_form/offer_other_support_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/offer_other_support_controller_spec.rb
@@ -36,6 +36,11 @@ RSpec.describe CoronavirusForm::OfferOtherSupportController, type: :controller d
       expect(session[session_key]).to eq "I offer you, my hacking script!"
     end
 
+    it "takes you to the next page regardless of input" do
+      post :submit
+      expect(response).to redirect_to(business_details_path)
+    end
+
     it "redirects to check your answers if check your answers previously seen" do
       session[:check_answers_seen] = true
       post :submit, params: { offer_other_support: text_response }


### PR DESCRIPTION
We won't check the input has been provided. Also updates next page routing.

https://trello.com/c/aRP12yaD/104-question-9-allow-users-to-leave-the-textarea-any-other-types-of-support-empty