### PR TITLE
Update add additional product link

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -169,7 +169,7 @@ en:
         title: Can you offer another product?
         link: |
           <p class="govuk-body">
-            <a href="/product-details" class="govuk-link">Add an additional product</a>
+            <a href="/medical-equipment-type" class="govuk-link">Add an additional product</a>
           </p>
         options:
           option_yes:


### PR DESCRIPTION
## What
Fix add product link on check your answers page to go to "Tell us about the medical equipment you can offer" page.

# Why
Medical equipment type question informs the product page.

[Trello card](https://trello.com/c/IAXffAQ4)