### PR TITLE
Fix additional product index

### DIFF
--- a/app/controllers/coronavirus_form/check_answers_controller.rb
+++ b/app/controllers/coronavirus_form/check_answers_controller.rb
@@ -66,12 +66,16 @@ private
     end
   end
 
+  def additional_product_index
+    items.index { |item| item[:field] === t("coronavirus_form.questions.additional_product.title") }
+  end
+
   def items_part_1
-    items.select.with_index { |_, index| index < questions.index("additional_product") }
+    items.select.with_index { |_, index| index < additional_product_index }
   end
 
   def items_part_2
-    items.select.with_index { |_, index| index > questions.index("additional_product") }
+    items.select.with_index { |_, index| index > additional_product_index }
   end
 
   def product_details(products)


### PR DESCRIPTION
Make sure the "Add additional product button" is correctly placed and the summary list is plit at the right point (after products).

Questions index is not the same with items index (as the journey is not linear and people can add multiple products).

Example below with no products:

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

<img width="713" alt="Screenshot 2020-03-26 at 16 59 02" src="https://user-images.githubusercontent.com/788096/77674323-4bb87480-6f83-11ea-8a62-9558aa78f520.png">


</td><td valign="top">

<img width="705" alt="Screenshot 2020-03-26 at 16 58 34" src="https://user-images.githubusercontent.com/788096/77674328-4eb36500-6f83-11ea-822c-f28e64594c59.png">


</td></tr>
</table>
