### PR TITLE
Custom radio validation for equipment_type

### DIFF
--- a/app/controllers/coronavirus_form/product_details_controller.rb
+++ b/app/controllers/coronavirus_form/product_details_controller.rb
@@ -47,9 +47,10 @@ private
 
   def validate_fields(product)
     missing_fields = validate_missing_fields(product)
+    product_equipment_type = selected_ppe? ? validate_radio_field("#{PAGE}.equipment_type", radio: product["equipment_type"]) : []
     product_location_validation = validate_radio_field("#{PAGE}.product_location", radio: product["product_location"])
     postcode_validation = validate_product_postcode(product)
-    missing_fields + product_location_validation + postcode_validation
+    missing_fields + product_equipment_type + product_location_validation + postcode_validation
   end
 
   def validate_product_postcode(product)
@@ -68,7 +69,6 @@ private
   def validate_missing_fields(product)
     required = []
     required.concat REQUIRED_FIELDS
-    required << "equipment_type" if selected_ppe?
     required.each_with_object([]) do |field, invalid_fields|
       next if product[field].present?
 

--- a/app/views/coronavirus_form/product_details.html.erb
+++ b/app/views/coronavirus_form/product_details.html.erb
@@ -40,7 +40,7 @@
     error_message: error_items('equipment_type'),
     items: t('coronavirus_form.questions.product_details.equipment_type.options').map.with_index do |(_, item), index|
       {
-        id: ("equipment_type" if index == 0),
+        id: ("product_details.equipment_type" if index == 0),
         value: item[:label],
         text: item[:label],
         checked: @product["equipment_type"] == item[:label],


### PR DESCRIPTION
Use custom error message via `validate_radio_field ` for `equipment_type` field.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

![localhost_5000_product-details (1)](https://user-images.githubusercontent.com/788096/77535875-48de5680-6e93-11ea-91fa-a26ae60b67c9.png)


</td><td valign="top">

![localhost_5000_product-details](https://user-images.githubusercontent.com/788096/77535880-4aa81a00-6e93-11ea-9ceb-fc6e60e6d233.png)

[Trello card](https://trello.com/c/ckf2yaxx)

</td></tr>
</table>
