### PR TITLE
Add additional fields to offer space type page

### DIFF
--- a/app/controllers/coronavirus_form/offer_space_type_controller.rb
+++ b/app/controllers/coronavirus_form/offer_space_type_controller.rb
@@ -7,11 +7,7 @@ class CoronavirusForm::OfferSpaceTypeController < ApplicationController
     offer_space_type = Array(params[:offer_space_type]).map { |item| strip_tags(item).presence }.compact
     offer_space_type_other = strip_tags(params[:offer_space_type_other]).presence
     session[:offer_space_type] = offer_space_type
-    session[:offer_space_type_other] = if selected_other?(offer_space_type)
-                                         offer_space_type_other
-                                       else
-                                         ""
-                                       end
+    session[:offer_space_type_other] = description(:offer_space_type_other, :other, offer_space_type)
 
     invalid_fields = validate_field_response_length(controller_name, TEXT_FIELDS) +
       validate_checkbox_field(
@@ -33,9 +29,17 @@ class CoronavirusForm::OfferSpaceTypeController < ApplicationController
 
 private
 
-  def selected_other?(offer_space_type)
-    offer_space_type.include?(
-      I18n.t("coronavirus_form.questions.#{controller_name}.options.other.label"),
+  def description(field, parent_field, checkboxes)
+    if selected_field?(parent_field, checkboxes)
+      strip_tags(params[field]).presence
+    else
+      ""
+    end
+  end
+
+  def selected_field?(field, checkboxes)
+    checkboxes.include?(
+      I18n.t("coronavirus_form.questions.#{controller_name}.options.#{field}.label"),
     )
   end
 

--- a/app/controllers/coronavirus_form/offer_space_type_controller.rb
+++ b/app/controllers/coronavirus_form/offer_space_type_controller.rb
@@ -1,21 +1,20 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::OfferSpaceTypeController < ApplicationController
-  TEXT_FIELDS = %w(offer_space_type_other).freeze
+  OPTIONS = I18n.t("coronavirus_form.questions.#{controller_name}.options")
+  ALLOWED_VALUES = OPTIONS.map { |_, item| item.dig(:label) }
+  TEXT_FIELDS = [:general_space_description].freeze
+  DESCRIPTION_FIELDS = OPTIONS.map { |_, item| item.dig(:description, :id) }.freeze
 
   def submit
     offer_space_type = Array(params[:offer_space_type]).map { |item| strip_tags(item).presence }.compact
-    offer_space_type_other = strip_tags(params[:offer_space_type_other]).presence
     session[:offer_space_type] = offer_space_type
-    session[:offer_space_type_other] = description(:offer_space_type_other, :other, offer_space_type)
+    session[:offer_space_type_other] = description(:other, offer_space_type)
+    session[:warehouse_space_description] = description(:warehouse_space, offer_space_type)
+    session[:office_space_description] = description(:office_space, offer_space_type)
+    session[:general_space_description] = strip_tags(params[:general_space_description]).presence
 
-    invalid_fields = validate_field_response_length(controller_name, TEXT_FIELDS) +
-      validate_checkbox_field(
-        controller_name,
-        values: offer_space_type,
-        allowed_values: I18n.t("coronavirus_form.questions.#{controller_name}.options").map { |_, item| item.dig(:label) },
-        other: offer_space_type_other,
-      )
+    invalid_fields = validate_fields(offer_space_type)
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
@@ -29,9 +28,55 @@ class CoronavirusForm::OfferSpaceTypeController < ApplicationController
 
 private
 
-  def description(field, parent_field, checkboxes)
-    if selected_field?(parent_field, checkboxes)
-      strip_tags(params[field]).presence
+  def validate_fields(offer_space_type)
+    [
+      validate_field_response_length(controller_name, TEXT_FIELDS),
+      validate_checkbox_field(controller_name, values: offer_space_type, allowed_values: ALLOWED_VALUES),
+      validate_mandatory_text_fields(controller_name, TEXT_FIELDS),
+      validate_description_fields(offer_space_type),
+      validate_descriptions_response_length(offer_space_type),
+    ].flatten.compact
+  end
+
+  def validate_descriptions_response_length(_selected_options)
+    overlong_descriptions.map do |(option_id, option)|
+      {
+        field: option.dig(:description, :id).to_s,
+        text: t("coronavirus_form.questions.#{controller_name}.options.#{option_id}.description.custom_length_error"),
+      }
+    end
+  end
+
+  def overlong_descriptions
+    filter_options do |_field_id, option|
+      val = session[option.dig(:description, :id)]
+      val.present? && val.length > 1000
+    end
+  end
+
+  def filter_options(&predicate)
+    OPTIONS.to_a.select { |(field_id, option)| predicate.call(field_id, option) }.to_h
+  end
+
+  def validate_description_fields(selected_options)
+    missing_descriptions(selected_options).map do |field_id, option|
+      {
+        field: option.dig(:description, :id).to_s,
+        text: t("coronavirus_form.questions.#{controller_name}.options.#{field_id}.description.error_message"),
+      }
+    end
+  end
+
+  def missing_descriptions(selected_options)
+    filter_options do |field_id, option|
+      description_id = option.dig(:description, :id).to_sym
+      selected_field?(field_id, selected_options) && session[description_id].blank?
+    end
+  end
+
+  def description(field, checkboxes)
+    if selected_field?(field, checkboxes)
+      strip_tags(params[OPTIONS.dig(field, :description, :id)]).presence
     else
       ""
     end

--- a/app/views/coronavirus_form/offer_space_type.erb
+++ b/app/views/coronavirus_form/offer_space_type.erb
@@ -56,7 +56,7 @@
         checked: session.fetch(:offer_space_type, []).include?(t('coronavirus_form.questions.offer_space_type.options.other.label')),
         conditional: render("govuk_publishing_components/components/input", {
           label: {
-            text: t('coronavirus_form.questions.offer_space_type.options.office_space.description.label'),
+            text: t('coronavirus_form.questions.offer_space_type.options.other.description.label'),
           },
           id: "offer_space_type_other",
           name: "offer_space_type_other",

--- a/app/views/coronavirus_form/offer_space_type.erb
+++ b/app/views/coronavirus_form/offer_space_type.erb
@@ -24,27 +24,57 @@
         value: t('coronavirus_form.questions.offer_space_type.options.warehouse_space.label'),
         label: t('coronavirus_form.questions.offer_space_type.options.warehouse_space.label'),
         checked: session.fetch(:offer_space_type, []).include?(t('coronavirus_form.questions.offer_space_type.options.warehouse_space.label')),
+        conditional: render("govuk_publishing_components/components/input", {
+          label: {
+            text: t('coronavirus_form.questions.offer_space_type.options.warehouse_space.description.label'),
+          },
+          id: "warehouse_space_description",
+          name: "warehouse_space_description",
+          error_message: error_items("warehouse_space_description"),
+          value: session[:warehouse_space_description],
+          width: 10,
+        })
       },
       {
         value: t('coronavirus_form.questions.offer_space_type.options.office_space.label'),
         label: t('coronavirus_form.questions.offer_space_type.options.office_space.label'),
         checked: session.fetch(:offer_space_type, []).include?(t('coronavirus_form.questions.offer_space_type.options.office_space.label')),
+        conditional: render("govuk_publishing_components/components/input", {
+          label: {
+            text: t('coronavirus_form.questions.offer_space_type.options.office_space.description.label'),
+          },
+          id: "office_space_description",
+          name: "office_space_description",
+          error_message: error_items("office_space_description"),
+          value: session[:office_space_description],
+          width: 10,
+        })
       },
       {
         value: t('coronavirus_form.questions.offer_space_type.options.other.label'),
         label: t('coronavirus_form.questions.offer_space_type.options.other.label'),
         checked: session.fetch(:offer_space_type, []).include?(t('coronavirus_form.questions.offer_space_type.options.other.label')),
-        conditional: render("govuk_publishing_components/components/textarea", {
+        conditional: render("govuk_publishing_components/components/input", {
           label: {
-            text: t('coronavirus_form.questions.offer_space_type.options.other.input.label'),
+            text: t('coronavirus_form.questions.offer_space_type.options.office_space.description.label'),
           },
           id: "offer_space_type_other",
           name: "offer_space_type_other",
           error_message: error_items("offer_space_type_other"),
           value: session[:offer_space_type_other],
+          width: 10,
         })
       },
     ]
+  } %>
+
+  <%= render "govuk_publishing_components/components/textarea", {
+    label: {
+      text: t("coronavirus_form.questions.offer_space_type.general_space_description.label")
+    },
+    name: "general_space_description",
+    error_message: error_items("general_space_description"),
+    value: session[:general_space_description]
   } %>
   <%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
 <% end %>

--- a/app/views/coronavirus_form/transport_type.html.erb
+++ b/app/views/coronavirus_form/transport_type.html.erb
@@ -34,7 +34,7 @@
     text: t("coronavirus_form.questions.transport_type.transport_description.label")
   },
   name: "transport_description",
-  error: error_items("transport_description"),
+  error_message: error_items("transport_description"),
   value: session[:transport_description]
 } %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -225,16 +225,30 @@ en:
         options:
           warehouse_space:
             label: "Warehouse space"
+            description:
+              id: warehouse_space_description
+              label: Approximate total size of all warehouses, in square feet
+              error_message: Enter the approximate total size of the warehouses, in square feet
+              custom_length_error: "Description of warehouse space must be 1000 characters or fewer"
           office_space:
             label: "Office space"
+            description:
+              id: office_space_description
+              label: Approximate total size of all offices, in square feet
+              error_message: Enter the approximate total size of the office space, in square feet
+              custom_length_error: "Description of office space must be 1000 characters or fewer"
           other:
             label: "Other"
-            input:
-              label: "Give a description"
-            error_message: "Enter a description of the type of space you have"
-        offer_space_type_other:
-          custom_length_error: "Description of your expertise must be 1000 characters or fewer"
-        custom_select_error: "Select the kind of space you can offer"
+            description:
+              id: offer_space_type_other
+              label: Approximate total size of all other spaces, in square feet
+              custom_length_error: "Description of other space must be 1000 characters or fewer"
+              error_message: Enter the approximate total size of the spaces, in square feet
+        general_space_description:
+          label: Give a description, for example whether you have one space, or multiple units
+          custom_error: Enter a description
+          custom_length_error: Description of space must be 1000 characters or fewer
+        custom_select_error: Select the kind of space you can offer
       expert_advice_type:
         title: "What kind of expertise can you offer?"
         hint: "Select the types of support you can offer"

--- a/spec/controllers/coronavirus_form/offer_space_type_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/offer_space_type_controller_spec.rb
@@ -24,21 +24,30 @@ RSpec.describe CoronavirusForm::OfferSpaceTypeController, type: :controller do
 
   describe "POST submit" do
     let(:selected) { ["Warehouse space", "Office space"] }
+    let(:params) do
+      {
+        offer_space_type: ["Warehouse space", "Office space", "Other"],
+        warehouse_space_description: "200msq",
+        offer_space_type_other: "500sqm",
+        office_space_description: "400msq",
+        general_space_description: "I have extra space of 1000msq",
+      }
+    end
     it "sets session variables" do
-      post :submit, params: { offer_space_type: selected }
+      post :submit, params: params
 
-      expect(session[session_key]).to eq selected
+      expect(session.to_h).to eq params.deep_stringify_keys
     end
 
     it "redirects to next step" do
-      post :submit, params: { offer_space_type: selected }
+      post :submit, params: params
 
       expect(response).to redirect_to(expert_advice_type_path)
     end
 
     it "redirects to check your answers if check your answers already seen" do
       session[:check_answers_seen] = true
-      post :submit, params: { offer_space_type: selected }
+      post :submit, params: params
 
       expect(response).to redirect_to("/check-your-answers")
     end
@@ -51,14 +60,41 @@ RSpec.describe CoronavirusForm::OfferSpaceTypeController, type: :controller do
       end
 
       it "adds the other option description to the session" do
-        post :submit, params: {
+        post :submit, params: params.merge(
           offer_space_type: ["Other", "Office space"],
           offer_space_type_other: "A really big garden.",
-        }
+        )
 
         expect(response).to redirect_to(expert_advice_type_path)
         expect(session[session_key]).to eq ["Other", "Office space"]
         expect(session[:offer_space_type_other]).to eq "A really big garden."
+      end
+    end
+
+    described_class::OPTIONS.each do |(option_id, option)|
+      context "when the option #{option_id} is selected" do
+        description_id = option.dig(:description, :id).to_sym
+
+        context "when the option #{option_id} is not provided" do
+          let(:acceptable_params) {
+            params.merge(
+              offer_space_type: params[:offer_space_type].reject { |type|
+                type == option.dig(:label)
+              },
+            ).except(description_id)
+          }
+          it "doesn't require the description field #{description_id}" do
+            post :submit, params: acceptable_params
+            expect(response).to redirect_to(expert_advice_type_path)
+          end
+        end
+
+        context "when the corresponding description field #{description_id} is not provided" do
+          it "won't accept the input" do
+            post :submit, params: params.except(description_id)
+            expect(response).to render_template(current_template)
+          end
+        end
       end
     end
 
@@ -76,14 +112,13 @@ RSpec.describe CoronavirusForm::OfferSpaceTypeController, type: :controller do
 
     it "redirects to check your answers if check your answers previously seen" do
       session[:check_answers_seen] = true
-      post :submit, params: { offer_space_type: selected }
+      post :submit, params: params
 
       expect(response).to redirect_to(check_your_answers_path)
     end
 
-    described_class::TEXT_FIELDS.each do |field|
+    (described_class::TEXT_FIELDS + described_class::DESCRIPTION_FIELDS).each do |field|
       it "validates that #{field} is 1000 or fewer characters" do
-        params = { offer_space_type: ["Other", "Office space"] }
         params[field] = SecureRandom.hex(1001)
         post :submit, params: params
 


### PR DESCRIPTION
Now a description field is required for each type of space that is offered.
There is also a general description field that is required.

https://trello.com/c/3UKYWxkd/7-business-form-content-change-size-of-space

Before:

<img width="671" alt="Screenshot 2020-04-03 at 11 48 28" src="https://user-images.githubusercontent.com/8124374/78352898-0eff0580-75a1-11ea-9599-c05a46e08eba.png">

After:

<img width="710" alt="Screenshot 2020-04-03 at 11 49 15" src="https://user-images.githubusercontent.com/8124374/78352939-29d17a00-75a1-11ea-804c-51401a128434.png">


<img width="689" alt="Screenshot 2020-04-03 at 11 28 55" src="https://user-images.githubusercontent.com/8124374/78352905-14f4e680-75a1-11ea-9ea4-4bea27aca9df.png">

<img width="667" alt="Screenshot 2020-04-03 at 11 28 39" src="https://user-images.githubusercontent.com/8124374/78352912-19b99a80-75a1-11ea-9396-82f7979b3193.png">
