### PR TITLE
Break up 'no expertise' from the list of options

### DIFF
--- a/app/views/coronavirus_form/expert_advice_type.html.erb
+++ b/app/views/coronavirus_form/expert_advice_type.html.erb
@@ -69,12 +69,18 @@
             value: session[:expert_advice_type_other],
           })
         },
+      ]
+    } %>
+    <%= tag.p t("coronavirus_form.questions.expert_advice_type.or"), class: "govuk-body" %>
+    <%= render "govuk_publishing_components/components/checkboxes", {
+      name: "expert_advice_type[]",
+      items: [
         {
           value: t("coronavirus_form.questions.expert_advice_type.options.no_expertise.label"),
           label: t("coronavirus_form.questions.expert_advice_type.options.no_expertise.label"),
           checked: session[:expert_advice_type].include?(t("coronavirus_form.questions.expert_advice_type.options.no_expertise.label")),
         },
-      ]
-    } %>
+      ],
+    }%>
     <%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -238,6 +238,7 @@ en:
       expert_advice_type:
         title: "What kind of expertise can you offer?"
         hint: "Select the types of support you can offer"
+        or: "Or"
         options:
           medical:
             label: "Medical"


### PR DESCRIPTION
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

![localhost_5000_expert-advice-type_change-answer (1)](https://user-images.githubusercontent.com/788096/77932076-ee833280-72a4-11ea-8b02-b5810732af11.png)


</td><td valign="top">

![localhost_5000_expert-advice-type_change-answer](https://user-images.githubusercontent.com/788096/77932079-f04cf600-72a4-11ea-8aac-6e41a10bb883.png)


</td></tr>
</table>

[Trello card](https://trello.com/c/bZMgYjGk)