### PR TITLE
Fix daily export of data to S3

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -98,6 +98,7 @@ jobs:
 
   - name: export-form-responses-daily
     plan:
+      - get: govuk-coronavirus-business-volunteer-form
       - get: every-day-after-midnight
         trigger: true
       - task: export-form-responses

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -3,7 +3,7 @@ require "aws-sdk-s3"
 namespace :export do
   desc "Exports all form responses for a specific date in JSON format"
   task :form_responses, [:date] => [:environment] do |_, args|
-    args.with_defaults(date: Date.yesterday)
+    args.with_defaults(date: Date.yesterday.to_s)
 
     responses = FormResponse.where(created_at: Date.parse(args.date).all_day)
     puts responses.to_json
@@ -11,7 +11,7 @@ namespace :export do
 
   desc "Uploads all form responses for a specific date (e.g. \"2015-03-24\") in JSON format to a S3 bucket"
   task :form_responses_s3, [:date] => [:environment] do |_, args|
-    args.with_defaults(date: Date.yesterday)
+    args.with_defaults(date: Date.yesterday.to_s)
 
     responses = FormResponse.where(created_at: Date.parse(args.date).all_day)
 


### PR DESCRIPTION
This was failing in two ways:
- Concourse couldn't locate the task YAML file
- The rake task default value resulted in a type mismatch

This PR fixes both of these issues.