### PR TITLE
Add postcode to business details question

### DIFF
--- a/app/controllers/coronavirus_form/check_answers_controller.rb
+++ b/app/controllers/coronavirus_form/check_answers_controller.rb
@@ -162,6 +162,7 @@ private
       concatenated_answer << "Company number: #{answer['company_number']}" if answer["company_number"]
       concatenated_answer << "Company size number: #{answer['company_size']}" if answer["company_size"]
       concatenated_answer << "Company location: #{answer['company_location']}" if answer["company_location"]
+      concatenated_answer << "Company postcode: #{answer['company_postcode']}" if answer["company_postcode"]
       joiner = "<br>"
     elsif question.eql?("support_address")
       concatenated_answer = answer.values.compact

--- a/app/views/coronavirus_form/business_details.html.erb
+++ b/app/views/coronavirus_form/business_details.html.erb
@@ -64,6 +64,17 @@
       value:  item[:label],
       text:  item[:label],
       checked: session.dig("business_details", "company_location") == item[:label],
+      conditional: item[:label] != t("coronavirus_form.questions.business_details.company_location.options.united_kingdom.label") ? nil :
+        render("govuk_publishing_components/components/input", {
+          label: {
+            text: t("coronavirus_form.questions.business_details.company_location.options.united_kingdom.input.label"),
+          },
+          id: "company_postcode",
+          name: "company_postcode",
+          error_message: error_items("company_postcode"),
+          value: session.dig("business_details", "company_postcode"),
+          width: 10
+        })
     }
   end
 } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -379,6 +379,9 @@ en:
           options:
             united_kingdom:
               label: "United Kingdom"
+              input:
+                label: "Postcode"
+                custom_error: "Enter a UK postcode"
             european_union:
               label: "European Union"
             rest_of_world:


### PR DESCRIPTION
When the business is located in the United Kingdom, we will ask for the company postcode and validate this is in the correct format.

![Screenshot 2020-04-02 at 10 06 28](https://user-images.githubusercontent.com/6329861/78230780-bf013f80-74c9-11ea-9d41-bcc6b6145269.png)

With no form responses:
![Screenshot 2020-04-02 at 10 06 36](https://user-images.githubusercontent.com/6329861/78230807-c6c0e400-74c9-11ea-8655-7ab93130e1ea.png)

UK selected, but no postcode entered:
![Screenshot 2020-04-02 at 10 06 45](https://user-images.githubusercontent.com/6329861/78230825-cde7f200-74c9-11ea-8097-5efe5fa4702e.png)

UK selected, invalid postcode entered:
![Screenshot 2020-04-02 at 10 06 55](https://user-images.githubusercontent.com/6329861/78230840-d4766980-74c9-11ea-8ded-921245d72990.png)

Trello card: https://trello.com/c/JjAbjvaI