### PR TITLE
Use fragment caching for views

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,8 +17,13 @@ class ApplicationController < ActionController::Base
 private
 
   helper_method :previous_path
+  helper_method :publishing_components_version
 
   def previous_path
     raise NotImplementedError, "Define a previous path"
+  end
+
+  def publishing_components_version
+    Gem.loaded_specs["govuk_publishing_components"].version.version
   end
 end

--- a/app/controllers/coronavirus_form/additional_product_controller.rb
+++ b/app/controllers/coronavirus_form/additional_product_controller.rb
@@ -18,7 +18,7 @@ class CoronavirusForm::AdditionalProductController < ApplicationController
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       render "coronavirus_form/#{PAGE}"
-    elsif additional_product == I18n.t("coronavirus_form.questions.additional_product.options.option_yes.label")
+    elsif additional_product == YES
       redirect_to controller: "coronavirus_form/medical_equipment_type", action: "show"
     elsif session["check_answers_seen"]
       redirect_to controller: "coronavirus_form/check_answers", action: "show"
@@ -30,6 +30,7 @@ class CoronavirusForm::AdditionalProductController < ApplicationController
 private
 
   PAGE = "additional_product"
+  YES = I18n.t("coronavirus_form.questions.additional_product.options.option_yes.label")
 
   def previous_path
     session["product_details"] ||= []

--- a/app/controllers/coronavirus_form/expert_advice_type_controller.rb
+++ b/app/controllers/coronavirus_form/expert_advice_type_controller.rb
@@ -22,7 +22,7 @@ class CoronavirusForm::ExpertAdviceTypeController < ApplicationController
       validate_checkbox_field(
         PAGE,
         values: expert_advice_type,
-        allowed_values: I18n.t("coronavirus_form.questions.#{PAGE}.options").map { |_, item| item.dig(:label) },
+        allowed_values: ALLOWED_VALUES,
         other: expert_advice_type_other,
       )
 
@@ -38,11 +38,11 @@ private
 
   PAGE = "expert_advice_type"
   NEXT_PAGE = "offer_care"
+  ALLOWED_VALUES = I18n.t("coronavirus_form.questions.#{PAGE}.options").map { |_, item| item.dig(:label) }
+  OTHER = I18n.t("coronavirus_form.questions.#{PAGE}.options.other.label")
 
   def selected_other?(expert_advice_type)
-    expert_advice_type.include?(
-      I18n.t("coronavirus_form.questions.#{PAGE}.options.other.label"),
-    )
+    expert_advice_type.include?(OTHER)
   end
 
   def previous_path

--- a/app/controllers/coronavirus_form/location_controller.rb
+++ b/app/controllers/coronavirus_form/location_controller.rb
@@ -16,7 +16,7 @@ class CoronavirusForm::LocationController < ApplicationController
     invalid_fields = validate_checkbox_field(
       PAGE,
       values: location,
-      allowed_values: I18n.t("coronavirus_form.questions.#{PAGE}.options").map { |_, item| item.dig(:label) },
+      allowed_values: ALLOWED_VALUES,
     )
 
     if invalid_fields.any?
@@ -32,6 +32,7 @@ class CoronavirusForm::LocationController < ApplicationController
 private
 
   PAGE = "location"
+  ALLOWED_VALUES = I18n.t("coronavirus_form.questions.#{PAGE}.options").map { |_, item| item.dig(:label) }
 
   def previous_path
     offer_other_support_path

--- a/app/controllers/coronavirus_form/medical_equipment_type_controller.rb
+++ b/app/controllers/coronavirus_form/medical_equipment_type_controller.rb
@@ -39,9 +39,10 @@ private
 
   PAGE = "medical_equipment_type"
   NEXT_PAGE = "product_details"
+  OTHER = I18n.t("coronavirus_form.questions.#{PAGE}.options.other.label")
 
   def selected_other?(medical_equipment_type)
