### PR TITLE
Return product quantity input field to default width

### DIFF
--- a/app/views/coronavirus_form/product_details.html.erb
+++ b/app/views/coronavirus_form/product_details.html.erb
@@ -54,7 +54,6 @@
   type: "number",
   error_message: error_items('product_quantity'),
   value: @product["product_quantity"],
-  width: 10,
 } %>
 <%= render "govuk_publishing_components/components/input", {
   label: {


### PR DESCRIPTION
This field was originally reduced in width with the intention that users would enter solely a number.  However, in practice users have entered additional essential information (e.g. "per week").  Making the field wider will make it easier for users to enter this information.

Before:
<img width="557" alt="Screenshot 2020-04-03 at 21 36 26" src="https://user-images.githubusercontent.com/6329861/78402827-31217380-75f3-11ea-84a7-e4440a848003.png">

After:
<img width="529" alt="Screenshot 2020-04-03 at 21 35 56" src="https://user-images.githubusercontent.com/6329861/78402803-25ce4800-75f3-11ea-890c-f242b518c145.png">

Trello card: https://trello.com/c/prOOYLSB