### PR TITLE
Add rake task for exporting data in JSON format

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,11 @@ which is configured in [concourse/pipeline.yml](concourse/pipeline.yml).
 
 The concourse pipeline has credentials for the `govuk-forms-deployer` user in
 GOV.UK PaaS. This user has the SpaceDeveloper role, so it can `cf push` the application.
+
+## Exporting data
+
+Data can be exported in JSON format for a single data using a Rake task:
+
+```
+rake export:form_responses["2020-03-26"]
+```

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -1,0 +1,7 @@
+namespace :export do
+  desc "Exports all form responses for a specific date in JSON format"
+  task :form_responses, [:date] => [:environment] do |_, args|
+    responses = FormResponse.where(created_at: Date.parse(args.date).all_day)
+    puts responses.to_json
+  end
+end


### PR DESCRIPTION
This is an incredibly MVP method of getting the submitted data, in order to send to the Cabinet Office.  We can work on a more elegant solution, if needed.