### PR TITLE
Enable users to remove products

### DIFF
--- a/app/controllers/coronavirus_form/check_answers_controller.rb
+++ b/app/controllers/coronavirus_form/check_answers_controller.rb
@@ -105,6 +105,9 @@ private
         edit: {
           href: "/product-details?product_id=#{product['product_id']}",
         },
+        delete: {
+          href: "/product-details/#{product['product_id']}/delete",
+        },
       }
     end
   end

--- a/app/controllers/coronavirus_form/product_details_controller.rb
+++ b/app/controllers/coronavirus_form/product_details_controller.rb
@@ -26,6 +26,11 @@ class CoronavirusForm::ProductDetailsController < ApplicationController
     end
   end
 
+  def destroy
+    remove_product_from_session(params[:id])
+    redirect_to check_your_answers_path, action: "show"
+  end
+
 private
 
   NEXT_PAGE = "additional_product"

--- a/app/helpers/product_helper.rb
+++ b/app/helpers/product_helper.rb
@@ -14,4 +14,11 @@ module ProductHelper
   def current_product(product_id, products)
     find_product(product_id, products)
   end
+
+  def remove_product_from_session(product_id)
+    session[:product_details] ||= []
+    session[:product_details] = session[:product_details].reject do |prod|
+      prod["product_id"] == product_id
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
   post "/are-you-a-manufacturer" => "coronavirus_form/are_you_a_manufacturer#submit"
 
   get "/product-details" => "coronavirus_form/product_details#show"
+  get "/product-details/:id/delete" => "coronavirus_form/product_details#destroy"
   post "/product-details" => "coronavirus_form/product_details#submit"
 
   get "/additional-product" => "coronavirus_form/additional_product#show"

--- a/spec/controllers/coronavirus_form/product_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/product_details_controller_spec.rb
@@ -74,6 +74,27 @@ RSpec.describe CoronavirusForm::ProductDetailsController, type: :controller do
     end
   end
 
+  describe "GET destroy" do
+    let(:product_1) do
+      params.merge("product_id" => product_id)
+    end
+    let(:product_2) do
+      params.merge("product_id" => SecureRandom.uuid)
+    end
+    before :each do
+      session[session_key] = [product_1, product_2]
+    end
+    it "deletes a product" do
+      get :destroy, params: { id: product_id }
+      expect(session[session_key]).to contain_exactly(product_2)
+    end
+
+    it "redirects to the check answers page" do
+      get :destroy, params: { id: product_id }
+      expect(response).to redirect_to(check_your_answers_path)
+    end
+  end
+
   describe "POST submit" do
     before :each do
       session[session_key] = [{


### PR DESCRIPTION
On the check your answers page users will be able to remove the products that they previously added.

<img width="681" alt="Screenshot 2020-03-30 at 10 35 48" src="https://user-images.githubusercontent.com/8124374/77899127-2d4cc480-7274-11ea-9834-64094bed7a82.png">


https://trello.com/c/bRb6bBS7/161-add-option-to-remove-product-to-check-your-answers-screen