### PR TITLE
Update care qualification question

### DIFF
--- a/app/controllers/coronavirus_form/check_answers_controller.rb
+++ b/app/controllers/coronavirus_form/check_answers_controller.rb
@@ -47,6 +47,10 @@ private
           next transport_type
         end
 
+        if question.eql?("offer_care_qualifications")
+          next offer_care_qualifications
+        end
+
         value = case session[question]
                 when Hash
                   concat_answer(session[question], question)
@@ -123,6 +127,22 @@ private
       value: sanitize(answer.join("<br>")),
       edit: {
         href: "transport-type?change-answer",
+      },
+    }]
+  end
+
+  def offer_care_qualifications
+    [{
+      field: t("coronavirus_form.questions.offer_care_qualifications.offer_care_type.title"),
+      value: sanitize(Array(session["offer_care_type"]).flatten.to_sentence),
+      edit: {
+        href: "offer-care-qualifications?change-answer",
+      },
+    }, {
+      field: t("coronavirus_form.questions.offer_care_qualifications.care_qualifications.title"),
+      value: sanitize(Array(session["offer_care_qualifications"]).flatten.to_sentence),
+      edit: {
+        href: "offer-care-qualifications?change-answer",
       },
     }]
   end

--- a/app/controllers/coronavirus_form/offer_care_qualifications_controller.rb
+++ b/app/controllers/coronavirus_form/offer_care_qualifications_controller.rb
@@ -4,17 +4,24 @@ class CoronavirusForm::OfferCareQualificationsController < ApplicationController
   TEXT_FIELDS = %w(offer_care_qualifications_type).freeze
 
   def submit
+    offer_care_type = Array(params[:offer_care_type]).map { |item| strip_tags(item).presence }.compact
     offer_care_qualifications = Array(params[:offer_care_qualifications]).map { |item| strip_tags(item).presence }.compact
     offer_care_qualifications_type = strip_tags(params[:offer_care_qualifications_type]).presence
 
+    session[:offer_care_type] = offer_care_type
     session[:offer_care_qualifications] = offer_care_qualifications
     session[:offer_care_qualifications_type] = offer_care_qualifications_type
 
-    invalid_fields = validate_field_response_length(controller_name, TEXT_FIELDS) +
+    invalid_fields = validate_field_response_length("#{controller_name}.care_qualifcations", TEXT_FIELDS) +
       validate_checkbox_field(
-        controller_name,
+        "#{controller_name}.offer_care_type",
+        values: offer_care_type,
+        allowed_values: I18n.t("coronavirus_form.questions.#{controller_name}.offer_care_type.options").map { |_, item| item.dig(:label) },
+      ) +
+      validate_checkbox_field(
+        "#{controller_name}.care_qualifications",
         values: offer_care_qualifications,
-        allowed_values: I18n.t("coronavirus_form.questions.#{controller_name}.options").map { |_, item| item.dig(:label) },
+        allowed_values: I18n.t("coronavirus_form.questions.#{controller_name}.care_qualifications.options").map { |_, item| item.dig(:label) },
         other: offer_care_qualifications_type,
         other_field: "nursing_or_healthcare_qualification",
       )

--- a/app/views/coronavirus_form/offer_care_qualifications.erb
+++ b/app/views/coronavirus_form/offer_care_qualifications.erb
@@ -54,7 +54,13 @@
           error_message: error_items("offer_care_qualifications_type"),
           value: session[:offer_care_qualifications_type],
         })
