### PR TITLE
Add production PaaS hostname to config.hosts

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -7,6 +7,7 @@ Rails.application.configure do
   config.hosts = [
     "coronavirus-business-volunteers.service.gov.uk",
     "d2uxybyx2btt89.cloudfront.net",
+    "govuk-coronavirus-business-volunteer-form-prod.cloudapps.digital",
     "govuk-coronavirus-business-volunteer-form-stg.cloudapps.digital",
   ]
 


### PR DESCRIPTION
This was causing production smoke tests to fail since they run against govuk-coronavirus-business-volunteer-form-prod.cloudapps.digital.

Trello card: https://trello.com/c/vdSUBzGw