### PR TITLE
Add timeout page to the service and increase session expiry time

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,8 @@ class ApplicationController < ActionController::Base
   include FormFlowHelper
   include ProductHelper
 
+  rescue_from ActionController::InvalidAuthenticityToken, with: :session_expired
+
   before_action :check_first_question_answered, only: :show
 
   if ENV["REQUIRE_BASIC_AUTH"]
@@ -23,6 +25,11 @@ class ApplicationController < ActionController::Base
 private
 
   helper_method :previous_path
+
+  def session_expired
+    reset_session
+    redirect_to session_expired_path
+  end
 
   def previous_path
     raise NotImplementedError, "Define a previous path"

--- a/app/controllers/coronavirus_form/session_expired_controller.rb
+++ b/app/controllers/coronavirus_form/session_expired_controller.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class CoronavirusForm::SessionExpiredController < ApplicationController
+  skip_before_action :check_first_question_answered
+end

--- a/app/views/coronavirus_form/session_expired.html.erb
+++ b/app/views/coronavirus_form/session_expired.html.erb
@@ -1,0 +1,17 @@
+<% content_for :title do %><%= t('session_expired.title') %><% end %>
+<% content_for :meta_tags do %>
+  <meta name="description" content="<%= t('session_expired.title') %>" />
+<% end %>
+
+<%= render "govuk_publishing_components/components/title", {
+  title:t("session_expired.title"),
+  margin_top: 0
+} %>
+
+<%= sanitize(t('session_expired.body_text')) %>
+
+<%= render "govuk_publishing_components/components/button", {
+  text: "Start now",
+  start: true,
+  href: "/"
+} %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -32,7 +32,7 @@ Rails.application.configure do
   end
 
   config.cache_store = :redis_cache_store
-  config.session_store :cache_store, expires_in: 2.hours, key: "_sessions_store"
+  config.session_store :cache_store, expires_in: 4.hours, key: "_sessions_store"
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -93,7 +93,7 @@ Rails.application.configure do
     redis = JSON.parse(ENV["VCAP_SERVICES"]).to_h.fetch("redis", [])
     instance = redis.first
     config.cache_store = :redis_cache_store, { url: instance.dig("credentials", "uri") }
-    config.session_store :cache_store, expires_in: 2.hours, key: "_sessions_store"
+    config.session_store :cache_store, expires_in: 4.hours, key: "_sessions_store"
   end
 
   # Inserts middleware to perform automatic connection switching.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,6 +79,11 @@ en:
     heading: "Now send the form"
     confirmation: "By submitting this form you’re confirming that, to the best of your knowledge, the details you’re providing are correct."
     submit: "Accept and send"
+  session_expired:
+    title: Your session has ended due to inactivity
+    body_text: |
+      <p class="govuk-body">Your session has ended because you have not done anything for 4 hours. You'll have to start again.</p>
+      <p class="govuk-body">We do this for your security. We've deleted all the details you entered to protect your data.</p>
   coronavirus_form:
     errors:
       heading: "There is a problem"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,5 +93,8 @@ Rails.application.routes.draw do
 
     # Other page - Accessibility statement
     get "/accessibility-statement", to: "accessibility_statement#show"
+
+    # Other page - Session expired notice
+    get "/session-expired", to: "session_expired#show"
   end
 end

--- a/spec/controllers/coronavirus_form/additional_product_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/additional_product_controller_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe CoronavirusForm::AdditionalProductController, type: :controller do
+  include_examples "session expiry"
+
   let(:current_template) { "coronavirus_form/additional_product" }
 
   describe "GET show" do

--- a/spec/controllers/coronavirus_form/are_you_a_manufacturer_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/are_you_a_manufacturer_controller_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe CoronavirusForm::AreYouAManufacturerController, type: :controller do
+  include_examples "session expiry"
+
   let(:current_template) { "coronavirus_form/are_you_a_manufacturer" }
   let(:session_key) { :are_you_a_manufacturer }
 

--- a/spec/controllers/coronavirus_form/business_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/business_details_controller_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe CoronavirusForm::BusinessDetailsController, type: :controller do
+  include_examples "session expiry"
+
   let(:current_template) { "coronavirus_form/business_details" }
   let(:session_key) { :business_details }
 

--- a/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe CoronavirusForm::CheckAnswersController, type: :controller do
+  include_examples "session expiry"
+
   let(:current_template) { "coronavirus_form/check_answers" }
 
   describe "GET show" do

--- a/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe CoronavirusForm::ContactDetailsController, type: :controller do
+  include_examples "session expiry"
+
   let(:current_template) { "coronavirus_form/contact_details" }
   let(:session_key) { :contact_details }
 

--- a/spec/controllers/coronavirus_form/expert_advice_type_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/expert_advice_type_controller_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe CoronavirusForm::ExpertAdviceTypeController, type: :controller do
+  include_examples "session expiry"
+
   let(:current_template) { "coronavirus_form/expert_advice_type" }
   let(:session_key) { :expert_advice_type }
 

--- a/spec/controllers/coronavirus_form/hotel_rooms_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/hotel_rooms_controller_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe CoronavirusForm::HotelRoomsController, type: :controller do
+  include_examples "session expiry"
+
   let(:current_template) { "coronavirus_form/hotel_rooms" }
   let(:session_key) { :hotel_rooms }
 