-    medical_equipment_type == I18n.t("coronavirus_form.questions.#{PAGE}.options.other.label")
+    medical_equipment_type == OTHER
   end
 
   def previous_path

--- a/app/controllers/coronavirus_form/offer_care_qualifications_controller.rb
+++ b/app/controllers/coronavirus_form/offer_care_qualifications_controller.rb
@@ -3,8 +3,6 @@
 class CoronavirusForm::OfferCareQualificationsController < ApplicationController
   before_action :check_first_question_answered, only: :show
 
-  TEXT_FIELDS = %w(offer_care_qualifications_type).freeze
-
   def show
     session[:offer_care_qualifications] ||= []
     render "coronavirus_form/#{PAGE}"
@@ -21,7 +19,7 @@ class CoronavirusForm::OfferCareQualificationsController < ApplicationController
       validate_checkbox_field(
         PAGE,
         values: offer_care_qualifications,
-        allowed_values: I18n.t("coronavirus_form.questions.#{PAGE}.options").map { |_, item| item.dig(:label) },
+        allowed_values: ALLOWED_VALUES,
         other: offer_care_qualifications_type,
         other_field: "nursing_or_healthcare_qualification",
       )
@@ -40,6 +38,8 @@ private
 
   PAGE = "offer_care_qualifications"
   NEXT_PAGE = "offer_other_support"
+  TEXT_FIELDS = %w(offer_care_qualifications_type).freeze
+  ALLOWED_VALUES = I18n.t("coronavirus_form.questions.#{PAGE}.options").map { |_, item| item.dig(:label) }
 
   def previous_path
     offer_care_path

--- a/app/controllers/coronavirus_form/offer_space_type_controller.rb
+++ b/app/controllers/coronavirus_form/offer_space_type_controller.rb
@@ -24,7 +24,7 @@ class CoronavirusForm::OfferSpaceTypeController < ApplicationController
       validate_checkbox_field(
         PAGE,
         values: offer_space_type,
-        allowed_values: I18n.t("coronavirus_form.questions.#{PAGE}.options").map { |_, item| item.dig(:label) },
+        allowed_values: ALLOWED_VALUES,
         other: offer_space_type_other,
       )
 
@@ -42,11 +42,11 @@ private
 
   PAGE = "offer_space_type"
   NEXT_PAGE = "expert_advice_type"
+  ALLOWED_VALUES = I18n.t("coronavirus_form.questions.#{PAGE}.options").map { |_, item| item.dig(:label) }
+  OTHER = I18n.t("coronavirus_form.questions.#{PAGE}.options.other.label")
 
   def selected_other?(offer_space_type)
-    offer_space_type.include?(
-      I18n.t("coronavirus_form.questions.#{PAGE}.options.other.label"),
-    )
+    offer_space_type.include?(OTHER)
   end
 
   def previous_path

--- a/app/controllers/coronavirus_form/offer_transport_controller.rb
+++ b/app/controllers/coronavirus_form/offer_transport_controller.rb
@@ -19,11 +19,11 @@ class CoronavirusForm::OfferTransportController < ApplicationController
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       render "coronavirus_form/#{PAGE}"
-    elsif session[:offer_transport] == I18n.t("coronavirus_form.questions.#{PAGE}.options.option_yes.label")
+    elsif session[:offer_transport] == YES
       redirect_to controller: "coronavirus_form/transport_type", action: "show"
     elsif session["check_answers_seen"]
       redirect_to controller: "coronavirus_form/check_answers", action: "show"
-    elsif session[:offer_transport] == I18n.t("coronavirus_form.questions.#{PAGE}.options.option_no.label")
+    elsif session[:offer_transport] == NO
       redirect_to controller: "coronavirus_form/offer_space", action: "show"
     end
   end
@@ -31,6 +31,8 @@ class CoronavirusForm::OfferTransportController < ApplicationController
 private
 
   PAGE = "offer_transport"
