### PR TITLE
Use strip_tags in place of sanitize

### DIFF
--- a/app/controllers/coronavirus_form/additional_product_controller.rb
+++ b/app/controllers/coronavirus_form/additional_product_controller.rb
@@ -8,7 +8,7 @@ class CoronavirusForm::AdditionalProductController < ApplicationController
   end
 
   def submit
-    additional_product = sanitize(params[:additional_product]).presence
+    additional_product = strip_tags(params[:additional_product]).presence
 
     invalid_fields = validate_radio_field(
       PAGE,

--- a/app/controllers/coronavirus_form/are_you_a_manufacturer_controller.rb
+++ b/app/controllers/coronavirus_form/are_you_a_manufacturer_controller.rb
@@ -9,7 +9,7 @@ class CoronavirusForm::AreYouAManufacturerController < ApplicationController
   end
 
   def submit
-    are_you_a_manufacturer = Array(params[:are_you_a_manufacturer]).map { |item| sanitize(item).presence }.compact
+    are_you_a_manufacturer = Array(params[:are_you_a_manufacturer]).map { |item| strip_tags(item).presence }.compact
     session["are_you_a_manufacturer"] = are_you_a_manufacturer
 
     invalid_fields = validate_checkbox_field(

--- a/app/controllers/coronavirus_form/business_details_controller.rb
+++ b/app/controllers/coronavirus_form/business_details_controller.rb
@@ -39,10 +39,10 @@ private
 
   def sanitized_business_details(params)
     {
-      "company_name" => sanitize(params[:company_name]).presence,
-      "company_number" => sanitize(params[:company_number]).presence,
-      "company_size" => sanitize(params[:company_size]).presence,
-      "company_location" => sanitize(params[:company_location]).presence,
+      "company_name" => strip_tags(params[:company_name]).presence,
+      "company_number" => strip_tags(params[:company_number]).presence,
+      "company_size" => strip_tags(params[:company_size]).presence,
+      "company_location" => strip_tags(params[:company_location]).presence,
     }
   end
 

--- a/app/controllers/coronavirus_form/contact_details_controller.rb
+++ b/app/controllers/coronavirus_form/contact_details_controller.rb
@@ -13,10 +13,10 @@ class CoronavirusForm::ContactDetailsController < ApplicationController
 
   def submit
     session[:contact_details] ||= {}
-    session[:contact_details]["contact_name"] = sanitize(params[:contact_name]).presence
-    session[:contact_details]["role"] = sanitize(params[:role]).presence
-    session[:contact_details]["phone_number"] = sanitize(params[:phone_number]).presence
-    session[:contact_details]["email"] = sanitize(params[:email]).presence
+    session[:contact_details]["contact_name"] = strip_tags(params[:contact_name]).presence
+    session[:contact_details]["role"] = strip_tags(params[:role]).presence
+    session[:contact_details]["phone_number"] = strip_tags(params[:phone_number]).presence
+    session[:contact_details]["email"] = strip_tags(params[:email]).presence
 
     invalid_fields = validate_field_response_length(PAGE, TEXT_FIELDS) +
       validate_fields(session[:contact_details])

--- a/app/controllers/coronavirus_form/expert_advice_type_controller.rb
+++ b/app/controllers/coronavirus_form/expert_advice_type_controller.rb
@@ -9,8 +9,8 @@ class CoronavirusForm::ExpertAdviceTypeController < ApplicationController
   end
 
   def submit
-    expert_advice_type = Array(params[:expert_advice_type]).map { |item| sanitize(item).presence }.compact
-    expert_advice_type_other = sanitize(params[:expert_advice_type_other]).presence
+    expert_advice_type = Array(params[:expert_advice_type]).map { |item| strip_tags(item).presence }.compact
+    expert_advice_type_other = strip_tags(params[:expert_advice_type_other]).presence
     session[:expert_advice_type] = expert_advice_type
     session[:expert_advice_type_other] = if selected_other?(expert_advice_type)
                                            expert_advice_type_other

--- a/app/controllers/coronavirus_form/hotel_rooms_controller.rb
+++ b/app/controllers/coronavirus_form/hotel_rooms_controller.rb
@@ -8,7 +8,7 @@ class CoronavirusForm::HotelRoomsController < ApplicationController
   end
 
   def submit
-    hotel_rooms = sanitize(params[:hotel_rooms]).presence
+    hotel_rooms = strip_tags(params[:hotel_rooms]).presence
     session[:hotel_rooms] = hotel_rooms
 
     invalid_fields = validate_radio_field(

--- a/app/controllers/coronavirus_form/location_controller.rb
+++ b/app/controllers/coronavirus_form/location_controller.rb
@@ -9,7 +9,7 @@ class CoronavirusForm::LocationController < ApplicationController
   end
 
   def submit
-    location = Array(params[:location]).map { |item| sanitize(item).presence }.compact
+    location = Array(params[:location]).map { |item| strip_tags(item).presence }.compact
 
     session[:location] = location
 

--- a/app/controllers/coronavirus_form/medical_equipment_controller.rb
+++ b/app/controllers/coronavirus_form/medical_equipment_controller.rb
@@ -6,7 +6,7 @@ class CoronavirusForm::MedicalEquipmentController < ApplicationController
   end
 
   def submit
-    medical_equipment = sanitize(params[:medical_equipment]).presence
+    medical_equipment = strip_tags(params[:medical_equipment]).presence
 
     session[:medical_equipment] = medical_equipment
 

--- a/app/controllers/coronavirus_form/medical_equipment_type_controller.rb
+++ b/app/controllers/coronavirus_form/medical_equipment_type_controller.rb
@@ -50,9 +50,9 @@ private
 
   def sanitized_product(params)
     {
-      "product_id" => sanitize(params[:product_id]).presence || SecureRandom.uuid,
-      "medical_equipment_type" => sanitize(params[:medical_equipment_type]).presence,
-      "medical_equipment_type_other" => sanitize(params[:medical_equipment_type_other]).presence,
+      "product_id" => strip_tags(params[:product_id]).presence || SecureRandom.uuid,
+      "medical_equipment_type" => strip_tags(params[:medical_equipment_type]).presence,
+      "medical_equipment_type_other" => strip_tags(params[:medical_equipment_type_other]).presence,
     }
   end
 end

--- a/app/controllers/coronavirus_form/offer_care_controller.rb
+++ b/app/controllers/coronavirus_form/offer_care_controller.rb
@@ -8,7 +8,7 @@ class CoronavirusForm::OfferCareController < ApplicationController
   end
 
   def submit
-    offer_care = sanitize(params[:offer_care]).presence
+    offer_care = strip_tags(params[:offer_care]).presence
     session[:offer_care] = offer_care
 
     invalid_fields = validate_radio_field(

--- a/app/controllers/coronavirus_form/offer_care_qualifications_controller.rb
+++ b/app/controllers/coronavirus_form/offer_care_qualifications_controller.rb
@@ -11,8 +11,8 @@ class CoronavirusForm::OfferCareQualificationsController < ApplicationController
   end
 
   def submit
-    offer_care_qualifications = Array(params[:offer_care_qualifications]).map { |item| sanitize(item).presence }.compact
-    offer_care_qualifications_type = sanitize(params[:offer_care_qualifications_type]).presence
+    offer_care_qualifications = Array(params[:offer_care_qualifications]).map { |item| strip_tags(item).presence }.compact
+    offer_care_qualifications_type = strip_tags(params[:offer_care_qualifications_type]).presence
 
     session[:offer_care_qualifications] = offer_care_qualifications
     session[:offer_care_qualifications_type] = offer_care_qualifications_type

--- a/app/controllers/coronavirus_form/offer_other_support_controller.rb
+++ b/app/controllers/coronavirus_form/offer_other_support_controller.rb
@@ -10,7 +10,7 @@ class CoronavirusForm::OfferOtherSupportController < ApplicationController
   end
 
   def submit
-    offer_other_support = sanitize(params[:offer_other_support]).presence
+    offer_other_support = strip_tags(params[:offer_other_support]).presence
 
     session[:offer_other_support] = offer_other_support
 

--- a/app/controllers/coronavirus_form/offer_space_controller.rb
+++ b/app/controllers/coronavirus_form/offer_space_controller.rb
@@ -8,7 +8,7 @@ class CoronavirusForm::OfferSpaceController < ApplicationController
   end
 
   def submit
-    offer_space = sanitize(params[:offer_space]).presence
+    offer_space = strip_tags(params[:offer_space]).presence
     session[:offer_space] = offer_space
 
     invalid_fields = validate_radio_field(

--- a/app/controllers/coronavirus_form/offer_space_type_controller.rb
+++ b/app/controllers/coronavirus_form/offer_space_type_controller.rb
@@ -11,8 +11,8 @@ class CoronavirusForm::OfferSpaceTypeController < ApplicationController
   end
 
   def submit
-    offer_space_type = Array(params[:offer_space_type]).map { |item| sanitize(item).presence }.compact
-    offer_space_type_other = sanitize(params[:offer_space_type_other]).presence
+    offer_space_type = Array(params[:offer_space_type]).map { |item| strip_tags(item).presence }.compact
+    offer_space_type_other = strip_tags(params[:offer_space_type_other]).presence
     session[:offer_space_type] = offer_space_type
     session[:offer_space_type_other] = if selected_other?(offer_space_type)
                                          offer_space_type_other

--- a/app/controllers/coronavirus_form/offer_transport_controller.rb
+++ b/app/controllers/coronavirus_form/offer_transport_controller.rb
@@ -8,7 +8,7 @@ class CoronavirusForm::OfferTransportController < ApplicationController
   end
 
   def submit
-    offer_transport = sanitize(params[:offer_transport]).presence
+    offer_transport = strip_tags(params[:offer_transport]).presence
     session[:offer_transport] = offer_transport
 
     invalid_fields = validate_radio_field(

--- a/app/controllers/coronavirus_form/product_details_controller.rb
+++ b/app/controllers/coronavirus_form/product_details_controller.rb
@@ -88,16 +88,16 @@ private
 
   def sanitized_product(params)
     {
-      "product_id" => sanitize(params[:product_id]).presence || SecureRandom.uuid,
-      "equipment_type" => sanitize(params[:equipment_type]).presence,
-      "product_name" => sanitize(params[:product_name]).presence,
-      "product_quantity" => sanitize(params[:product_quantity]).presence,
-      "product_cost" => sanitize(params[:product_cost]).presence,
-      "certification_details" => sanitize(params[:certification_details]).presence,
-      "product_location" => sanitize(params[:product_location]).presence,
-      "product_postcode" => sanitize(params[:product_postcode]).presence,
-      "product_url" => sanitize(params[:product_url]).presence,
-      "lead_time" => sanitize(params[:lead_time]).presence,
+      "product_id" => strip_tags(params[:product_id]).presence || SecureRandom.uuid,
+      "equipment_type" => strip_tags(params[:equipment_type]).presence,
+      "product_name" => strip_tags(params[:product_name]).presence,
+      "product_quantity" => strip_tags(params[:product_quantity]).presence,
+      "product_cost" => strip_tags(params[:product_cost]).presence,
+      "certification_details" => strip_tags(params[:certification_details]).presence,
+      "product_location" => strip_tags(params[:product_location]).presence,
+      "product_postcode" => strip_tags(params[:product_postcode]).presence,
+      "product_url" => strip_tags(params[:product_url]).presence,
+      "lead_time" => strip_tags(params[:lead_time]).presence,
     }
   end
 

--- a/app/controllers/coronavirus_form/transport_type_controller.rb
+++ b/app/controllers/coronavirus_form/transport_type_controller.rb
@@ -9,7 +9,7 @@ class CoronavirusForm::TransportTypeController < ApplicationController
   end
 
   def submit
-    transport_type = Array(params[:transport_type]).map { |item| sanitize(item).presence }.compact
+    transport_type = Array(params[:transport_type]).map { |item| strip_tags(item).presence }.compact
 
     session[:transport_type] = transport_type
 

--- a/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
@@ -46,6 +46,18 @@ RSpec.describe CoronavirusForm::ContactDetailsController, type: :controller do
       expect(session[session_key]).to eq contact_details
     end
 
+    it "strips html characters" do
+      nasty_params = {
+        "contact_name" => "<h1 class='big'><p>John</p></h1><script></script>",
+        "role" => "<script></script>CEO",
+        "phone_number" => "<img src='x' onerror=alert(124)>0118 999 881 999 119 7253",
+        "email" => "john@example.org",
+      }
+
+      post :submit, params: nasty_params
+      expect(session[session_key]).to eq contact_details
+    end
+
     it "redirects to next step when all required fields are provided" do
       post :submit, params: params
 

--- a/spec/controllers/coronavirus_form/offer_other_support_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/offer_other_support_controller_spec.rb
@@ -31,9 +31,18 @@ RSpec.describe CoronavirusForm::OfferOtherSupportController, type: :controller d
       expect(session[session_key]).to eq text_response
     end
 
-    it "cleans sanitizers any html in the text response" do
+    it "sanitizers any html in the text response" do
       post :submit, params: { offer_other_support: evil_script_response }
       expect(session[session_key]).to eq "I offer you, my hacking script!"
+    end
+
+    it "strips html characters" do
+      params = {
+        "offer_other_support" => '<a href="https://www.example.com">Link</a>',
+      }
+
+      post :submit, params: params
+      expect(session[session_key]).to eq "Link"
     end
 
     it "takes you to the next page regardless of input" do


### PR DESCRIPTION
Using [`strip_tags`](https://api.rubyonrails.org/classes/ActionView/Helpers/SanitizeHelper.html#method-i-strip_tags) removes all HTML elements, not just those considered unsafe.

This follows on from https://github.com/alphagov/govuk-coronavirus-vulnerable-people-form/pull/187

This leaves some `sanitize` calls in place, where the values are translation values intended to be rendered as HTML. All user input now is first passed through `strip_tags`.