--- a/spec/controllers/coronavirus_form/hotel_rooms_number_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/hotel_rooms_number_controller_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe CoronavirusForm::HotelRoomsNumberController, type: :controller do
+  include_examples "session expiry"
+
   let(:current_template) { "coronavirus_form/hotel_rooms_number" }
   let(:session_key) { :hotel_rooms_number }
 

--- a/spec/controllers/coronavirus_form/location_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/location_controller_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe CoronavirusForm::LocationController, type: :controller do
+  include_examples "session expiry"
+
   let(:current_template) { "coronavirus_form/location" }
   let(:session_key) { :location }
 

--- a/spec/controllers/coronavirus_form/medical_equipment_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/medical_equipment_controller_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe CoronavirusForm::MedicalEquipmentController, type: :controller do
+  include_examples "session expiry"
+
   let(:current_template) { "coronavirus_form/medical_equipment" }
   let(:session_key) { :medical_equipment }
 

--- a/spec/controllers/coronavirus_form/medical_equipment_type_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/medical_equipment_type_controller_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe CoronavirusForm::MedicalEquipmentTypeController, type: :controller do
+  include_examples "session expiry"
+
   let(:current_template) { "coronavirus_form/medical_equipment_type" }
   let(:session_key) { :product_details }
 

--- a/spec/controllers/coronavirus_form/offer_care_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/offer_care_controller_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe CoronavirusForm::OfferCareController, type: :controller do
+  include_examples "session expiry"
+
   let(:current_template) { "coronavirus_form/offer_care" }
   let(:session_key) { :offer_care }
 

--- a/spec/controllers/coronavirus_form/offer_care_qualifications_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/offer_care_qualifications_controller_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe CoronavirusForm::OfferCareQualificationsController, type: :controller do
+  include_examples "session expiry"
+
   let(:current_template) { "coronavirus_form/offer_care_qualifications" }
   let(:session_key_type) { :offer_care_type }
   let(:session_key_qualifcation) { :offer_care_qualifications }

--- a/spec/controllers/coronavirus_form/offer_other_support_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/offer_other_support_controller_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe CoronavirusForm::OfferOtherSupportController, type: :controller do
+  include_examples "session expiry"
+
   let(:current_template) { "coronavirus_form/offer_other_support" }
   let(:session_key) { :offer_other_support }
 

--- a/spec/controllers/coronavirus_form/offer_space_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/offer_space_controller_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe CoronavirusForm::OfferSpaceController, type: :controller do
+  include_examples "session expiry"
+
   let(:current_template) { "coronavirus_form/offer_space" }
   let(:session_key) { :offer_space }
 

--- a/spec/controllers/coronavirus_form/offer_space_type_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/offer_space_type_controller_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe CoronavirusForm::OfferSpaceTypeController, type: :controller do
+  include_examples "session expiry"
+
   let(:current_template) { "coronavirus_form/offer_space_type" }
   let(:session_key) { :offer_space_type }
 

--- a/spec/controllers/coronavirus_form/offer_transport_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/offer_transport_controller_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe CoronavirusForm::OfferTransportController, type: :controller do
+  include_examples "session expiry"
+
   let(:current_template) { "coronavirus_form/offer_transport" }
   let(:session_key) { :offer_transport }
 

--- a/spec/controllers/coronavirus_form/product_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/product_details_controller_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe CoronavirusForm::ProductDetailsController, type: :controller do
+  include_examples "session expiry"
+
   let(:current_template) { "coronavirus_form/product_details" }
   let(:session_key) { :product_details }
   let(:product_id) { SecureRandom.uuid }

--- a/spec/controllers/coronavirus_form/session_expired_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/session_expired_controller_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe CoronavirusForm::SessionExpiredController, type: :controller do
+  let(:current_template) { "coronavirus_form/session_expired" }
+
+  describe "GET show" do
+    it "renders the page" do
+      get :show
+      expect(response).to render_template(current_template)
+    end
+  end
+end

--- a/spec/controllers/coronavirus_form/transport_type_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/transport_type_controller_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe CoronavirusForm::TransportTypeController, type: :controller do
+  include_examples "session expiry"
+
   let(:current_template) { "coronavirus_form/transport_type" }
   let(:session_key) { :transport_type }
   let(:session_key_text) { :transport_description }

--- a/spec/support/shared_examples_for_controllers.rb
+++ b/spec/support/shared_examples_for_controllers.rb
@@ -1,0 +1,8 @@
+RSpec.shared_examples "session expiry" do
+  it "redirects to session expired page if the session has timed out" do
+    allow(controller).to receive(:submit).and_raise(ActionController::InvalidAuthenticityToken)
+
+    post :submit
+    expect(response).to redirect_to(session_expired_path)
+  end
+end


### PR DESCRIPTION
We have a short expiry time on session data so user responses are not stored in the user does not submit the form.

This makes the following changes:
- Shows a pretty error when the session expires
- Increases the session timeout from 2 to 4 hours (increasing the time allowed to complete the form)

Example of session expired page:
<img width="984" alt="Screenshot 2020-04-02 at 11 28 56" src="https://user-images.githubusercontent.com/6329861/78243977-a5b5be80-74dc-11ea-9f42-53b97722989f.png">

This mirrors changes made in https://github.com/alphagov/govuk-coronavirus-vulnerable-people-form/pull/189 and https://github.com/alphagov/govuk-coronavirus-vulnerable-people-form/pull/186 for the vulnerable people form.

Trello card: https://trello.com/c/WY2eN2JL