### PR TITLE
concourse: Fix typo in self-update get resource name

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -37,7 +37,7 @@ resources:
 jobs:
   - name: update-pipeline
     plan:
-      - get: govuk-coronavirus-business-volunteer-people-form
+      - get: govuk-coronavirus-business-volunteer-form
         trigger: true
       - set_pipeline: govuk-corona-business-volunteer-form
         file: govuk-coronavirus-business-volunteer-form/concourse/pipeline.yml


### PR DESCRIPTION
- This failed to apply:

```
error: invalid pipeline config:
invalid jobs:
	jobs.update-pipeline.plan[0].get.govuk-coronavirus-business-volunteer-people-form refers to a resource that does not exist
```

Already applied. :cowboy: