### PR TITLE
Allow user to indicate transport capacity

### DIFF
--- a/app/controllers/coronavirus_form/business_details_controller.rb
+++ b/app/controllers/coronavirus_form/business_details_controller.rb
@@ -31,7 +31,7 @@ private
   PAGE = "business_details"
 
   def validate_fields(business_details)
-    missing_fields = validate_mandatory_text_fields(REQUIRED_FIELDS, PAGE)
+    missing_fields = validate_mandatory_text_fields(PAGE, REQUIRED_FIELDS)
     company_size_validation = validate_radio_field("#{PAGE}.company_size", radio: business_details["company_size"])
     company_location_validation = validate_radio_field("#{PAGE}.company_location", radio: business_details["company_location"])
     missing_fields + company_size_validation + company_location_validation

--- a/app/controllers/coronavirus_form/check_answers_controller.rb
+++ b/app/controllers/coronavirus_form/check_answers_controller.rb
@@ -46,6 +46,10 @@ private
           next product_details(session[question])
         end
 
+        if question.eql?("transport_type")
+          next transport_type(question)
+        end
+
         value = case session[question]
                 when Hash
                   concat_answer(session[question], question)
@@ -110,6 +114,20 @@ private
         },
       }
     end
+  end
+
+  def transport_type(question)
+    answer = []
+    answer << session["transport_type"].flatten.to_sentence
+    answer << session["transport_description"]
+
+    [{
+      field: t("coronavirus_form.questions.#{question}.title"),
+      value: sanitize(answer.join("<br>")),
+      edit: {
+        href: "#{question.dasherize}?change-answer",
+      },
+    }]
   end
 
   def concat_answer(answer, question)

--- a/app/controllers/coronavirus_form/transport_type_controller.rb
+++ b/app/controllers/coronavirus_form/transport_type_controller.rb
@@ -3,6 +3,9 @@
 class CoronavirusForm::TransportTypeController < ApplicationController
   before_action :check_first_question_answered, only: :show
 
+  REQUIRED_FIELDS = %w(transport_description).freeze
+  TEXT_FIELDS = %w(transport_description).freeze
+
   def show
     session[:transport_type] ||= []
     render "coronavirus_form/#{PAGE}"
@@ -12,12 +15,15 @@ class CoronavirusForm::TransportTypeController < ApplicationController
     transport_type = Array(params[:transport_type]).map { |item| strip_tags(item).presence }.compact
 
     session[:transport_type] = transport_type
+    session[:transport_description] = params[:transport_description]
 
     invalid_fields = validate_checkbox_field(
       PAGE,
       values: transport_type,
       allowed_values: I18n.t("coronavirus_form.questions.#{PAGE}.options").map { |_, item| item.dig(:label) },
-    )
+                      ) +
+      validate_mandatory_text_fields(PAGE, REQUIRED_FIELDS) +
+      validate_field_response_length(PAGE, TEXT_FIELDS)
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields

--- a/app/helpers/field_validation_helper.rb
+++ b/app/helpers/field_validation_helper.rb
@@ -14,10 +14,10 @@ module FieldValidationHelper
     invalid_fields
   end
 
-  def validate_mandatory_text_fields(mandatory_fields, page)
+  def validate_mandatory_text_fields(page, mandatory_fields)
     invalid_fields = []
     mandatory_fields.each do |field|
-      next if session[page][field].present?
+      next if params[field].present?
 
       invalid_fields << { field: field.to_s,
                           text: t("coronavirus_form.questions.#{page}.#{field}.custom_error",

--- a/app/views/coronavirus_form/transport_type.html.erb
+++ b/app/views/coronavirus_form/transport_type.html.erb
@@ -13,6 +13,7 @@
   "id": "transport_type",
   "novalidate": "true"
 ) do %>
+
 <%= render "govuk_publishing_components/components/checkboxes", {
   heading: t('coronavirus_form.questions.transport_type.title'),
   hint_text: t('coronavirus_form.questions.transport_type.hint'),
@@ -27,5 +28,15 @@
     }
   end
 } %>
+
+<%= render "govuk_publishing_components/components/textarea", {
+  label: {
+    text: t("coronavirus_form.questions.transport_type.transport_description.label")
+  },
+  name: "transport_description",
+  error: error_items("transport_description"),
+  value: session[:transport_description]
+} %>
+
 <%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -196,14 +196,20 @@ en:
             label: "No"
         custom_select_error: "Select if you can offer transport or logistics"
       transport_type:
-        title: "What kind of transport can you offer?"
+        title: "What kind of services can you offer?"
         hint: "Select all that apply"
         options:
           moving_people:
             label: "Moving people"
           moving_goods:
             label: "Moving goods"
+          other:
+            label: "Other"
         custom_select_error: "Select what kind of transport can you offer"
+        transport_description:
+          label: "Give a description, for example how many vehicles you can offer"
+          custom_error: "Enter a description"
+          custom_length_error: "Description of the support you can offer must be 1000 characters or fewer"
       offer_space:
         title: "Can you offer space?"
         hint: "For example, offices or warehouses, for medical use or storage."

--- a/spec/controllers/coronavirus_form/transport_type_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/transport_type_controller_spec.rb
@@ -5,6 +5,7 @@ require "spec_helper"
 RSpec.describe CoronavirusForm::TransportTypeController, type: :controller do
   let(:current_template) { "coronavirus_form/transport_type" }
   let(:session_key) { :transport_type }
+  let(:session_key_text) { :transport_description }
 
   describe "GET show" do
     it "renders the form when first question answered" do
@@ -27,22 +28,33 @@ RSpec.describe CoronavirusForm::TransportTypeController, type: :controller do
       I18n.t("coronavirus_form.questions.transport_type.options").map { |_, item| item[:label] }
     end
     let(:selected) { [options, [options.sample]].sample }
+    let(:description) { "Something" }
 
     it "sets session variables" do
-      post :submit, params: { transport_type: selected }
+      post :submit, params: {
+        transport_type: selected,
+      transport_description: description,
+    }
 
       expect(session[session_key]).to eq selected
+      expect(session[session_key_text]).to eq description
     end
 
     it "redirects to next step" do
-      post :submit, params: { transport_type: selected }
+      post :submit, params: {
+        transport_type: selected,
+        transport_description: description,
+      }
 
       expect(response).to redirect_to(offer_space_path)
     end
 
     it "redirects to check your answers if check your answers previously seen" do
       session[:check_answers_seen] = true
-      post :submit, params: { transport_type: selected }
+      post :submit, params: {
+        transport_type: selected,
+      transport_description: description,
+}
 
       expect(response).to redirect_to("/check-your-answers")
     end
@@ -55,6 +67,16 @@ RSpec.describe CoronavirusForm::TransportTypeController, type: :controller do
 
     it "validates a valid option is chosen" do
       post :submit, params: { transport_type: ["<script></script", "invalid option", "Medical equipment"] }
+
+      expect(response).to render_template(current_template)
+    end
+
+    it "validates a description is entered" do
+      session[:check_answers_seen] = true
+      post :submit, params: {
+        transport_type: selected,
+      transport_description: "",
+}
 
       expect(response).to render_template(current_template)
     end


### PR DESCRIPTION
Trello: https://trello.com/c/A1S8pkM8/103-indicate-transport-capacity

Adds an "other" option and also a textarea to gather details of the transport that can be offered.  Check your answers page updated to display both fields alongside the same question.

Also refactors the mandatory text field validator to keep it consistent with the other validators.

![Screenshot 2020-03-30 at 15 42 35](https://user-images.githubusercontent.com/6329861/77925707-1a9ab580-729d-11ea-8da2-e3a868e66735.png)

![Screenshot 2020-03-30 at 15 44 08](https://user-images.githubusercontent.com/6329861/77925873-50d83500-729d-11ea-92d5-2c8ea9ca8db0.png)

Trello card: https://trello.com/c/A1S8pkM8