### PR TITLE
Allow medical equipment type to be specified for each product

### DIFF
--- a/app/controllers/coronavirus_form/additional_product_controller.rb
+++ b/app/controllers/coronavirus_form/additional_product_controller.rb
@@ -23,7 +23,7 @@ class CoronavirusForm::AdditionalProductController < ApplicationController
       flash.now[:validation] = invalid_fields
       render "coronavirus_form/#{PAGE}"
     elsif additional_product == I18n.t("coronavirus_form.questions.additional_product.options.option_yes.label")
-      redirect_to controller: "coronavirus_form/product_details", action: "show"
+      redirect_to controller: "coronavirus_form/medical_equipment_type", action: "show"
     elsif session["check_answers_seen"]
       redirect_to controller: "coronavirus_form/check_answers", action: "show"
     else

--- a/app/controllers/coronavirus_form/check_answers_controller.rb
+++ b/app/controllers/coronavirus_form/check_answers_controller.rb
@@ -49,6 +49,8 @@ private
         # We have answers as strings and hashes. The hashes need a little more
         # work to make them readable.
 
+        next if question.eql?("medical_equipment_type")
+
         if question.eql?("additional_product")
           next add_extra_product(question)
         end
@@ -89,6 +91,11 @@ private
     joiner = "<br>"
     products.map do |product|
       prod = []
+      prod << if product["medical_equipment_type_other"]
+                "Type: #{product['medical_equipment_type']} (#{product['medical_equipment_type_other']})"
+              else
+                "Type: #{product['medical_equipment_type']}"
+              end
       prod << "Product: #{product['product_name']}" if product["product_name"]
       prod << "Equipment type: #{product['equipment_type']}" if product["equipment_type"]
       prod << "Cost: #{product['product_cost']}" if product["product_cost"]

--- a/app/controllers/coronavirus_form/medical_equipment_type_controller.rb
+++ b/app/controllers/coronavirus_form/medical_equipment_type_controller.rb
@@ -4,29 +4,38 @@ class CoronavirusForm::MedicalEquipmentTypeController < ApplicationController
   include ActionView::Helpers::SanitizeHelper
   include FieldValidationHelper
   include FormFlowHelper
+  include ProductHelper
 
   before_action :check_first_question_answered, only: :show
 
   def show
+    session[:product_details] ||= []
+    @product = find_product(params["product_id"], session[:product_details])
     render "coronavirus_form/#{PAGE}"
   end
 
   def submit
-    medical_equipment_type = sanitize(params[:medical_equipment_type]).presence
-    medical_equipment_type_other = sanitize(params[:medical_equipment_type_other]).presence
-    session[:medical_equipment_type] = medical_equipment_type
-    session[:medical_equipment_type_other] = medical_equipment_type_other
+    session[:product_details] ||= []
+    @product = sanitized_product(params)
+    add_product_to_session(@product)
+
     invalid_fields = validate_radio_field(
       PAGE,
-      radio: medical_equipment_type,
-      other: medical_equipment_type_other,
+      radio: @product["medical_equipment_type"],
+      other: @product["medical_equipment_type_other"],
     )
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       render "coronavirus_form/#{PAGE}"
+    elsif session["check_answers_seen"]
+      redirect_to controller: "coronavirus_form/check_answers", action: "show"
     else
-      redirect_to controller: session["check_answers_seen"] ? "coronavirus_form/check_answers" : "coronavirus_form/#{NEXT_PAGE}", action: "show"
+      redirect_to(
+        controller: "coronavirus_form/#{NEXT_PAGE}",
+        action: "show",
+        params: { product_id: @product["product_id"] },
+      )
     end
   end
 
@@ -41,5 +50,13 @@ private
 
   def previous_path
     are_you_a_manufacturer_path
+  end
+
+  def sanitized_product(params)
+    {
+      "product_id" => sanitize(params[:product_id]).presence || SecureRandom.uuid,
+      "medical_equipment_type" => sanitize(params[:medical_equipment_type]).presence,
+      "medical_equipment_type_other" => sanitize(params[:medical_equipment_type_other]).presence,
+    }
   end
 end

--- a/app/helpers/product_helper.rb
+++ b/app/helpers/product_helper.rb
@@ -1,0 +1,17 @@
+module ProductHelper
+  def add_product_to_session(product)
+    session[:product_details] ||= []
+    products = session[:product_details].reject do |prod|
+      prod["product_id"] == product["product_id"]
+    end
+    session[:product_details] = products << product
+  end
+
+  def find_product(product_id, products)
+    products.find { |product| product["product_id"] == product_id } || {}
+  end
+
+  def current_product(product_id, products)
+    find_product(product_id, products)
+  end
+end

