### PR TITLE
Fix error summary

### DIFF
--- a/app/controllers/coronavirus_form/contact_details_controller.rb
+++ b/app/controllers/coronavirus_form/contact_details_controller.rb
@@ -7,7 +7,7 @@ class CoronavirusForm::ContactDetailsController < ApplicationController
 
   before_action :check_first_question_answered, only: :show
 
-  REQUIRED_FIELDS = %w(contact_name phone_number email).freeze
+  REQUIRED_FIELDS = %w(contact_name phone_number).freeze
 
   def show
     session[:contact_details] ||= {}

--- a/app/controllers/coronavirus_form/product_details_controller.rb
+++ b/app/controllers/coronavirus_form/product_details_controller.rb
@@ -8,7 +8,7 @@ class CoronavirusForm::ProductDetailsController < ApplicationController
 
   before_action :check_first_question_answered, only: :show
 
-  REQUIRED_FIELDS = %w(product_name product_cost certification_details product_location lead_time).freeze
+  REQUIRED_FIELDS = %w(product_name product_cost certification_details lead_time).freeze
 
   def show
     session["product_details"] ||= []
@@ -51,8 +51,9 @@ private
 
   def validate_fields(product)
     missing_fields = validate_missing_fields(product)
+    product_location_validation = validate_radio_field("#{PAGE}.product_location", radio: product["product_location"])
     postcode_validation = validate_product_postcode(product)
-    missing_fields + postcode_validation
+    missing_fields + product_location_validation + postcode_validation
   end
 
   def validate_product_postcode(product)

--- a/app/views/coronavirus_form/business_details.html.erb
+++ b/app/views/coronavirus_form/business_details.html.erb
@@ -42,8 +42,9 @@
   heading_size: "s",
   name: "company_size",
   error_message: error_items('company_size'),
-  items: t('coronavirus_form.questions.business_details.company_size.options').map do |_, item|
+  items: t('coronavirus_form.questions.business_details.company_size.options').map.with_index do |(_, item), index|
     {
+      id: ("business_details.company_size" if index == 0),
       value:  item[:label],
       text:  item[:label],
       checked: session.dig("business_details", "company_size") == item[:label],
@@ -56,8 +57,9 @@
   heading_size: "s",
   name: "company_location",
   error_message: error_items('company_location'),
-  items: t('coronavirus_form.questions.business_details.company_location.options').map do |_, item|
+  items: t('coronavirus_form.questions.business_details.company_location.options').map.with_index do |(_, item), index|
     {
+      id: ("business_details.company_location" if index == 0),
       value:  item[:label],
       text:  item[:label],
       checked: session.dig("business_details", "company_location") == item[:label],

--- a/app/views/coronavirus_form/business_details.html.erb
+++ b/app/views/coronavirus_form/business_details.html.erb
@@ -19,6 +19,7 @@
 } %>
 
 <%= render "govuk_publishing_components/components/input", {
+  id: "company_name",
   name: "company_name",
   label: {
     text: t('coronavirus_form.questions.business_details.company_name.label'),

--- a/app/views/coronavirus_form/contact_details.html.erb
+++ b/app/views/coronavirus_form/contact_details.html.erb
@@ -21,6 +21,7 @@
   label: {
     text: t('coronavirus_form.questions.contact_details.contact_name.label')
   },
+  id: "contact_name",
   name: "contact_name",
   error_message: error_items("contact_name"),
   value: session[:contact_details]["contact_name"],
@@ -37,6 +38,7 @@
   label: {
     text: t('coronavirus_form.questions.contact_details.phone_number.label')
   },
+  id: "phone_number",
   name: "phone_number",
   error_message: error_items('phone_number'),
   value: session[:contact_details]["phone_number"],
@@ -45,6 +47,7 @@
   label: {
     text: t('coronavirus_form.questions.contact_details.email.label')
   },
+  id: "email",
   name: "email",
   error_message: error_items('email'),
   value: session[:contact_details]["email"],

--- a/app/views/coronavirus_form/expert_advice_type.html.erb
+++ b/app/views/coronavirus_form/expert_advice_type.html.erb
@@ -62,6 +62,7 @@
             label: {
               text: t("coronavirus_form.questions.expert_advice_type.options.other.input.label"),
             },
+            id: "expert_advice_type_other",
             name: "expert_advice_type_other",
             error_message: error_items("expert_advice_type_other"),
             value: session[:expert_advice_type_other],

--- a/app/views/coronavirus_form/medical_equipment_type.html.erb
+++ b/app/views/coronavirus_form/medical_equipment_type.html.erb
@@ -37,6 +37,7 @@
         label: {
           text: t('coronavirus_form.questions.medical_equipment_type.options.other.input.label'),
         },
+        id: "medical_equipment_type_other",
         name: "medical_equipment_type_other",
         value: session[:medical_equipment_type_other]
       })

--- a/app/views/coronavirus_form/offer_care_qualifications.erb
+++ b/app/views/coronavirus_form/offer_care_qualifications.erb
@@ -32,6 +32,7 @@
           label: {
             text: t('coronavirus_form.questions.offer_care_qualifications.options.nursing_or_healthcare_qualification.input.label'),
           },
+          id: "offer_care_qualifications_type",
           name: "offer_care_qualifications_type",
           error_message: error_items("offer_care_qualifications_type"),
           value: session[:offer_care_qualifications_type],

--- a/app/views/coronavirus_form/offer_space_type.erb
+++ b/app/views/coronavirus_form/offer_space_type.erb
@@ -37,6 +37,7 @@
           label: {
             text: t('coronavirus_form.questions.offer_space_type.options.other.input.label'),
           },
+          id: "offer_space_type_other",
           name: "offer_space_type_other",
           error_message: error_items("offer_space_type_other"),
           value: session[:offer_space_type_other],

--- a/app/views/coronavirus_form/product_details.html.erb
+++ b/app/views/coronavirus_form/product_details.html.erb
@@ -26,14 +26,15 @@
   label: {
     text: t('coronavirus_form.questions.product_details.product_name.label')
   },
+  id: "product_name",
   name: "product_name",
   error_message: error_items('product_name'),
   value: @product["product_name"],
 } %>
 <% if selected_ppe? %>
   <%= render "govuk_publishing_components/components/radio", {
-    description: t('coronavirus_form.questions.product_details.equipment_type.label'),
-    is_page_heading: true,
+    heading: t('coronavirus_form.questions.product_details.equipment_type.label'),
+    heading_size: 's',
     name: "equipment_type",
     error_message: error_items('equipment_type'),
     items: t('coronavirus_form.questions.product_details.equipment_type.options').map do |_, item|
@@ -51,6 +52,7 @@
     text: t('coronavirus_form.questions.product_details.product_cost.label'),
   },
   hint: t('coronavirus_form.questions.product_details.product_cost.hint'),
