### PR TITLE
Apply cache control in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,6 +25,13 @@ Rails.application.configure do
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
+    config.public_file_server.enabled = true
+    config.public_file_server.headers = {
+      "Cache-Control" => "public, s-maxage=31536000, max-age=31536000",
+    }
+  else
+    config.public_file_server.enabled = false
+  end
 
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass


### PR DESCRIPTION
Setup static asset cache time to 1 year.

[Trello card](https://trello.com/c/FwfoW01n)