### PR TITLE
Schedule export of form responses daily

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -11,6 +11,14 @@ resource_types:
       repository: rbakergds/travis-resource
       tag: latest
 
+  - name: every-day-after-midnight
+    type: time
+    icon: clock-outline
+    source:
+      start: 00:00
+      stop: 01:00
+      location: Europe/London
+
 resources:
   - name: govuk-coronavirus-business-volunteer-form
     type: git
@@ -87,3 +95,13 @@ jobs:
         params:
           URL: 'https://govuk-coronavirus-business-volunteer-form-prod.cloudapps.digital/'
           MESSAGE: "Checks that the application deployed to staging is not serving HTTP error codes"
+
+  - name: export-form-responses-daily
+    plan:
+      - get: every-day-after-midnight
+        trigger: true
+      - task: export-form-responses
+        file: govuk-coronavirus-business-volunteer-form/concourse/tasks/export-form-responses.yml
+        params:
+          CF_SPACE: production
+          SENTRY_DSN: https://((sentry-dsn))

--- a/concourse/tasks/export-form-responses.yml
+++ b/concourse/tasks/export-form-responses.yml
@@ -1,0 +1,25 @@
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: governmentpaas/cf-cli
+    tag: latest
+params:
+  CF_API: https://api.cloud.service.gov.uk
+  CF_USERNAME: ((paas-username))
+  CF_PASSWORD: ((paas-password))
+  CF_ORG: govuk_development
+  SENTRY_DSN: https://((sentry-dsn))
+  CF_SPACE:
+run:
+  dir: src
+  path: sh
+  args:
+    - '-c'
+    - |
+      set -eu
+
+      cf api "$CF_API"
+      cf auth
+      cf t -o "$CF_ORG" -s "$CF_SPACE"
+      cf run-task govuk-coronavirus-business-volunteer-form "rake export:form_responses_s3"

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -3,12 +3,16 @@ require "aws-sdk-s3"
 namespace :export do
   desc "Exports all form responses for a specific date in JSON format"
   task :form_responses, [:date] => [:environment] do |_, args|
+    args.with_defaults(date: Date.yesterday)
+
     responses = FormResponse.where(created_at: Date.parse(args.date).all_day)
     puts responses.to_json
   end
 
   desc "Uploads all form responses for a specific date (e.g. \"2015-03-24\") in JSON format to a S3 bucket"
   task :form_responses_s3, [:date] => [:environment] do |_, args|
+    args.with_defaults(date: Date.yesterday)
+
     responses = FormResponse.where(created_at: Date.parse(args.date).all_day)
 
     credentials = JSON.parse(ENV["VCAP_SERVICES"]).to_h.dig("aws-s3-bucket", 0, "credentials")


### PR DESCRIPTION
Adds a scheduled Concourse task to export the previous day's form responses to the configured S3 bucket on a daily basis, between midnight and 1am.

Trello card: https://trello.com/c/D4mG8WWb