-      },
+      }
+    ]
+  } %>
+  <%= tag.p t("coronavirus_form.questions.offer_care_qualifications.care_qualifications.or"), class: "govuk-body" %>
+  <%= render "govuk_publishing_components/components/checkboxes", {
+    name: "offer_care_qualifications[]",
+    items: [
       {
         value: t('coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.no_qualification.label'),
         label: t('coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.no_qualification.label'),

--- a/app/views/coronavirus_form/offer_care_qualifications.erb
+++ b/app/views/coronavirus_form/offer_care_qualifications.erb
@@ -10,28 +10,44 @@
 <%= form_tag({},
   "data-module": "track-coronavirus-form-business-offer-care-qualifications",
   "data-question-key": "offer_care_qualifications",
-  "id": "what_qualifications_do_you_have",
   "novalidate": "true"
 ) do %>
+<%= render "govuk_publishing_components/components/checkboxes", {
+  heading: t("coronavirus_form.questions.offer_care_qualifications.offer_care_type.title"),
+  hint_text: t('coronavirus_form.questions.offer_care_qualifications.offer_care_type.hint'),
+  is_page_heading: true,
+  id: "offer_care_type",
+  name: "offer_care_type[]",
+  error_message: error_items("offer_care_type"),
+  items: t("coronavirus_form.questions.offer_care_qualifications.offer_care_type.options").map do |_, item|
+    {
+      value: item[:label],
+      label: item[:label],
+      checked: session.fetch(:offer_care_type, []).include?(item[:label]),
+    }
+  end
+}
+  %>
+
   <%= render "govuk_publishing_components/components/checkboxes", {
-    heading: t('coronavirus_form.questions.offer_care_qualifications.title'),
-    hint_text: t('coronavirus_form.questions.offer_care_qualifications.hint'),
-    is_page_heading: true,
+    heading: t('coronavirus_form.questions.offer_care_qualifications.care_qualifications.title'),
+    hint_text: t('coronavirus_form.questions.offer_care_qualifications.care_qualifications.hint'),
+    id: "offer_care_qualifications",
     name: "offer_care_qualifications[]",
-    error: error_items("offer_care_qualifications"),
+    error_message: error_items("offer_care_qualifications"),
     items: [
       {
-        value: t('coronavirus_form.questions.offer_care_qualifications.options.dbs_check.label'),
-        label: t('coronavirus_form.questions.offer_care_qualifications.options.dbs_check.label'),
-        checked: session.fetch(:offer_care_qualifications, []).include?(t('coronavirus_form.questions.offer_care_qualifications.options.dbs_check.label')),
+        value: t('coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.dbs_check.label'),
+        label: t('coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.dbs_check.label'),
+        checked: session.fetch(:offer_care_qualifications, []).include?(t('coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.dbs_check.label')),
       },
       {
-        value: t('coronavirus_form.questions.offer_care_qualifications.options.nursing_or_healthcare_qualification.label'),
-        label: t('coronavirus_form.questions.offer_care_qualifications.options.nursing_or_healthcare_qualification.label'),
-        checked: session.fetch(:offer_care_qualifications, []).include?(t('coronavirus_form.questions.offer_care_qualifications.options.nursing_or_healthcare_qualification.label')),
+        value: t('coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.nursing_or_healthcare_qualification.label'),
+        label: t('coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.nursing_or_healthcare_qualification.label'),
+        checked: session.fetch(:offer_care_qualifications, []).include?(t('coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.nursing_or_healthcare_qualification.label')),
         conditional: render("govuk_publishing_components/components/textarea", {
           label: {
-            text: t('coronavirus_form.questions.offer_care_qualifications.options.nursing_or_healthcare_qualification.input.label'),
+            text: t('coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.nursing_or_healthcare_qualification.input.label'),
           },
           id: "offer_care_qualifications_type",
           name: "offer_care_qualifications_type",
@@ -40,9 +56,9 @@
         })
       },
       {
-        value: t('coronavirus_form.questions.offer_care_qualifications.options.no_qualification.label'),
-        label: t('coronavirus_form.questions.offer_care_qualifications.options.no_qualification.label'),
-        checked: session.fetch(:offer_care_qualifications, []).include?(t('coronavirus_form.questions.offer_care_qualifications.options.no_qualification.label')),
+        value: t('coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.no_qualification.label'),
+        label: t('coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.no_qualification.label'),
+        checked: session.fetch(:offer_care_qualifications, []).include?(t('coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.no_qualification.label')),
       },
     ]
   } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -274,21 +274,32 @@ en:
             label: "No"
         custom_select_error: "Select if you can offer social care or childcare"
       offer_care_qualifications:
-        title: "What qualifications or certificates do you have?"
-        hint: "Select the qualifications that you or people in your business have"
-        options:
-          dbs_check:
-            label: "DBS check"
-          nursing_or_healthcare_qualification:
-            label: "Nursing or other healthcare qualification"
-            input:
-              label: "Give a description"
-              custom_error: "Give a description of your qualification"
-          no_qualification:
-            label: "I do not have a qualification"
-        custom_select_error: "Select the qualifications that you or people in your company have. If you do not have any select ‘I do not have a qualification’"
-        offer_care_qualifications_type:
-          custom_length_error: "Description of your qualification must be 1000 characters or fewer"
+        title: "What kind of care can you offer?"
+        offer_care_type:
+          title: "What kind of care can you offer?"
+          hint: ""
+          options:
+            adult_care:
+              label: "Care for adults"
+            child_care:
+              label: "Care for children"
+          custom_select_error: "Select if you can offer care for adults or children"
+        care_qualifications:
+          title: "What qualifications or certificates do you have?"
+          hint: "Select the qualifications that you or people in your business have"
+          options:
+            dbs_check:
+              label: "DBS check"
+            nursing_or_healthcare_qualification:
+              label: "Nursing or other healthcare qualification"
+              input:
+                label: "Give a description"
+              error_message: "Give a description of your qualification"
+            no_qualification:
+              label: "I do not have a qualification"
+          custom_select_error: "Select the qualifications that you or people in your company have. If you do not have any select ‘I do not have a qualification’"
+          offer_care_qualifications_type:
+            custom_length_error: "Description of your qualification must be 1000 characters or fewer"
       offer_other_support:
           title: "Can you offer any other kind of support?"
           hint: "Give a description"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -297,6 +297,7 @@ en:
               error_message: "Give a description of your qualification"
             no_qualification:
               label: "I do not have a qualification"
+          or: "Or"
           custom_select_error: "Select the qualifications that you or people in your company have. If you do not have any select ‘I do not have a qualification’"
           offer_care_qualifications_type:
             custom_length_error: "Description of your qualification must be 1000 characters or fewer"

--- a/spec/controllers/coronavirus_form/offer_care_qualifications_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/offer_care_qualifications_controller_spec.rb
@@ -4,7 +4,8 @@ require "spec_helper"
 
 RSpec.describe CoronavirusForm::OfferCareQualificationsController, type: :controller do
   let(:current_template) { "coronavirus_form/offer_care_qualifications" }
-  let(:session_key) { :offer_care_qualifications }
+  let(:session_key_type) { :offer_care_type }
+  let(:session_key_qualifcation) { :offer_care_qualifications }
 
   describe "GET show" do
     it "renders the form when first question answered" do
@@ -23,53 +24,87 @@ RSpec.describe CoronavirusForm::OfferCareQualificationsController, type: :contro
   end
 
   describe "POST submit" do
-    let(:selected) { ["DBS check"] }
-    it "sets session variables" do
-      post :submit, params: { offer_care_qualifications: selected }
+    let(:selected_type) { ["Care for adults"] }
+    let(:selected_qualification) { ["DBS check"] }
 
-      expect(session[session_key]).to eq selected
+    it "sets session variables" do
+      post :submit, params: {
+        offer_care_type: selected_type,
+        offer_care_qualifications: selected_qualification,
+      }
+
+      expect(session[session_key_type]).to eq selected_type
+      expect(session[session_key_qualifcation]).to eq selected_qualification
     end
 
     it "redirects to next step" do
-      post :submit, params: { offer_care_qualifications: selected }
-
+      post :submit, params: {
+        offer_care_type: selected_type,
+        offer_care_qualifications: selected_qualification,
+      }
       expect(response).to redirect_to(offer_other_support_path)
     end
 
     it "redirects to check your answers if check your answers already seen" do
       session[:check_answers_seen] = true
-      post :submit, params: { offer_care_qualifications: selected }
-
+      post :submit, params: {
+        offer_care_type: selected_type,
+        offer_care_qualifications: selected_qualification,
+      }
       expect(response).to redirect_to(check_your_answers_path)
     end
 
-    it "validates any option is chosen" do
-      post :submit, params: { offer_care_qualifications: [] }
+    it "validates any care type is chosen" do
+      post :submit, params: {
+        offer_care_type: [],
+        offer_care_qualifications: selected_qualification,
+      }
+      expect(response).to render_template(current_template)
+    end
 
+    it "validates any qualification is chosen" do
+      post :submit, params: {
+        offer_care_type: selected_type,
+        offer_care_qualifications: [],
+      }
       expect(response).to render_template(current_template)
     end
 
     context "when Nursing or other healthcare qualification option is selected" do
       it "validates the Nursing or other healthcare qualification option description is provided" do
-        post :submit, params: { offer_care_qualifications: ["DBS check", "Nursing or other healthcare qualification"] }
+        post :submit, params: {
+          offer_care_type: selected_type,
+          offer_care_qualifications: ["DBS check", "Nursing or other healthcare qualification"],
+        }
 
         expect(response).to render_template(current_template)
       end
 
       it "adds the details to the session" do
         post :submit, params: {
+          offer_care_type: selected_type,
           offer_care_qualifications: ["DBS check", "Nursing or other healthcare qualification"],
-          offer_care_qualifications_type: "Registered Nurse",
-        }
+        offer_care_qualifications_type: "Registered Nurse",
+      }
 
         expect(response).to redirect_to(offer_other_support_path)
-        expect(session[session_key]).to eq ["DBS check", "Nursing or other healthcare qualification"]
+        expect(session[session_key_qualifcation]).to eq ["DBS check", "Nursing or other healthcare qualification"]
         expect(session[:offer_care_qualifications_type]).to eq "Registered Nurse"
       end
     end
 
-    it "validates a valid option is chosen" do
+    it "validates a valid care type is chosen" do
       post :submit, params: {
+        offer_care_type: ["<script></script", "invalid option", "DBS check"],
+        offer_care_qualifications: selected_qualification,
+      }
+
+      expect(response).to render_template(current_template)
+    end
+
+    it "validates a valid qualification is chosen" do
+      post :submit, params: {
+        offer_care_type: selected_type,
         offer_care_qualifications: ["<script></script", "invalid option", "DBS check"],
       }
 
@@ -79,6 +114,7 @@ RSpec.describe CoronavirusForm::OfferCareQualificationsController, type: :contro
     described_class::TEXT_FIELDS.each do |field|
       it "validates that #{field} is 1000 or fewer characters" do
         params = {
+          offer_care_type: selected_type,
           offer_care_qualifications: ["DBS check", "Nursing or other healthcare qualification"],
           offer_care_qualifications_type: "Registered Nurse",
         }


### PR DESCRIPTION
Adds an additional question asking what type of care can be offered.  Additionally adds an 'Or' separator into the list of qualifications.

![Screenshot 2020-04-01 at 11 59 07](https://user-images.githubusercontent.com/6329861/78130548-6a01f280-7411-11ea-9546-df6ceccce659.png)

Trello card: https://trello.com/c/i1bH0AtM