### PR TITLE
Allow users to change their mind about adding an additional product

### DIFF
--- a/app/controllers/coronavirus_form/medical_equipment_type_controller.rb
+++ b/app/controllers/coronavirus_form/medical_equipment_type_controller.rb
@@ -45,7 +45,7 @@ private
   end
 
   def previous_path
-    are_you_a_manufacturer_path
+    session[:product_details].empty? ? are_you_a_manufacturer_path : additional_product_path
   end
 
   def sanitized_product(params)


### PR DESCRIPTION
Changes path for the previous link on the "tell us about the medical equipment you can offer" question to point to the correct previous question, based on whether the user is adding their first product or subsequent products.

Trello card: https://trello.com/c/DexZBieC