+  YES = I18n.t("coronavirus_form.questions.#{PAGE}.options.option_yes.label")
+  NO = I18n.t("coronavirus_form.questions.#{PAGE}.options.option_no.label")
 
   def previous_path
     hotel_rooms_path

--- a/app/controllers/coronavirus_form/product_details_controller.rb
+++ b/app/controllers/coronavirus_form/product_details_controller.rb
@@ -35,19 +35,17 @@ private
 
   NEXT_PAGE = "additional_product"
   PAGE = "product_details"
+  PPE = I18n.t("coronavirus_form.questions.medical_equipment_type.options.number_ppe.label")
+  UK = I18n.t("coronavirus_form.questions.product_details.product_location.options.option_uk.label")
 
   helper_method :selected_ppe?
 
   def selected_ppe?
-    @product["medical_equipment_type"] == I18n.t(
-      "coronavirus_form.questions.medical_equipment_type.options.number_ppe.label",
-    )
+    @product["medical_equipment_type"] == PPE
   end
 
   def selected_made_in_uk?
-    @product["product_location"] == I18n.t(
-      "coronavirus_form.questions.product_details.product_location.options.option_uk.label",
-    )
+    @product["product_location"] == UK
   end
 
   def validate_fields(product)

--- a/app/controllers/coronavirus_form/transport_type_controller.rb
+++ b/app/controllers/coronavirus_form/transport_type_controller.rb
@@ -20,8 +20,8 @@ class CoronavirusForm::TransportTypeController < ApplicationController
     invalid_fields = validate_checkbox_field(
       PAGE,
       values: transport_type,
-      allowed_values: I18n.t("coronavirus_form.questions.#{PAGE}.options").map { |_, item| item.dig(:label) },
-                      ) +
+      allowed_values: ALLOWED_VALUES,
+    ) +
       validate_mandatory_text_fields(PAGE, REQUIRED_FIELDS) +
       validate_field_response_length(PAGE, TEXT_FIELDS)
 
@@ -38,6 +38,7 @@ class CoronavirusForm::TransportTypeController < ApplicationController
 private
 
   PAGE = "transport_type"
+  ALLOWED_VALUES = I18n.t("coronavirus_form.questions.#{PAGE}.options").map { |_, item| item.dig(:label) }
 
   def previous_path
     offer_transport_path

--- a/app/views/coronavirus_form/check_answers.html.erb
+++ b/app/views/coronavirus_form/check_answers.html.erb
@@ -6,10 +6,12 @@
   <%= render "govuk_publishing_components/components/back_link", { href: previous_path } %>
 <% end %>
 
-<%= render "govuk_publishing_components/components/title", {
-  title: t('check_your_answers.title'),
-  margin_top: 0
-} %>
+<% cache [publishing_components_version, "title-v1", t('check_your_answers.title')] do %>
+  <%= render "govuk_publishing_components/components/title", {
+    title: t('check_your_answers.title'),
+    margin_top: 0
+  } %>
+<% end %>
 
 <%= render "govuk_publishing_components/components/summary_list", {
   items: items_part_1,
@@ -27,15 +29,19 @@
   items: items_part_2,
 } %>
 
-<%= render "govuk_publishing_components/components/heading", {
-  text: t('check_your_answers.heading'),
-  heading_level: 2,
-  margin_bottom: 2,
-} %>
+<% cache [publishing_components_version, "heading-v1", t('check_your_answers.heading')] do %>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: t('check_your_answers.heading'),
+    heading_level: 2,
+    margin_bottom: 2,
+  } %>
+<% end %>
 
