### PR TITLE
Correct use of arrays for checkbox form inputs

### DIFF
--- a/app/views/coronavirus_form/manufacturer_check.html.erb
+++ b/app/views/coronavirus_form/manufacturer_check.html.erb
@@ -16,7 +16,7 @@
   heading: t('coronavirus_form.manufacturer_check.title'),
   hint_text: t('coronavirus_form.manufacturer_check.hint'),
   is_page_heading: true,
-  name: "manufacturer_check",
+  name: "manufacturer_check[]",
   error: error_items('manufacturer_check'),
   items: t('coronavirus_form.manufacturer_check.options').map do |_, item|
     {

--- a/app/views/coronavirus_form/offer_space_type.erb
+++ b/app/views/coronavirus_form/offer_space_type.erb
@@ -16,8 +16,8 @@
     heading: t('coronavirus_form.offer_space_type.title'),
     hint: t('coronavirus_form.offer_space_type.hint'),
     is_page_heading: true,
-    name: "offer_space_type",
-    error: error_items("offer_space_type[]"),
+    name: "offer_space_type[]",
+    error: error_items("offer_space_type"),
     items: [
       {
         value: t('coronavirus_form.offer_space_type.options.warehouse_space.label'),

--- a/app/views/coronavirus_form/transport_type.html.erb
+++ b/app/views/coronavirus_form/transport_type.html.erb
@@ -15,7 +15,7 @@
 <%= render "govuk_publishing_components/components/checkboxes", {
   heading: t('coronavirus_form.transport_type.title'),
   is_page_heading: true,
-  name: "transport_type",
+  name: "transport_type[]",
   error: error_items('transport_type'),
   items: t('coronavirus_form.transport_type.options').map do |_, item|
     {


### PR DESCRIPTION
There are some places where checkbox fields do not have an array name, therefore only one value was being stored.  Updated to use array naming convention.

Also fixed the error naming for some checkboxes, since the array name raises an exception when used.