### PR TITLE
Change Dynimoid logging level to :warn

### DIFF
--- a/config/initializers/dynamoid.rb
+++ b/config/initializers/dynamoid.rb
@@ -8,7 +8,7 @@ Dynamoid.configure do |config|
   config.access_key = ENV["AWS_ACCESS_KEY_ID"]
   config.secret_key = ENV["AWS_SECRET_ACCESS_KEY"]
   config.region = "eu-west-2"
-  config.logger.level = :error
+  config.logger.level = :warn
 
   unless Rails.env.production?
     # [Optional]. If provided, it communicates with the DB listening at the endpoint - to communication with DynamoDB local.


### PR DESCRIPTION
[Trello Card](https://trello.com/c/99xm7mlq/86-ensure-sensitive-data-doesnt-go-to-logit-splunk)

# What
[Dynimod config.logger is a rails logger by default](https://github.com/Dynamoid/Dynamoid#configuration), rails logging comes with `:debug`, `:info`, `:warn`, `:error`, `:fatal`, and `:unknown`.

We were saying `:info` was TMI, but `:error` is perhaps overly cautious.
Lets see what `:warn` gets us

# Why
Default logging behaviour with Dynimod is to log everything, so we need to calm it down it bit to keep our logs free of PII.