-<p class="govuk-body">
-  <%= t('check_your_answers.confirmation') %>
-</p>
+<% cache [publishing_components_version, "confirm-v1", t('check_your_answers.confirmation')] do %>
+  <p class="govuk-body">
+    <%= t('check_your_answers.confirmation') %>
+  </p>
+<% end %>
 
 <%= form_tag({},
   "data-module": "track-coronavirus-form-business-check-your-answers",

--- a/app/views/coronavirus_form/medical_equipment.html.erb
+++ b/app/views/coronavirus_form/medical_equipment.html.erb
@@ -13,18 +13,20 @@
   "id": "medical_equipment",
   "novalidate": "true"
 ) do %>
-<%= render "govuk_publishing_components/components/radio", {
-  heading: t('coronavirus_form.questions.medical_equipment.title'),
-  is_page_heading: true,
-  name: "medical_equipment",
-  error_message: error_items('medical_equipment'),
-  items: t('coronavirus_form.questions.medical_equipment.options').map do |_, item|
-    {
-      value: item[:label],
-      text: item[:label],
-      checked: session[:medical_equipment] == item[:label],
-    }
-  end
-} %>
+<% cache [publishing_components_version, "medical-equipment-v1", session[:medical_equipment]] do %>
+  <%= render "govuk_publishing_components/components/radio", {
+    heading: t('coronavirus_form.questions.medical_equipment.title'),
+    is_page_heading: true,
+    name: "medical_equipment",
+    error_message: error_items('medical_equipment'),
+    items: t('coronavirus_form.questions.medical_equipment.options').map do |_, item|
+      {
+        value: item[:label],
+        text: item[:label],
+        checked: session[:medical_equipment] == item[:label],
+      }
+    end
+  } %>
+<% end %>
 <%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
 <% end %>

--- a/app/views/coronavirus_form/product_details.html.erb
+++ b/app/views/coronavirus_form/product_details.html.erb
@@ -17,6 +17,7 @@
   "id": "product_details",
   "novalidate": "true"
 ) do %>
+<% cache [publishing_components_version, "product-v1", @product] do %>
 <%= tag.input type: "hidden", name: "product_id", value: @product["product_id"] %>
 <%= render "govuk_publishing_components/components/input", {
   label: {
@@ -132,4 +133,5 @@
   width: 10,
 } %>
 <%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
+<% end %>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,9 @@
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>
     <%= render "govuk_publishing_components/components/skip_link" %>
-    <%= render "govuk_publishing_components/components/layout_header", { environment: "public" } %>
+    <% cache [publishing_components_version, "header-v1"] do %>
+      <%= render "govuk_publishing_components/components/layout_header", { environment: "public" } %>
+    <% end %>
     <div class="govuk-width-container">
       <%= yield(:back_link) %>
       <main class="govuk-main-wrapper<%= " govuk-main-wrapper--l" if yield(:back_link).blank?%>" id="main-content" role="main">
@@ -29,16 +31,18 @@
         </div>
       </main>
     </div>
-    <%= render "govuk_publishing_components/components/layout_footer", {
-      meta: {
-        items: [
-          {
-            href: "/privacy",
-            text: t("privacy_notice_footer_link.label")
-          },
-        ]
-      }
-    } %>
+    <% cache [publishing_components_version, "footer-v1", t("privacy_notice_footer_link.label")] do %>
+      <%= render "govuk_publishing_components/components/layout_footer", {
+        meta: {
+          items: [
+            {
+              href: "/privacy",
+              text: t("privacy_notice_footer_link.label")
+            },
+          ]
+        }
+      } %>
+    <% end %>
     <%= javascript_include_tag "application" %>
   </body>
 </html>


### PR DESCRIPTION
This is an attempt to improve on an already quite fast response time; feel free to close if this is unnecessary / confusing, since I'm not sure if we'll see big gains from this at our current scale.

Since we can't cache pages based on the URL (due to sessions), we can instead make use of [Rails 'fragment' caching](https://guides.rubyonrails.org/caching_with_rails.html#fragment-caching).

We can cache 'fragments' of the views. If two users view the same thing, e.g. a page without any user input, we can serve a fragment from the cache.