+  id: "product_cost",
   name: "product_cost",
   error_message: error_items('product_cost'),
   value: @product["product_cost"],
@@ -61,13 +63,14 @@
     text: t('coronavirus_form.questions.product_details.certification_details.label'),
   },
   hint: t('coronavirus_form.questions.product_details.certification_details.hint'),
+  id: "certification_details",
   name: "certification_details",
   error_message: error_items('certification_details'),
   value: @product["certification_details"],
 } %>
 <%= render "govuk_publishing_components/components/radio", {
-  description: t('coronavirus_form.questions.product_details.product_location.label'),
-  is_page_heading: true,
+  heading: t('coronavirus_form.questions.product_details.product_location.label'),
+  heading_size: "s",
   name: "product_location",
   error_message: error_items('product_location'),
   items: [
@@ -109,6 +112,7 @@
   label: {
     text: t('coronavirus_form.questions.product_details.lead_time.label')
   },
+  id: "lead_time",
   name: "lead_time",
   error_message: error_items('lead_time'),
   type: "number",

--- a/app/views/coronavirus_form/product_details.html.erb
+++ b/app/views/coronavirus_form/product_details.html.erb
@@ -84,6 +84,7 @@
         label: {
           text: t('coronavirus_form.questions.product_details.product_location.options.option_uk.input.label'),
         },
+        id: "product_postcode",
         name: "product_postcode",
         error_message: error_items('product_postcode'),
         value: @product["product_postcode"],

--- a/app/views/coronavirus_form/product_details.html.erb
+++ b/app/views/coronavirus_form/product_details.html.erb
@@ -37,8 +37,9 @@
     heading_size: 's',
     name: "equipment_type",
     error_message: error_items('equipment_type'),
-    items: t('coronavirus_form.questions.product_details.equipment_type.options').map do |_, item|
+    items: t('coronavirus_form.questions.product_details.equipment_type.options').map.with_index do |(_, item), index|
       {
+        id: ("equipment_type" if index == 0),
         value: item[:label],
         text: item[:label],
         checked: @product["equipment_type"] == item[:label],
@@ -75,6 +76,7 @@
   error_message: error_items('product_location'),
   items: [
     {
+      id: "product_details.product_location",
       value: t('coronavirus_form.questions.product_details.product_location.options.option_uk.label'),
       text: t('coronavirus_form.questions.product_details.product_location.options.option_uk.label'),
       checked: @product["product_location"] == t('coronavirus_form.questions.product_details.product_location.options.option_uk.label'),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -161,6 +161,7 @@ en:
               label: Gowns
             other:
               label: Something else
+          custom_select_error: Select a type of equipment, or ‘something else’
       additional_product:
         title: Can you offer another product?
         link: |

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -71,7 +71,7 @@ en:
       missing_day: "%{field} must include a day"
       invalid_date: "Enter a real %{field}"
       date_order: "The end date must be after the start date"
-      email_format: "Enter email address in the correct format, like name@example.com"
+      email_format: "Enter an email address in the correct format, like name@example.com"
       postcode_format: "Enter a real postcode"
     questions:
       medical_equipment:


### PR DESCRIPTION
- [x] Error summary links to inputs
- [x] Error summary with multiple errors on the same field (see example below)
- [x] Error summary links to radios/checkboxes
- [x] Error summary links to conditionally revealed inputs (~~in conjunction with https://github.com/alphagov/govuk_publishing_components/pull/1402 – requires a gem bump~~ bumped and rebased)

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

![localhost_5000_contact-details (1)](https://user-images.githubusercontent.com/788096/77446290-24787080-6de6-11ea-8179-76577c70741b.png)

</td><td valign="top">

![localhost_5000_contact-details](https://user-images.githubusercontent.com/788096/77446301-280bf780-6de6-11ea-8112-0be393509f09.png)


</td></tr>
</table>


[Trello card](https://trello.com/c/ckf2yaxx)