### PR TITLE
Fix validation error message for contact details form

### DIFF
--- a/app/controllers/coronavirus_form/contact_details_controller.rb
+++ b/app/controllers/coronavirus_form/contact_details_controller.rb
@@ -7,7 +7,7 @@ class CoronavirusForm::ContactDetailsController < ApplicationController
 
   before_action :check_first_question_answered, only: :show
 
-  REQUIRED_FIELDS = %w(name phone_number email).freeze
+  REQUIRED_FIELDS = %w(contact_name phone_number email).freeze
 
   def show
     session[:contact_details] ||= {}
@@ -16,7 +16,7 @@ class CoronavirusForm::ContactDetailsController < ApplicationController
 
   def submit
     session[:contact_details] ||= {}
-    session[:contact_details]["name"] = sanitize(params[:name]).presence
+    session[:contact_details]["contact_name"] = sanitize(params[:contact_name]).presence
     session[:contact_details]["role"] = sanitize(params[:role]).presence
     session[:contact_details]["phone_number"] = sanitize(params[:phone_number]).presence
     session[:contact_details]["email"] = sanitize(params[:email]).presence

--- a/app/views/coronavirus_form/contact_details.html.erb
+++ b/app/views/coronavirus_form/contact_details.html.erb
@@ -19,11 +19,11 @@
 ) do %>
 <%= render "govuk_publishing_components/components/input", {
   label: {
-    text: t('coronavirus_form.contact_details.name.label')
+    text: t('coronavirus_form.contact_details.contact_name.label')
   },
-  name: "name",
-  error_message: error_items('name'),
-  value: session[:contact_details]["name"],
+  name: "contact_name",
+  error_message: error_items("contact_name"),
+  value: session[:contact_details]["contact_name"],
 } %>
 <%= render "govuk_publishing_components/components/input", {
   label: {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -284,7 +284,7 @@ en:
        custom_select_error: Select if you can offer community support
     contact_details:
       title: Contact details
-      name:
+      contact_name:
         label: Name of main contact
       role:
         label: Role of main contact (optional)


### PR DESCRIPTION
The word "name" appears to be reserved for the error messages.  Currently, an invalid email address will also show alongside the "Name of main contact field".  Therefore changing the name of this field to something that isn't reserved.

Example:
![Screenshot 2020-03-24 at 08 27 32](https://user-images.githubusercontent.com/6329861/77404268-5d462480-6da9-11ea-8a4c-0d5c223397d9.png)
