### PR TITLE
Fix error message not showing on medical equipment type

### DIFF
--- a/app/views/coronavirus_form/medical_equipment_type.html.erb
+++ b/app/views/coronavirus_form/medical_equipment_type.html.erb
@@ -18,7 +18,7 @@
   hint: t('coronavirus_form.questions.medical_equipment_type.hint'),
   is_page_heading: true,
   name: "medical_equipment_type",
-  error: error_items('medical_equipment_type'),
+  error_message: error_items('medical_equipment_type'),
   items: [
     {
       value: t('coronavirus_form.questions.medical_equipment_type.options.number_ppe.label'),


### PR DESCRIPTION
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

![localhost_5000_medical-equipment-type (1)](https://user-images.githubusercontent.com/788096/77781769-0614ae00-704e-11ea-9871-2ce75616b4f8.png)


</td><td valign="top">

![localhost_5000_medical-equipment-type](https://user-images.githubusercontent.com/788096/77781774-090f9e80-704e-11ea-93cc-6f4660b76e9c.png)


</td></tr>
</table>
