### PR TITLE
Update check your answers page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,6 @@ group :development do
 end
 
 group :test do
-  gem "scss-lint", "~> 0.7.0", require: false
   gem "simplecov", "~> 0.16"
   gem "therubyracer", "~> 0.12"
 end
@@ -34,4 +33,5 @@ group :development, :test do
   gem "rails-controller-testing", "~> 1.0"
   gem "rspec-rails", "~> 4.0.0"
   gem "rubocop-govuk"
+  gem "scss_lint-govuk", "~> 0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,6 @@ GEM
     builder (3.2.4)
     byebug (11.1.1)
     coderay (1.1.2)
-    colorize (0.8.1)
     concurrent-ruby (1.1.6)
     crass (1.0.6)
     diff-lcs (1.3)
@@ -280,9 +279,10 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    scss-lint (0.7.0)
-      colorize
-      sass
+    scss_lint (0.59.0)
+      sass (~> 3.5, >= 3.5.5)
+    scss_lint-govuk (0.2.0)
+      scss_lint
     sentry-raven (3.0.0)
       faraday (>= 1.0)
     simplecov (0.18.5)
@@ -340,7 +340,7 @@ DEPENDENCIES
   rspec-rails (~> 4.0.0)
   rubocop-govuk
   sass-rails (< 6)
-  scss-lint (~> 0.7.0)
+  scss_lint-govuk (~> 0)
   sentry-raven (~> 3.0)
   simplecov (~> 0.16)
   therubyracer (~> 0.12)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,1 +1,7 @@
 @import 'govuk_publishing_components/all_components';
+
+.app-body--right {
+  @include govuk-media-query($from: tablet) {
+    text-align: right;
+  }
+}

--- a/app/controllers/coronavirus_form/check_answers_controller.rb
+++ b/app/controllers/coronavirus_form/check_answers_controller.rb
@@ -27,7 +27,7 @@ class CoronavirusForm::CheckAnswersController < ApplicationController
 
 private
 
-  helper_method :items
+  helper_method :items_part_1, :items_part_2
 
   def reference_number
     timestamp = Time.zone.now.strftime("%Y%m%d-%H%M%S")
@@ -46,10 +46,6 @@ private
         # work to make them readable.
 
         next if question.eql?("medical_equipment_type")
-
-        if question.eql?("additional_product")
-          next add_extra_product(question)
-        end
 
         if question.eql?("product_details")
           next product_details(session[question])
@@ -75,10 +71,12 @@ private
     end
   end
 
-  def add_extra_product(question)
-    {
-      field: sanitize(t("coronavirus_form.questions.#{question}.link")),
-    }
+  def items_part_1
+    items.select.with_index { |_, index| index < questions.index("additional_product") }
+  end
+
+  def items_part_2
+    items.select.with_index { |_, index| index > questions.index("additional_product") }
   end
 
   def product_details(products)

--- a/app/views/coronavirus_form/check_answers.html.erb
+++ b/app/views/coronavirus_form/check_answers.html.erb
@@ -12,7 +12,19 @@
 } %>
 
 <%= render "govuk_publishing_components/components/summary_list", {
-  items: items,
+  items: items_part_1,
+  block: sanitize(
+          tag.p(
+            link_to("Add an additional product",
+                    "/medical-equipment-type",
+                    class: "govuk-link"
+            ),
+          class: "govuk-body app-body--right")
+         )
+} %>
+
+<%= render "govuk_publishing_components/components/summary_list", {
+  items: items_part_2,
 } %>
 
 <%= render "govuk_publishing_components/components/heading", {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -167,10 +167,6 @@ en:
           custom_select_error: Select a type of equipment, or ‘something else’
       additional_product:
         title: Can you offer another product?
-        link: |
-          <p class="govuk-body">
-            <a href="/medical-equipment-type" class="govuk-link">Add an additional product</a>
-          </p>
         options:
           option_yes:
             label: "Yes"


### PR DESCRIPTION
Split items into two groups to place the "Add an additional product" link between them (as per agreed design). Open to suggestions regarding the approach.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

![cya-desktop-before](https://user-images.githubusercontent.com/788096/77554933-9b793c00-6eae-11ea-86af-0f5a213fc769.png)


</td><td valign="top">

![cya-desktop-after](https://user-images.githubusercontent.com/788096/77554952-a03df000-6eae-11ea-8d25-98326ec883ac.png)


</td></tr>
</table>

[Trello card](https://trello.com/c/IAXffAQ4)