### PR TITLE
Fix error state on care qualifications

### DIFF
--- a/app/views/coronavirus_form/offer_care_qualifications.erb
+++ b/app/views/coronavirus_form/offer_care_qualifications.erb
@@ -16,9 +16,9 @@
   heading: t("coronavirus_form.questions.offer_care_qualifications.offer_care_type.title"),
   hint_text: t('coronavirus_form.questions.offer_care_qualifications.offer_care_type.hint'),
   is_page_heading: true,
-  id: "offer_care_type",
+  id: "offer_care_qualifications.offer_care_type",
   name: "offer_care_type[]",
-  error_message: error_items("offer_care_type"),
+  error: error_items("offer_care_type"),
   items: t("coronavirus_form.questions.offer_care_qualifications.offer_care_type.options").map do |_, item|
     {
       value: item[:label],
@@ -32,9 +32,9 @@
   <%= render "govuk_publishing_components/components/checkboxes", {
     heading: t('coronavirus_form.questions.offer_care_qualifications.care_qualifications.title'),
     hint_text: t('coronavirus_form.questions.offer_care_qualifications.care_qualifications.hint'),
-    id: "offer_care_qualifications",
+    id: "offer_care_qualifications.care_qualifications",
     name: "offer_care_qualifications[]",
-    error_message: error_items("offer_care_qualifications"),
+    error: error_items("offer_care_qualifications"),
     items: [
       {
         value: t('coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.dbs_check.label'),


### PR DESCRIPTION
Adjust ids to match the generated error summary links. Fix component attribute (for checkboxes it's `error`, not `error_message` – annoyingly inconsistent with radios).

Follow up on #166.