### PR TITLE
🚧 Change Dynimoid logging level to :info

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,7 +59,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]

--- a/config/initializers/dynamoid.rb
+++ b/config/initializers/dynamoid.rb
@@ -8,7 +8,6 @@ Dynamoid.configure do |config|
   config.access_key = ENV["AWS_ACCESS_KEY_ID"]
   config.secret_key = ENV["AWS_SECRET_ACCESS_KEY"]
   config.region = "eu-west-2"
-  config.logger.level = :error
 
   unless Rails.env.production?
     # [Optional]. If provided, it communicates with the DB listening at the endpoint - to communication with DynamoDB local.


### PR DESCRIPTION
Trello: https://trello.com/c/99xm7mlq/86-ensure-sensitive-data-doesnt-go-to-logit-splunk

**DRAFT PENDING TEST ON STAGING**
Replaced by: https://github.com/alphagov/govuk-coronavirus-business-volunteer-form/pull/168

# Test
- Get this on staging
- Noodle around
  - Normal browse behaviour
  - Cause an error
  - Submit a stand-in for PII
  - Cause validation error
- Logs should have No PII
- Logs should have validation errors
- Logs should have errors
- check the logs since deploy

# What
tweak the logging levels in production to prevent PII getting in, but ensure we still get useful logs on validation attempts

# Why
Keep cyber happy, keep debugging devs happy.