### PR TITLE
Add GA to all business form pages

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -44,5 +44,13 @@
       }
     } %>
     <%= javascript_include_tag "application" %>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-43115970-1"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'UA-43115970-1');
+    </script>
   </body>
 </html>


### PR DESCRIPTION
This adds Google Analytics to the business form, to help us understand how businesses are using the service to offer help, so the development team can make improvements.

We have no plans to add this to the vulnerable people service.

The GA views have been set up by John B already.