### PR TITLE
Store medical equipment type in session only when valid

### DIFF
--- a/app/controllers/coronavirus_form/medical_equipment_type_controller.rb
+++ b/app/controllers/coronavirus_form/medical_equipment_type_controller.rb
@@ -14,7 +14,6 @@ class CoronavirusForm::MedicalEquipmentTypeController < ApplicationController
   def submit
     session[:product_details] ||= []
     @product = sanitized_product(params)
-    add_product_to_session(@product)
 
     invalid_fields = validate_field_response_length(PAGE, TEXT_FIELDS) +
       validate_radio_field(
@@ -27,6 +26,7 @@ class CoronavirusForm::MedicalEquipmentTypeController < ApplicationController
       flash.now[:validation] = invalid_fields
       render "coronavirus_form/#{PAGE}"
     else
+      add_product_to_session(@product)
       redirect_to(
         controller: "coronavirus_form/#{NEXT_PAGE}",
         action: "show",

--- a/spec/controllers/coronavirus_form/medical_equipment_type_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/medical_equipment_type_controller_spec.rb
@@ -48,6 +48,11 @@ RSpec.describe CoronavirusForm::MedicalEquipmentTypeController, type: :controlle
       expect(response).to render_template(current_template)
     end
 
+    it "doesn't store my response if it is invalid" do
+      post :submit, params: { medical_equipment_type: nil }
+      expect(session[session_key]).to eq []
+    end
+
     context "when Other option is selected" do
       it "validates the Other option description is provided" do
         post :submit, params: { medical_equipment_type: "Other" }


### PR DESCRIPTION
This prevents one from storing an invalid value for this field in the session.

https://trello.com/c/zIOCiJLn/143