### PR TITLE
Use en dashes not hyphens to separate clauses

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -181,9 +181,9 @@ en:
         title: Can you offer hotel rooms?
         options:
           yes_staying_in:
-            label: "Yes - for people to stay in"
+            label: "Yes – for people to stay in"
           yes_all_uses:
-            label: "Yes - for any use"
+            label: "Yes – for any use"
           no_option:
             label: "No"
         custom_select_error: Select if you can offer hotel rooms


### PR DESCRIPTION
Hyphens are used to join words together, for example load-bearing or dog-friendly.

To separate clauses – in a similar way to how you’d use a comma – a dash should be used instead.

Typically American usage is an em dash—a character the width of an uppercase M—with no spaces, while British usage is an en dash – a character the width of an uppercase N.