--- a/app/views/coronavirus_form/medical_equipment_type.html.erb
+++ b/app/views/coronavirus_form/medical_equipment_type.html.erb
@@ -22,17 +22,17 @@
     {
       value: t('coronavirus_form.questions.medical_equipment_type.options.number_ppe.label'),
       text: t('coronavirus_form.questions.medical_equipment_type.options.number_ppe.label'),
-      checked: session[:medical_equipment_type] == t('coronavirus_form.questions.medical_equipment_type.options.number_ppe.label'),
+      checked: @product["medical_equipment_type"] == t('coronavirus_form.questions.medical_equipment_type.options.number_ppe.label'),
     },
     {
       value: t('coronavirus_form.questions.medical_equipment_type.options.number_testing_equipment.label'),
       text: t('coronavirus_form.questions.medical_equipment_type.options.number_testing_equipment.label'),
-      checked: session[:medical_equipment_type] == t('coronavirus_form.questions.medical_equipment_type.options.number_testing_equipment.label'),
+      checked: @product["medical_equipment_type"] == t('coronavirus_form.questions.medical_equipment_type.options.number_testing_equipment.label'),
     },
     {
       value: t('coronavirus_form.questions.medical_equipment_type.options.other.label'),
       text: t('coronavirus_form.questions.medical_equipment_type.options.other.label'),
-      checked: session[:medical_equipment_type] == t('coronavirus_form.questions.medical_equipment_type.options.other.label'),
+      checked: @product["medical_equipment_type"] == t('coronavirus_form.questions.medical_equipment_type.options.other.label'),
       conditional: render("govuk_publishing_components/components/textarea", {
         label: {
           text: t('coronavirus_form.questions.medical_equipment_type.options.other.input.label'),

--- a/spec/controllers/coronavirus_form/additional_product_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/additional_product_controller_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe CoronavirusForm::AdditionalProductController, type: :controller d
   describe "POST submit" do
     it "redirects to next step for yes response" do
       post :submit, params: { additional_product: "Yes" }
-      expect(response).to redirect_to(product_details_path)
+      expect(response).to redirect_to(medical_equipment_type_path)
     end
 
     it "redirects to next sub-question for no response" do
@@ -37,14 +37,14 @@ RSpec.describe CoronavirusForm::AdditionalProductController, type: :controller d
       session[:check_answers_seen] = true
       post :submit, params: { additional_product: "No" }
 
-      expect(response).to redirect_to("/check-your-answers")
+      expect(response).to redirect_to(check_your_answers_path)
     end
 
-    it "redirects to check your answers regardless of if check your answers previously seen" do
+    it "does not redirect to check your answers if answers seen but additional product selected" do
       session[:check_answers_seen] = true
       post :submit, params: { additional_product: "Yes" }
 
-      expect(response).to redirect_to(product_details_path)
+      expect(response).to redirect_to(medical_equipment_type_path)
     end
 
     it "validates any option is chosen" do

--- a/spec/controllers/coronavirus_form/medical_equipment_type_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/medical_equipment_type_controller_spec.rb
@@ -4,7 +4,9 @@ require "spec_helper"
 
 RSpec.describe CoronavirusForm::MedicalEquipmentTypeController, type: :controller do
   let(:current_template) { "coronavirus_form/medical_equipment_type" }
-  let(:session_key) { :medical_equipment_type }
+  let(:session_key) { :product_details }
+
+  before { allow(SecureRandom).to receive(:uuid).and_return("abcd1234") }
 
   describe "GET show" do
     it "renders the form when first question answered" do
@@ -27,13 +29,17 @@ RSpec.describe CoronavirusForm::MedicalEquipmentTypeController, type: :controlle
     it "sets session variables" do
       post :submit, params: { medical_equipment_type: selected }
 
-      expect(session[session_key]).to eq selected
+      expect(session[session_key][0]["medical_equipment_type"]).to eq selected
     end
 
     it "redirects to next step" do
       post :submit, params: { medical_equipment_type: selected }
 
-      expect(response).to redirect_to(product_details_path)
+      expect(response).to redirect_to(
+        controller: "coronavirus_form/product_details",
+        action: :show,
+        params: { product_id: "abcd1234" },
+      )
     end
 
     it "redirects to check your answers if check your answers already seen" do
@@ -62,9 +68,13 @@ RSpec.describe CoronavirusForm::MedicalEquipmentTypeController, type: :controlle
           medical_equipment_type_other: "Demo text",
         }
 
-        expect(response).to redirect_to(product_details_path)
-        expect(session[session_key]).to eq "Other"
-        expect(session[:medical_equipment_type_other]).to eq "Demo text"
+        expect(response).to redirect_to(
+          controller: "coronavirus_form/product_details",
+          action: :show,
+          params: { product_id: "abcd1234" },
+        )
+        expect(session[session_key][0]["medical_equipment_type"]).to eq "Other"
+        expect(session[session_key][0]["medical_equipment_type_other"]).to eq "Demo text"
       end
     end
 


### PR DESCRIPTION
Currently users can only specify a single medical equipment type, but multiple products.  This stores the medical equipment type against the product hash.  Logic is also updated so users are redirected to the correct questions.

Session Before:
```
 "medical_equipment_type" => "Something",
 "medical_equipment_type_other" => "Something",
 "products" => [
    {
      "product_id" => "1234",
      ...
    }
  ]
```

Session After:
```
 "products" => [
    {
      "medical_equipment_type" => "Something",
      "medical_equipment_type_other" => "Something",
      "product_id" => "1234",
      ...
    }
  ]
```

Trello card: https://trello.com/c/KjnzVeNd