### PR TITLE
Increase frequency of response data dump to S3 bucket

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -28,13 +28,10 @@ resources:
       branch: master
       pro: true
 
-  - name: every-day-after-midnight
+  - name: every-six-hours
     type: time
     icon: clock-outline
-    source:
-      start: 00:00
-      stop: 01:00
-      location: Europe/London
+    source: {interval: 6h}
 
 jobs:
   - name: deploy-to-staging
@@ -96,10 +93,10 @@ jobs:
           URL: 'https://govuk-coronavirus-business-volunteer-form-prod.cloudapps.digital/'
           MESSAGE: "Checks that the application deployed to staging is not serving HTTP error codes"
 
-  - name: export-form-responses-daily
+  - name: export-form-responses-periodically
     plan:
       - get: govuk-coronavirus-business-volunteer-form
-      - get: every-day-after-midnight
+      - get: every-six-hours
         trigger: true
       - task: export-form-responses
         file: govuk-coronavirus-business-volunteer-form/concourse/tasks/export-form-responses.yml

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -9,11 +9,16 @@ namespace :export do
     puts responses.to_json
   end
 
-  desc "Uploads all form responses for a specific date (e.g. \"2015-03-24\") in JSON format to a S3 bucket"
+  desc "Uploads all form responses since a specific date (e.g. \"2015-03-24\") in JSON format to a S3 bucket"
   task :form_responses_s3, [:date] => [:environment] do |_, args|
     args.with_defaults(date: Date.yesterday.to_s)
 
-    responses = FormResponse.where(created_at: Date.parse(args.date).all_day)
+    start_time = Date.parse(args.date).beginning_of_day
+    end_time = Time.current
+    puts "finding responses between #{start_time} and #{end_time}"
+
+    responses = FormResponse.where(created_at: start_time..end_time)
+    puts "found #{responses.count} responses"
 
     credentials = JSON.parse(ENV["VCAP_SERVICES"]).to_h.dig("aws-s3-bucket", 0, "credentials")
 
@@ -23,10 +28,12 @@ namespace :export do
       secret_access_key: credentials["aws_secret_access_key"],
     )
 
+    filename = "#{args.date}_to_#{end_time.strftime('%Y-%m-%d')}.json"
     s3.put_object(
       bucket: credentials["bucket_name"],
-      key: "#{args.date}.json",
+      key: filename,
       body: responses.to_json,
     )
+    puts "Uploaded responses #{filename} to #{credentials['bucket_name']}"
   end
 end


### PR DESCRIPTION
[Story](https://trello.com/c/HErHvmtW)
## What
Data dumping responses was once a day at midnight. We increase it every 6 hours per requested. 

The data dump has been modified to include data from "yesterday" until the current time. It will write to a file that is in the format of "2020-03-31_to_2020-04-01.json". 

The task is run 4 times a day. Each time the same file is overwritten. 

The changes include:
- Modified the pipelines to every 6 hours interval
- Changed the rack task to write response to current time
- Changed the output filename

## How to review
Deploy it to staging, and check if the rake task run as expected. 
Fly deploy the new concourse pipeline. 
