### PR TITLE
Do not redirect to "check your answers" from the medical equipment type

### DIFF
--- a/app/controllers/coronavirus_form/medical_equipment_type_controller.rb
+++ b/app/controllers/coronavirus_form/medical_equipment_type_controller.rb
@@ -26,8 +26,6 @@ class CoronavirusForm::MedicalEquipmentTypeController < ApplicationController
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       render "coronavirus_form/#{PAGE}"
-    elsif session["check_answers_seen"]
-      redirect_to controller: "coronavirus_form/check_answers", action: "show"
     else
       redirect_to(
         controller: "coronavirus_form/#{NEXT_PAGE}",

--- a/spec/controllers/coronavirus_form/medical_equipment_type_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/medical_equipment_type_controller_spec.rb
@@ -42,13 +42,6 @@ RSpec.describe CoronavirusForm::MedicalEquipmentTypeController, type: :controlle
       )
     end
 
-    it "redirects to check your answers if check your answers already seen" do
-      session[:check_answers_seen] = true
-      post :submit, params: { medical_equipment_type: selected }
-
-      expect(response).to redirect_to(check_your_answers_path)
-    end
-
     it "validates any option is chosen" do
       post :submit, params: { medical_equipment_type: nil }
 


### PR DESCRIPTION
The product questions are split over two pages, so the user should always be sent to the second part, rather than back to the "check your answers" screen.