### PR TITLE
Optimise stylesheet and JavaScript assets

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,2 +1,2 @@
-//= require govuk_publishing_components/dependencies
-//= require govuk_publishing_components/all_components
+// = require govuk/all.js
+window.GOVUKFrontend.initAll()

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,29 @@
-@import 'govuk_publishing_components/all_components';
+// Helpers
+@import 'govuk_publishing_components/govuk_frontend_support';
+@import 'govuk_publishing_components/component_support';
 
+// Components
+@import 'govuk_publishing_components/components/back-link';
+@import 'govuk_publishing_components/components/breadcrumbs';
+@import 'govuk_publishing_components/components/button';
+@import 'govuk_publishing_components/components/checkboxes';
+@import 'govuk_publishing_components/components/error-message';
+@import 'govuk_publishing_components/components/error-summary';
+@import 'govuk_publishing_components/components/fieldset';
+@import 'govuk_publishing_components/components/heading';
+@import 'govuk_publishing_components/components/hint';
+@import 'govuk_publishing_components/components/input';
+@import 'govuk_publishing_components/components/label';
+@import 'govuk_publishing_components/components/layout-footer';
+@import 'govuk_publishing_components/components/layout-header';
+@import 'govuk_publishing_components/components/panel';
+@import 'govuk_publishing_components/components/radio';
+@import 'govuk_publishing_components/components/skip-link';
+@import 'govuk_publishing_components/components/summary-list';
+@import 'govuk_publishing_components/components/textarea';
+@import 'govuk_publishing_components/components/title';
+
+// Application
 .app-body--right {
   @include govuk-media-query($from: tablet) {
     text-align: right;


### PR DESCRIPTION
Selectively import stylesheets and only import and initialise specific script.

In the table below a comparison of sizes (uncompressed) and localhost times.
<table>
<tr><th></th><th>Size Before</th><th> Size After</th><th>Time Before</th><th> Time After</th></tr>
<tr><th align="left">application.js</th>
  <td>644 KB</td><td>80.6 KB</td>
  <td>351 ms</td><td>19 ms</td>
</tr>
<tr><th align="left">application.css</th>
  <td>825 KB</td><td>317 KB</td>
  <td>356 ms</td><td>35 ms</td>
</tr>
</table>

### Before
<img width="1440" alt="assets-before" src="https://user-images.githubusercontent.com/788096/77944543-0f548380-72b7-11ea-8c4d-d41838ddb918.png">


### After
<img width="1440" alt="assets-after" src="https://user-images.githubusercontent.com/788096/77944559-124f7400-72b7-11ea-8a6e-05ea6f51e2e9.png">

This also removes jQuery, which means an overall audit should show significant improvement – will update with a Lighthouse report in production after it gets merged.

[Trello card](https://trello.com/c/I35qjJcP)