### PR TITLE
Adjust summary list layout

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,0 +1,1 @@
+plugin_gems: ['scss_lint-govuk']

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,3 +5,15 @@
     text-align: right;
   }
 }
+
+.govuk-summary-list__value {
+  @include govuk-media-query($from: tablet) {
+    width: 45%;
+  }
+}
+
+.govuk-summary-list__actions {
+  @include govuk-media-query($from: tablet) {
+    width: 25%;
+  }
+}


### PR DESCRIPTION
Shift 5% width from `govuk-summary-list__value` to `govuk-summary-list__actions` to have both actions (Change, Delete) on the same line when the summary list component is rendered in a 2/3 container.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

![localhost_5000_check-your-answers (1)](https://user-images.githubusercontent.com/788096/77906362-bcaba500-727f-11ea-888f-a7f2985b9794.png)


</td><td valign="top">

![localhost_5000_check-your-answers](https://user-images.githubusercontent.com/788096/77906372-bf0dff00-727f-11ea-9405-9752bff333c4.png)


</td></tr>
</table>


Follow up on #147.