### PR TITLE
Remove full stops from form field IDs

### DIFF
--- a/app/helpers/field_validation_helper.rb
+++ b/app/helpers/field_validation_helper.rb
@@ -19,7 +19,7 @@ module FieldValidationHelper
     mandatory_fields.each do |field|
       next if params[field].present?
 
-      invalid_fields << { field: field.to_s,
+      invalid_fields << { field: field.to_s.sub(".", "_"),
                           text: t("coronavirus_form.questions.#{page}.#{field}.custom_error",
                                   default: t("coronavirus_form.errors.missing_mandatory_text_field", field: t("coronavirus_form.questions.#{page}.#{field}.label")).humanize) }
     end
@@ -48,7 +48,7 @@ module FieldValidationHelper
 
   def validate_checkbox_field(page, values:, allowed_values:, other: false, other_field: "other")
     if values.blank? || values.empty?
-      return [{ field: page.to_s,
+      return [{ field: page.to_s.sub(".", "_"),
                 text: t(
                   "coronavirus_form.questions.#{page}.custom_select_error",
                   default: t("coronavirus_form.errors.checkbox_field", field: t("coronavirus_form.questions.#{page}.title")).humanize,
@@ -56,7 +56,7 @@ module FieldValidationHelper
     end
 
     if (values - allowed_values).any?
-      return [{ field: page.to_s,
+      return [{ field: page.to_s.sub(".", "_"),
                 text: t(
                   "coronavirus_form.questions.#{page}.custom_select_error",
                   default: t("coronavirus_form.errors.missing_mandatory_text_field", field: t("coronavirus_form.questions.#{page}.title")).humanize,
@@ -64,7 +64,7 @@ module FieldValidationHelper
     end
 
     if other != false && other.blank? && values.include?(I18n.t("coronavirus_form.questions.#{page}.options.#{other_field}.label"))
-      return [{ field: page.to_s,
+      return [{ field: page.to_s.sub(".", "_"),
                 text: t(
                   "coronavirus_form.questions.#{page}.options.#{other_field}.error_message",
                   default: t("coronavirus_form.errors.missing_mandatory_text_field", field: t("coronavirus_form.questions.#{page}.title")).humanize,
@@ -78,7 +78,7 @@ module FieldValidationHelper
     if email_address =~ /@/
       []
     else
-      [{ field: field.to_s, text: t("coronavirus_form.errors.email_format") }]
+      [{ field: field.to_s.sub(".", "_"), text: t("coronavirus_form.errors.email_format") }]
     end
   end
 
@@ -86,7 +86,7 @@ module FieldValidationHelper
     if postcode =~ /^(([A-Z]{1,2}[0-9][A-Z0-9]?|ASCN|STHL|TDCU|BBND|[BFS]IQQ|PCRN|TKCA) ?[0-9][A-Z]{2}|BFPO ?[0-9]{1,4}|(KY[0-9]|MSR|VG|AI)[ -]?[0-9]{4}|[A-Z]{2} ?[0-9]{2}|GE ?CX|GIR ?0A{2}|SAN ?TA1)$/i
       []
     else
-      [{ field: field.to_s, text: t("coronavirus_form.errors.postcode_format") }]
+      [{ field: field.to_s.sub(".", "_"), text: t("coronavirus_form.errors.postcode_format") }]
     end
   end
 end

--- a/app/views/coronavirus_form/business_details.html.erb
+++ b/app/views/coronavirus_form/business_details.html.erb
@@ -45,7 +45,7 @@
   error_message: error_items('company_size'),
   items: t('coronavirus_form.questions.business_details.company_size.options').map.with_index do |(_, item), index|
     {
-      id: ("business_details.company_size" if index == 0),
+      id: ("business_details_company_size" if index == 0),
       value:  item[:label],
       text:  item[:label],
       checked: session.dig("business_details", "company_size") == item[:label],
@@ -60,7 +60,7 @@
   error_message: error_items('company_location'),
   items: t('coronavirus_form.questions.business_details.company_location.options').map.with_index do |(_, item), index|
     {
-      id: ("business_details.company_location" if index == 0),
+      id: ("business_details_company_location" if index == 0),
       value:  item[:label],
       text:  item[:label],
       checked: session.dig("business_details", "company_location") == item[:label],

--- a/app/views/coronavirus_form/offer_care_qualifications.erb
+++ b/app/views/coronavirus_form/offer_care_qualifications.erb
@@ -16,7 +16,7 @@
   heading: t("coronavirus_form.questions.offer_care_qualifications.offer_care_type.title"),
   hint_text: t('coronavirus_form.questions.offer_care_qualifications.offer_care_type.hint'),
   is_page_heading: true,
-  id: "offer_care_qualifications.offer_care_type",
+  id: "offer_care_qualifications_offer_care_type",
   name: "offer_care_type[]",
   error: error_items("offer_care_type"),
   items: t("coronavirus_form.questions.offer_care_qualifications.offer_care_type.options").map do |_, item|
@@ -32,7 +32,7 @@
   <%= render "govuk_publishing_components/components/checkboxes", {
     heading: t('coronavirus_form.questions.offer_care_qualifications.care_qualifications.title'),
     hint_text: t('coronavirus_form.questions.offer_care_qualifications.care_qualifications.hint'),
-    id: "offer_care_qualifications.care_qualifications",
+    id: "offer_care_qualifications_care_qualifications",
     name: "offer_care_qualifications[]",
     error: error_items("offer_care_qualifications"),
     items: [

--- a/app/views/coronavirus_form/product_details.html.erb
+++ b/app/views/coronavirus_form/product_details.html.erb
@@ -35,7 +35,7 @@
     error_message: error_items('equipment_type'),
     items: t('coronavirus_form.questions.product_details.equipment_type.options').map.with_index do |(_, item), index|
       {
-        id: ("product_details.equipment_type" if index == 0),
+        id: ("product_details_equipment_type" if index == 0),
         value: item[:label],
         text: item[:label],
         checked: @product["equipment_type"] == item[:label],
@@ -85,7 +85,7 @@
   error_message: error_items('product_location'),
   items: [
     {
-      id: "product_details.product_location",
+      id: "product_details_product_location",
       value: t('coronavirus_form.questions.product_details.product_location.options.option_uk.label'),
       text: t('coronavirus_form.questions.product_details.product_location.options.option_uk.label'),
       checked: @product["product_location"] == t('coronavirus_form.questions.product_details.product_location.options.option_uk.label'),


### PR DESCRIPTION
We have some form fields which contain a full stop.  This breaks conditional reveals since the space is not escaped in the CSS selector.

Therefore replacing all full stops in the IDs with underscores and updating the validators to replace full stops in field names.  This maintains the link to specific errors that appear in the flash box.

Trello card: https://trello.com/c/JOdhNGhY