### PR TITLE
Perform validations before setting session values

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,6 +19,7 @@ class ApplicationController < ActionController::Base
   end
 
   def show
+    @form_responses = session.to_hash.with_indifferent_access
     render controller_path
   end
 

--- a/app/controllers/coronavirus_form/additional_product_controller.rb
+++ b/app/controllers/coronavirus_form/additional_product_controller.rb
@@ -2,27 +2,36 @@
 
 class CoronavirusForm::AdditionalProductController < ApplicationController
   def submit
-    additional_product = strip_tags(params[:additional_product]).presence
+    @form_responses = {
+      additional_product: strip_tags(params[:additional_product]).presence,
+    }
 
     invalid_fields = validate_radio_field(
       controller_name,
-      radio: additional_product,
+      radio: @form_responses[:additional_product],
     )
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
       render controller_path
-    elsif additional_product == I18n.t("coronavirus_form.questions.additional_product.options.option_yes.label")
+    elsif @form_responses[:additional_product] == I18n.t("coronavirus_form.questions.additional_product.options.option_yes.label")
+      update_session_store
       redirect_to medical_equipment_type_url
     elsif session["check_answers_seen"]
+      update_session_store
       redirect_to check_your_answers_url
     else
+      update_session_store
       redirect_to hotel_rooms_url
     end
   end
 
 private
+
+  def update_session_store
+    session[:additional_product] = @form_responses[:additional_product]
+  end
 
   def previous_path
     session["product_details"] ||= []

--- a/app/controllers/coronavirus_form/are_you_a_manufacturer_controller.rb
+++ b/app/controllers/coronavirus_form/are_you_a_manufacturer_controller.rb
@@ -2,12 +2,13 @@
 
 class CoronavirusForm::AreYouAManufacturerController < ApplicationController
   def submit
-    are_you_a_manufacturer = Array(params[:are_you_a_manufacturer]).map { |item| strip_tags(item).presence }.compact
-    session["are_you_a_manufacturer"] = are_you_a_manufacturer
+    @form_responses = {
+      are_you_a_manufacturer: Array(params[:are_you_a_manufacturer]).map { |item| strip_tags(item).presence }.compact,
+    }
 
     invalid_fields = validate_checkbox_field(
       controller_name,
-      values: are_you_a_manufacturer,
+      values: @form_responses[:are_you_a_manufacturer],
       allowed_values: I18n.t("coronavirus_form.questions.#{controller_name}.options").map { |_, item| item.dig(:label) },
     )
 
@@ -16,13 +17,19 @@ class CoronavirusForm::AreYouAManufacturerController < ApplicationController
       log_validation_error(invalid_fields)
       render controller_path
     elsif session["check_answers_seen"]
+      update_session_store
       redirect_to check_your_answers_url
     else
+      update_session_store
       redirect_to medical_equipment_type_url
     end
   end
 
 private
+
+  def update_session_store
+    session[:are_you_a_manufacturer] = @form_responses[:are_you_a_manufacturer]
+  end
 
   def previous_path
     medical_equipment_url

--- a/app/controllers/coronavirus_form/business_details_controller.rb
+++ b/app/controllers/coronavirus_form/business_details_controller.rb
@@ -5,38 +5,45 @@ class CoronavirusForm::BusinessDetailsController < ApplicationController
   TEXT_FIELDS = %w(company_name company_number).freeze
 
   def submit
-    @business_details = sanitized_business_details(params)
-    session[:business_details] = @business_details
+    @form_responses = {
+      business_details: sanitized_business_details(params),
+    }
 
-    invalid_fields = validate_field_response_length(controller_name, TEXT_FIELDS) +
-      validate_fields(@business_details)
+    invalid_fields = validate_fields
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
       render controller_path
     elsif session["check_answers_seen"]
+      update_session_store
       redirect_to check_your_answers_url
     else
+      update_session_store
       redirect_to contact_details_url
     end
   end
 
 private
 
-  def validate_fields(business_details)
+  def update_session_store
+    session[:business_details] = @form_responses[:business_details]
+  end
+
+  def validate_fields
     errors = []
 
+    errors << validate_field_response_length(controller_name, TEXT_FIELDS)
     errors << validate_mandatory_text_fields(controller_name, REQUIRED_FIELDS)
-    errors << validate_radio_field("#{controller_name}.company_size", radio: business_details["company_size"])
-    errors << validate_radio_field("#{controller_name}.company_location", radio: business_details["company_location"])
+    errors << validate_radio_field("#{controller_name}.company_size", radio: @form_responses.dig(:business_details, :company_size))
+    errors << validate_radio_field("#{controller_name}.company_location", radio: @form_responses.dig(:business_details, :company_location))
 
-    errors << if @business_details["company_location"] == I18n.t("coronavirus_form.questions.business_details.company_location.options.united_kingdom.label") &&
-        @business_details["company_postcode"].blank?
+    errors << if @form_responses[:business_details][:company_location] == I18n.t("coronavirus_form.questions.business_details.company_location.options.united_kingdom.label") &&
+        @form_responses[:business_details][:company_postcode].blank?
                 { field: "company_postcode",
                   text: t("coronavirus_form.questions.#{controller_name}.company_location.options.united_kingdom.input.custom_error") }
-              elsif @business_details["company_location"] == I18n.t("coronavirus_form.questions.business_details.company_location.options.united_kingdom.label")
-                validate_postcode("company_postcode", @business_details["company_postcode"])
+              elsif @form_responses[:business_details][:company_location] == I18n.t("coronavirus_form.questions.business_details.company_location.options.united_kingdom.label")
+                validate_postcode("company_postcode", @form_responses[:business_details][:company_postcode])
               end
 
     errors.compact.flatten
@@ -44,11 +51,11 @@ private
 
   def sanitized_business_details(params)
     {
-      "company_name" => strip_tags(params[:company_name]).presence,
-      "company_number" => strip_tags(params[:company_number]).presence,
-      "company_size" => strip_tags(params[:company_size]).presence,
-      "company_location" => strip_tags(params[:company_location]).presence,
-      "company_postcode" => strip_tags(params[:company_postcode]).presence,
+      company_name: strip_tags(params[:company_name]).presence,
+      company_number: strip_tags(params[:company_number]).presence,
+      company_size: strip_tags(params[:company_size]).presence,
+      company_location: strip_tags(params[:company_location]).presence,
+      company_postcode: strip_tags(params[:company_postcode]).presence,
     }
   end
 

--- a/app/controllers/coronavirus_form/expert_advice_type_controller.rb
+++ b/app/controllers/coronavirus_form/expert_advice_type_controller.rb
@@ -4,21 +4,17 @@ class CoronavirusForm::ExpertAdviceTypeController < ApplicationController
   TEXT_FIELDS = %w(expert_advice_type_other).freeze
 
   def submit
-    expert_advice_type = Array(params[:expert_advice_type]).map { |item| strip_tags(item).presence }.compact
-    expert_advice_type_other = strip_tags(params[:expert_advice_type_other]).presence
-    session[:expert_advice_type] = expert_advice_type
-    session[:expert_advice_type_other] = if selected_other?(expert_advice_type)
-                                           expert_advice_type_other
-                                         else
-                                           ""
-                                         end
+    @form_responses = {
+      expert_advice_type: Array(params[:expert_advice_type]).map { |item| strip_tags(item).presence }.compact,
+    }
+    @form_responses[:expert_advice_type_other] = strip_tags(params[:expert_advice_type_other]).presence if selected_other?
 
     invalid_fields = validate_field_response_length(controller_name, TEXT_FIELDS) +
       validate_checkbox_field(
         controller_name,
-        values: expert_advice_type,
+        values: @form_responses[:expert_advice_type],
         allowed_values: I18n.t("coronavirus_form.questions.#{controller_name}.options").map { |_, item| item.dig(:label) },
-        other: expert_advice_type_other,
+        other: @form_responses[:expert_advice_type_other],
       )
 
     if invalid_fields.any?
@@ -26,16 +22,23 @@ class CoronavirusForm::ExpertAdviceTypeController < ApplicationController
       log_validation_error(invalid_fields)
       render controller_path
     elsif session["check_answers_seen"]
+      update_session_store
       redirect_to check_your_answers_url
     else
+      update_session_store
       redirect_to offer_care_url
     end
   end
 
 private
 
-  def selected_other?(expert_advice_type)
-    expert_advice_type.include?(
+  def update_session_store
+    session[:expert_advice_type] = @form_responses[:expert_advice_type]
+    session[:expert_advice_type_other] = @form_responses[:expert_advice_type_other]
+  end
+
+  def selected_other?
+    @form_responses[:expert_advice_type].include?(
       I18n.t("coronavirus_form.questions.#{controller_name}.options.other.label"),
     )
   end

--- a/app/controllers/coronavirus_form/hotel_rooms_controller.rb
+++ b/app/controllers/coronavirus_form/hotel_rooms_controller.rb
@@ -2,29 +2,37 @@
 
 class CoronavirusForm::HotelRoomsController < ApplicationController
   def submit
-    hotel_rooms = strip_tags(params[:hotel_rooms]).presence
-    session[:hotel_rooms] = hotel_rooms
+    @form_responses = {
+      hotel_rooms: strip_tags(params[:hotel_rooms]).presence,
+    }
 
     invalid_fields = validate_radio_field(
       controller_name,
-      radio: hotel_rooms,
+      radio: @form_responses[:hotel_rooms],
     )
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
       render controller_path
-    elsif session[:hotel_rooms] == I18n.t("coronavirus_form.questions.hotel_rooms.options.yes_staying_in.label") ||
-        session[:hotel_rooms] == I18n.t("coronavirus_form.questions.hotel_rooms.options.yes_all_uses.label")
+    elsif @form_responses[:hotel_rooms] == I18n.t("coronavirus_form.questions.hotel_rooms.options.yes_staying_in.label") ||
+        @form_responses[:hotel_rooms] == I18n.t("coronavirus_form.questions.hotel_rooms.options.yes_all_uses.label")
+      update_session_store
       redirect_to hotel_rooms_number_url
     elsif session["check_answers_seen"]
+      update_session_store
       redirect_to check_your_answers_url
     else
+      update_session_store
       redirect_to offer_transport_url
     end
   end
 
 private
+
+  def update_session_store
+    session[:hotel_rooms] = @form_responses[:hotel_rooms]
+  end
 
   def previous_path
     medical_equipment_url

--- a/app/controllers/coronavirus_form/hotel_rooms_number_controller.rb
+++ b/app/controllers/coronavirus_form/hotel_rooms_number_controller.rb
@@ -4,8 +4,9 @@ class CoronavirusForm::HotelRoomsNumberController < ApplicationController
   REQUIRED_FIELDS = %w(hotel_rooms_number).freeze
 
   def submit
-    hotel_rooms_number = strip_tags(params[:hotel_rooms_number]).presence
-    session[:hotel_rooms_number] = hotel_rooms_number
+    @form_responses = {
+      hotel_rooms_number: strip_tags(params[:hotel_rooms_number]).presence,
+    }
 
     invalid_fields = validate_mandatory_text_fields(controller_name, REQUIRED_FIELDS)
 
@@ -13,13 +14,19 @@ class CoronavirusForm::HotelRoomsNumberController < ApplicationController
       flash.now[:validation] = invalid_fields
       render controller_path
     elsif session["check_answers_seen"]
+      update_session_store
       redirect_to check_your_answers_url
     else
+      update_session_store
       redirect_to offer_transport_url
     end
   end
 
 private
+
+  def update_session_store
+    session[:hotel_rooms_number] = @form_responses[:hotel_rooms_number]
+  end
 
   def previous_path
     hotel_rooms_path

--- a/app/controllers/coronavirus_form/location_controller.rb
+++ b/app/controllers/coronavirus_form/location_controller.rb
@@ -2,13 +2,13 @@
 
 class CoronavirusForm::LocationController < ApplicationController
   def submit
-    location = Array(params[:location]).map { |item| strip_tags(item).presence }.compact
-
-    session[:location] = location
+    @form_responses = {
+      location: Array(params[:location]).map { |item| strip_tags(item).presence }.compact,
+    }
 
     invalid_fields = validate_checkbox_field(
       controller_name,
-      values: location,
+      values: @form_responses[:location],
       allowed_values: I18n.t("coronavirus_form.questions.#{controller_name}.options").map { |_, item| item.dig(:label) },
     )
 
@@ -17,13 +17,19 @@ class CoronavirusForm::LocationController < ApplicationController
       log_validation_error(invalid_fields)
       render controller_path
     elsif session["check_answers_seen"]
+      update_session_store
       redirect_to check_your_answers_url
     else
+      update_session_store
       redirect_to business_details_url
     end
   end
 
 private
+
+  def update_session_store
+    session[:location] = @form_responses[:location]
+  end
 
   def previous_path
     offer_other_support_url

--- a/app/controllers/coronavirus_form/medical_equipment_controller.rb
+++ b/app/controllers/coronavirus_form/medical_equipment_controller.rb
@@ -26,8 +26,6 @@ class CoronavirusForm::MedicalEquipmentController < ApplicationController
     elsif @form_responses[:medical_equipment] == I18n.t("coronavirus_form.questions.#{controller_name}.options.option_no.label")
       update_session_store
       redirect_to hotel_rooms_url
-    else
-      render controller_path
     end
   end
 

--- a/app/controllers/coronavirus_form/medical_equipment_controller.rb
+++ b/app/controllers/coronavirus_form/medical_equipment_controller.rb
@@ -4,13 +4,13 @@ class CoronavirusForm::MedicalEquipmentController < ApplicationController
   skip_before_action :check_first_question_answered
 
   def submit
-    medical_equipment = strip_tags(params[:medical_equipment]).presence
-
-    session[:medical_equipment] = medical_equipment
+    @form_responses = {
+      medical_equipment: strip_tags(params[:medical_equipment]).presence,
+    }
 
     invalid_fields = validate_radio_field(
       controller_name,
-      radio: medical_equipment,
+      radio: @form_responses[:medical_equipment],
     )
 
     if invalid_fields.any?
@@ -18,12 +18,13 @@ class CoronavirusForm::MedicalEquipmentController < ApplicationController
       log_validation_error(invalid_fields)
       render controller_path
     elsif session["check_answers_seen"]
+      update_session_store
       redirect_to check_your_answers_url
-    elsif session[:medical_equipment] == I18n.t("coronavirus_form.questions.#{controller_name}.options.option_yes.label")
-      # YES goes to what kind of business are you / are_you_a_manufacturer
+    elsif @form_responses[:medical_equipment] == I18n.t("coronavirus_form.questions.#{controller_name}.options.option_yes.label")
+      update_session_store
       redirect_to are_you_a_manufacturer_url
-    elsif session[:medical_equipment] == I18n.t("coronavirus_form.questions.#{controller_name}.options.option_no.label")
-      # NO goes to hotel rooms
+    elsif @form_responses[:medical_equipment] == I18n.t("coronavirus_form.questions.#{controller_name}.options.option_no.label")
+      update_session_store
       redirect_to hotel_rooms_url
     else
       render controller_path
@@ -31,6 +32,10 @@ class CoronavirusForm::MedicalEquipmentController < ApplicationController
   end
 
 private
+
+  def update_session_store
+    session[:medical_equipment] = @form_responses[:medical_equipment]
+  end
 
   def previous_path
     "/"

--- a/app/controllers/coronavirus_form/medical_equipment_type_controller.rb
+++ b/app/controllers/coronavirus_form/medical_equipment_type_controller.rb
@@ -16,8 +16,8 @@ class CoronavirusForm::MedicalEquipmentTypeController < ApplicationController
     invalid_fields = validate_field_response_length(controller_name, TEXT_FIELDS) +
       validate_radio_field(
         controller_name,
-        radio: @product["medical_equipment_type"],
-        other: @product["medical_equipment_type_other"],
+        radio: @product[:medical_equipment_type],
+        other: @product[:medical_equipment_type_other],
       )
 
     if invalid_fields.any?
@@ -26,7 +26,7 @@ class CoronavirusForm::MedicalEquipmentTypeController < ApplicationController
       render controller_path
     else
       add_product_to_session(@product)
-      redirect_to product_details_url(product_id: @product["product_id"])
+      redirect_to product_details_url(product_id: @product[:product_id])
     end
   end
 
@@ -42,9 +42,9 @@ private
 
   def sanitized_product(params)
     {
-      "product_id" => strip_tags(params[:product_id]).presence || SecureRandom.uuid,
-      "medical_equipment_type" => strip_tags(params[:medical_equipment_type]).presence,
-      "medical_equipment_type_other" => strip_tags(params[:medical_equipment_type_other]).presence,
+      product_id: strip_tags(params[:product_id]).presence || SecureRandom.uuid,
+      medical_equipment_type: strip_tags(params[:medical_equipment_type]).presence,
+      medical_equipment_type_other: strip_tags(params[:medical_equipment_type_other]).presence,
     }
   end
 end

--- a/app/controllers/coronavirus_form/offer_care_controller.rb
+++ b/app/controllers/coronavirus_form/offer_care_controller.rb
@@ -2,28 +2,36 @@
 
 class CoronavirusForm::OfferCareController < ApplicationController
   def submit
-    offer_care = strip_tags(params[:offer_care]).presence
-    session[:offer_care] = offer_care
+    @form_responses = {
+      offer_care: strip_tags(params[:offer_care]).presence,
+    }
 
     invalid_fields = validate_radio_field(
       controller_name,
-      radio: offer_care,
+      radio: @form_responses[:offer_care],
     )
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
       render controller_path
-    elsif session[:offer_care] == I18n.t("coronavirus_form.questions.#{controller_name}.options.option_yes.label")
+    elsif @form_responses[:offer_care] == I18n.t("coronavirus_form.questions.#{controller_name}.options.option_yes.label")
+      update_session_store
       redirect_to offer_care_qualifications_url
     elsif session["check_answers_seen"]
+      update_session_store
       redirect_to check_your_answers_url
     else
+      update_session_store
       redirect_to offer_other_support_url
     end
   end
 
 private
+
+  def update_session_store
+    session[:offer_care] = @form_responses[:offer_care]
+  end
 
   def previous_path
     expert_advice_type_url

--- a/app/controllers/coronavirus_form/offer_care_qualifications_controller.rb
+++ b/app/controllers/coronavirus_form/offer_care_qualifications_controller.rb
@@ -4,25 +4,23 @@ class CoronavirusForm::OfferCareQualificationsController < ApplicationController
   TEXT_FIELDS = %w(offer_care_qualifications_type).freeze
 
   def submit
-    offer_care_type = Array(params[:offer_care_type]).map { |item| strip_tags(item).presence }.compact
-    offer_care_qualifications = Array(params[:offer_care_qualifications]).map { |item| strip_tags(item).presence }.compact
-    offer_care_qualifications_type = strip_tags(params[:offer_care_qualifications_type]).presence
-
-    session[:offer_care_type] = offer_care_type
-    session[:offer_care_qualifications] = offer_care_qualifications
-    session[:offer_care_qualifications_type] = offer_care_qualifications_type
+    @form_responses = {
+      offer_care_type: Array(params[:offer_care_type]).map { |item| strip_tags(item).presence }.compact,
+      offer_care_qualifications: Array(params[:offer_care_qualifications]).map { |item| strip_tags(item).presence }.compact,
+      offer_care_qualifications_type: strip_tags(params[:offer_care_qualifications_type]).presence,
+    }
 
     invalid_fields = validate_field_response_length("#{controller_name}.care_qualifcations", TEXT_FIELDS) +
       validate_checkbox_field(
         "#{controller_name}.offer_care_type",
-        values: offer_care_type,
+        values: @form_responses[:offer_care_type],
         allowed_values: I18n.t("coronavirus_form.questions.#{controller_name}.offer_care_type.options").map { |_, item| item.dig(:label) },
       ) +
       validate_checkbox_field(
         "#{controller_name}.care_qualifications",
-        values: offer_care_qualifications,
+        values: @form_responses[:offer_care_qualifications],
         allowed_values: I18n.t("coronavirus_form.questions.#{controller_name}.care_qualifications.options").map { |_, item| item.dig(:label) },
-        other: offer_care_qualifications_type,
+        other: @form_responses[:offer_care_qualifications_type],
         other_field: "nursing_or_healthcare_qualification",
       )
 
@@ -31,13 +29,21 @@ class CoronavirusForm::OfferCareQualificationsController < ApplicationController
       log_validation_error(invalid_fields)
       render controller_path
     elsif session["check_answers_seen"]
+      update_session_store
       redirect_to check_your_answers_url
     else
+      update_session_store
       redirect_to offer_other_support_url
     end
   end
 
 private
+
+  def update_session_store
+    session[:offer_care_type] = @form_responses[:offer_care_type]
+    session[:offer_care_qualifications] = @form_responses[:offer_care_qualifications]
+    session[:offer_care_qualifications_type] = @form_responses[:offer_care_qualifications_type]
+  end
 
   def previous_path
     offer_care_url

--- a/app/controllers/coronavirus_form/offer_other_support_controller.rb
+++ b/app/controllers/coronavirus_form/offer_other_support_controller.rb
@@ -4,9 +4,9 @@ class CoronavirusForm::OfferOtherSupportController < ApplicationController
   TEXT_FIELDS = %w(offer_other_support).freeze
 
   def submit
-    offer_other_support = strip_tags(params[:offer_other_support]).presence
-
-    session[:offer_other_support] = offer_other_support
+    @form_responses = {
+      offer_other_support: strip_tags(params[:offer_other_support]).presence,
+    }
 
     invalid_fields = validate_field_response_length(controller_name, TEXT_FIELDS)
 
@@ -15,13 +15,19 @@ class CoronavirusForm::OfferOtherSupportController < ApplicationController
       log_validation_error(invalid_fields)
       render controller_path
     elsif session["check_answers_seen"]
+      update_session_store
       redirect_to check_your_answers_url
     else
+      update_session_store
       redirect_to location_url
     end
   end
 
 private
+
+  def update_session_store
+    session[:offer_other_support] = @form_responses[:offer_other_support]
+  end
 
   def previous_path
     offer_care_url

--- a/app/controllers/coronavirus_form/offer_space_controller.rb
+++ b/app/controllers/coronavirus_form/offer_space_controller.rb
@@ -2,25 +2,33 @@
 
 class CoronavirusForm::OfferSpaceController < ApplicationController
   def submit
-    offer_space = strip_tags(params[:offer_space]).presence
-    session[:offer_space] = offer_space
+    @form_responses = {
+      offer_space: strip_tags(params[:offer_space]).presence,
+    }
 
-    invalid_fields = validate_radio_field(controller_name, radio: offer_space)
+    invalid_fields = validate_radio_field(controller_name, radio: @form_responses[:offer_space])
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
       render controller_path
-    elsif offer_space.eql? "Yes"
+    elsif @form_responses[:offer_space].eql? "Yes"
+      update_session_store
       redirect_to offer_space_type_url
     elsif session["check_answers_seen"]
+      update_session_store
       redirect_to check_your_answers_url
     else
+      update_session_store
       redirect_to expert_advice_type_url
     end
   end
 
 private
+
+  def update_session_store
+    session[:offer_space] = @form_responses[:offer_space]
+  end
 
   def previous_path
     offer_transport_url

--- a/app/controllers/coronavirus_form/offer_transport_controller.rb
+++ b/app/controllers/coronavirus_form/offer_transport_controller.rb
@@ -2,28 +2,36 @@
 
 class CoronavirusForm::OfferTransportController < ApplicationController
   def submit
-    offer_transport = strip_tags(params[:offer_transport]).presence
-    session[:offer_transport] = offer_transport
+    @form_responses = {
+      offer_transport: strip_tags(params[:offer_transport]).presence,
+    }
 
     invalid_fields = validate_radio_field(
       controller_name,
-      radio: offer_transport,
+      radio: @form_responses[:offer_transport],
     )
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
       render controller_path
-    elsif session[:offer_transport] == I18n.t("coronavirus_form.questions.#{controller_name}.options.option_yes.label")
+    elsif @form_responses[:offer_transport] == I18n.t("coronavirus_form.questions.#{controller_name}.options.option_yes.label")
+      update_session_store
       redirect_to transport_type_url
     elsif session["check_answers_seen"]
+      update_session_store
       redirect_to check_your_answers_url
-    elsif session[:offer_transport] == I18n.t("coronavirus_form.questions.#{controller_name}.options.option_no.label")
+    elsif @form_responses[:offer_transport] == I18n.t("coronavirus_form.questions.#{controller_name}.options.option_no.label")
+      update_session_store
       redirect_to offer_space_url
     end
   end
 
 private
+
+  def update_session_store
+    session[:offer_transport] = @form_responses[:offer_transport]
+  end
 
   def previous_path
     hotel_rooms_url

--- a/app/controllers/coronavirus_form/product_details_controller.rb
+++ b/app/controllers/coronavirus_form/product_details_controller.rb
@@ -5,24 +5,25 @@ class CoronavirusForm::ProductDetailsController < ApplicationController
   TEXT_FIELDS = %w(product_name product_quantity product_cost certification_details product_postcode product_url lead_time).freeze
 
   def show
-    session["product_details"] ||= []
-    @product = find_product(params["product_id"], session["product_details"])
+    session[:product_details] ||= []
+    @product = find_product(params["product_id"], session[:product_details])
     super
   end
 
   def submit
-    @product = current_product(params[:product_id], session[:product_details]).merge(sanitized_product(params))
-    add_product_to_session(@product)
+    @product = current_product(params["product_id"], session[:product_details]).merge(sanitized_product(params))
 
-    invalid_fields = validate_field_response_length(controller_name, TEXT_FIELDS) + validate_fields(@product)
+    invalid_fields = validate_fields
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
       render controller_path
     elsif session["check_answers_seen"]
+      add_product_to_session(@product)
       redirect_to check_your_answers_url
     else
+      add_product_to_session(@product)
       redirect_to additional_product_url
     end
   end
@@ -37,46 +38,48 @@ private
   helper_method :selected_ppe?
 
   def selected_ppe?
-    @product["medical_equipment_type"] == I18n.t(
+    @product[:medical_equipment_type] == I18n.t(
       "coronavirus_form.questions.medical_equipment_type.options.number_ppe.label",
     )
   end
 
   def selected_made_in_uk?
-    @product["product_location"] == I18n.t(
+    @product[:product_location] == I18n.t(
       "coronavirus_form.questions.product_details.product_location.options.option_uk.label",
     )
   end
 
-  def validate_fields(product)
-    missing_fields = validate_missing_fields(product)
-    product_equipment_type = selected_ppe? ? validate_radio_field("#{controller_name}.equipment_type", radio: product["equipment_type"]) : []
-    product_location_validation = validate_radio_field("#{controller_name}.product_location", radio: product["product_location"])
-    postcode_validation = validate_product_postcode(product)
-    missing_fields + product_equipment_type + product_location_validation + postcode_validation
+  def validate_fields
+    [
+      validate_field_response_length(controller_name, TEXT_FIELDS),
+      validate_missing_fields,
+      selected_ppe? ? validate_radio_field("#{controller_name}.equipment_type", radio: @product[:equipment_type]) : [],
+      validate_radio_field("#{controller_name}.product_location", radio: @product[:product_location]),
+      validate_product_postcode,
+    ].compact.flatten
   end
 
-  def validate_product_postcode(product)
+  def validate_product_postcode
     return [] unless selected_made_in_uk?
 
-    if product["product_postcode"].blank?
+    if @product[:product_postcode].blank?
       return [{
-        field: "product_postcode".to_s,
+        field: "product_postcode",
         text: t("coronavirus_form.questions.#{controller_name}.product_location.options.option_uk.input.custom_error"),
       }]
     end
 
-    validate_postcode("product_postcode", product["product_postcode"])
+    validate_postcode("product_postcode", @product[:product_postcode])
   end
 
-  def validate_missing_fields(product)
+  def validate_missing_fields
     required = []
     required.concat REQUIRED_FIELDS
     required.each_with_object([]) do |field, invalid_fields|
-      next if product[field].present?
+      next if @product[field.to_sym].present?
 
       invalid_fields << {
-        field: field.to_s,
+        field: field,
         text: t("coronavirus_form.questions.#{controller_name}.#{field}.custom_error",
                 default: t("coronavirus_form.errors.missing_mandatory_text_field",
                            field: t("coronavirus_form.questions.#{controller_name}.#{field}.label")).humanize),
@@ -86,16 +89,16 @@ private
 
   def sanitized_product(params)
     {
-      "product_id" => strip_tags(params[:product_id]).presence || SecureRandom.uuid,
-      "equipment_type" => strip_tags(params[:equipment_type]).presence,
-      "product_name" => strip_tags(params[:product_name]).presence,
-      "product_quantity" => strip_tags(params[:product_quantity]).presence,
-      "product_cost" => strip_tags(params[:product_cost]).presence,
-      "certification_details" => strip_tags(params[:certification_details]).presence,
-      "product_location" => strip_tags(params[:product_location]).presence,
-      "product_postcode" => strip_tags(params[:product_postcode]).presence,
-      "product_url" => strip_tags(params[:product_url]).presence,
-      "lead_time" => strip_tags(params[:lead_time]).presence,
+      product_id: strip_tags(params[:product_id]).presence || SecureRandom.uuid,
+      equipment_type: strip_tags(params[:equipment_type]).presence,
+      product_name: strip_tags(params[:product_name]).presence,
+      product_quantity: strip_tags(params[:product_quantity]).presence,
+      product_cost: strip_tags(params[:product_cost]).presence,
+      certification_details: strip_tags(params[:certification_details]).presence,
+      product_location: strip_tags(params[:product_location]).presence,
+      product_postcode: strip_tags(params[:product_postcode]).presence,
+      product_url: strip_tags(params[:product_url]).presence,
+      lead_time: strip_tags(params[:lead_time]).presence,
     }
   end
 

--- a/app/controllers/coronavirus_form/transport_type_controller.rb
+++ b/app/controllers/coronavirus_form/transport_type_controller.rb
@@ -5,14 +5,14 @@ class CoronavirusForm::TransportTypeController < ApplicationController
   TEXT_FIELDS = %w(transport_description).freeze
 
   def submit
-    transport_type = Array(params[:transport_type]).map { |item| strip_tags(item).presence }.compact
-
-    session[:transport_type] = transport_type
-    session[:transport_description] = params[:transport_description]
+    @form_responses = {
+      transport_type: Array(params[:transport_type]).map { |item| strip_tags(item).presence }.compact,
+      transport_description: params[:transport_description],
+    }
 
     invalid_fields = validate_checkbox_field(
       controller_name,
-      values: transport_type,
+      values: @form_responses[:transport_type],
       allowed_values: I18n.t("coronavirus_form.questions.#{controller_name}.options").map { |_, item| item.dig(:label) },
                       ) +
       validate_mandatory_text_fields(controller_name, REQUIRED_FIELDS) +
@@ -23,13 +23,20 @@ class CoronavirusForm::TransportTypeController < ApplicationController
       log_validation_error(invalid_fields)
       render controller_path
     elsif session["check_answers_seen"]
+      update_session_store
       redirect_to check_your_answers_url
     else
+      update_session_store
       redirect_to offer_space_url
     end
   end
 
 private
+
+  def update_session_store
+    session[:transport_type] = @form_responses[:transport_type]
+    session[:transport_description] = @form_responses[:transport_description]
+  end
 
   def previous_path
     offer_transport_url

--- a/app/helpers/check_answers_helper.rb
+++ b/app/helpers/check_answers_helper.rb
@@ -57,13 +57,13 @@ module CheckAnswersHelper
 
     products.map do |product|
       {
-        field: "Details for product #{product['product_name']}",
+        field: "Details for product #{product[:product_name]}",
         value: sanitize(product_info(product)),
         edit: {
-          href: product_details_url(product_id: product["product_id"]),
+          href: product_details_url(product_id: product[:product_id]),
         },
         delete: {
-          href: "/product-details/#{product['product_id']}/delete",
+          href: "/product-details/#{product[:product_id]}/delete",
         },
       }
     end
@@ -72,19 +72,19 @@ module CheckAnswersHelper
   def product_info(product)
     prod = []
     prod << if product["medical_equipment_type_other"]
-              "Type: #{product['medical_equipment_type']} (#{product['medical_equipment_type_other']})"
+              "Type: #{product[:medical_equipment_type]} (#{product['medical_equipment_type_other']})"
             else
-              "Type: #{product['medical_equipment_type']}"
+              "Type: #{product[:medical_equipment_type]}"
             end
-    prod << "Product: #{product['product_name']}" if product["product_name"]
-    prod << "Equipment type: #{product['equipment_type']}" if product["equipment_type"]
-    prod << "Quantity: #{product['product_quantity']}" if product["product_quantity"]
-    prod << "Cost: #{product['product_cost']}" if product["product_cost"]
-    prod << "Certification details: #{product['certification_details']}" if product["certification_details"]
-    prod << "Location: #{product['product_location']}" if product["product_location"]
-    prod << "Postcode: #{product['product_postcode']}" if product["product_postcode"]
-    prod << "URL: #{product['product_url']}" if product["product_url"]
-    prod << "Lead time: #{product['lead_time']}" if product["lead_time"]
+    prod << "Product: #{product[:product_name]}" if product[:product_name]
+    prod << "Equipment type: #{product[:equipment_type]}" if product[:equipment_type]
+    prod << "Quantity: #{product[:product_quantity]}" if product[:product_quantity]
+    prod << "Cost: #{product[:product_cost]}" if product[:product_cost]
+    prod << "Certification details: #{product[:certification_details]}" if product[:certification_details]
+    prod << "Location: #{product[:product_location]}" if product[:product_location]
+    prod << "Postcode: #{product[:product_postcode]}" if product[:product_postcode]
+    prod << "URL: #{product[:product_url]}" if product[:product_url]
+    prod << "Lead time: #{product[:lead_time]}" if product[:lead_time]
 
     prod.join("<br>")
   end
@@ -132,17 +132,17 @@ module CheckAnswersHelper
     joiner = " "
 
     if question.eql?("contact_details")
-      concatenated_answer << "Name: #{answer['contact_name']}" if answer["contact_name"]
-      concatenated_answer << "Role: #{answer['role']}" if answer["role"]
-      concatenated_answer << "Phone number: #{answer['phone_number']}" if answer["phone_number"]
-      concatenated_answer << "Email: #{answer['email']}" if answer["email"]
+      concatenated_answer << "Name: #{answer[:contact_name]}" if answer[:contact_name]
+      concatenated_answer << "Role: #{answer[:role]}" if answer[:role]
+      concatenated_answer << "Phone number: #{answer[:phone_number]}" if answer[:phone_number]
+      concatenated_answer << "Email: #{answer[:email]}" if answer[:email]
       joiner = "<br>"
     elsif question.eql?("business_details")
-      concatenated_answer << "Company name: #{answer['company_name']}" if answer["company_name"]
-      concatenated_answer << "Company number: #{answer['company_number']}" if answer["company_number"]
-      concatenated_answer << "Company size number: #{answer['company_size']}" if answer["company_size"]
-      concatenated_answer << "Company location: #{answer['company_location']}" if answer["company_location"]
-      concatenated_answer << "Company postcode: #{answer['company_postcode']}" if answer["company_postcode"]
+      concatenated_answer << "Company name: #{answer[:company_name]}" if answer[:company_name]
+      concatenated_answer << "Company number: #{answer[:company_number]}" if answer[:company_number]
+      concatenated_answer << "Company size number: #{answer[:company_size]}" if answer[:company_size]
+      concatenated_answer << "Company location: #{answer[:company_location]}" if answer[:company_location]
+      concatenated_answer << "Company postcode: #{answer[:company_postcode]}" if answer[:company_postcode]
       joiner = "<br>"
     else
       concatenated_answer = answer.values.compact

--- a/app/helpers/check_answers_helper.rb
+++ b/app/helpers/check_answers_helper.rb
@@ -101,8 +101,8 @@ module CheckAnswersHelper
 
   def transport_type_info
     answer = []
-    answer << Array(session["transport_type"]).flatten.to_sentence
-    answer << session["transport_description"]
+    answer << Array(session[:transport_type]).flatten.to_sentence
+    answer << session[:transport_description]
 
     answer.join("<br>")
   end
@@ -110,13 +110,13 @@ module CheckAnswersHelper
   def offer_care_qualifications
     [{
       field: t("coronavirus_form.questions.offer_care_qualifications.offer_care_type.title"),
-      value: sanitize(Array(session["offer_care_type"]).flatten.to_sentence),
+      value: sanitize(Array(session[:offer_care_type]).flatten.to_sentence),
       edit: {
         href: "offer-care-qualifications?change-answer",
       },
     }, {
       field: t("coronavirus_form.questions.offer_care_qualifications.care_qualifications.title"),
-      value: sanitize(Array(session["offer_care_qualifications"]).flatten.to_sentence),
+      value: sanitize(Array(session[:offer_care_qualifications]).flatten.to_sentence),
       edit: {
         href: "offer-care-qualifications?change-answer",
       },

--- a/app/helpers/product_helper.rb
+++ b/app/helpers/product_helper.rb
@@ -2,13 +2,13 @@ module ProductHelper
   def add_product_to_session(product)
     session[:product_details] ||= []
     products = session[:product_details].reject do |prod|
-      prod["product_id"] == product["product_id"]
+      prod[:product_id] == product[:product_id]
     end
     session[:product_details] = products << product
   end
 
   def find_product(product_id, products)
-    products.find { |product| product["product_id"] == product_id } || {}
+    products.find { |product| product[:product_id] == product_id } || {}
   end
 
   def current_product(product_id, products)
@@ -18,7 +18,7 @@ module ProductHelper
   def remove_product_from_session(product_id)
     session[:product_details] ||= []
     session[:product_details] = session[:product_details].reject do |prod|
-      prod["product_id"] == product_id
+      prod[:product_id] == product_id
     end
   end
 end

--- a/app/views/coronavirus_form/additional_product.html.erb
+++ b/app/views/coronavirus_form/additional_product.html.erb
@@ -22,12 +22,12 @@
     {
       value: t('coronavirus_form.questions.additional_product.options.option_yes.label'),
       text: t('coronavirus_form.questions.additional_product.options.option_yes.label'),
-      checked: session[:additional_product] == t('coronavirus_form.questions.additional_product.options.option_yes.label'),
+      checked: @form_responses[:additional_product] == t('coronavirus_form.questions.additional_product.options.option_yes.label'),
     },
     {
       value: t('coronavirus_form.questions.additional_product.options.option_no.label'),
       text: t('coronavirus_form.questions.additional_product.options.option_no.label'),
-      checked: session[:additional_product] == t('coronavirus_form.questions.additional_product.options.option_no.label'),
+      checked: @form_responses[:additional_product] == t('coronavirus_form.questions.additional_product.options.option_no.label'),
     },
   ]
 } %>

--- a/app/views/coronavirus_form/are_you_a_manufacturer.html.erb
+++ b/app/views/coronavirus_form/are_you_a_manufacturer.html.erb
@@ -23,7 +23,7 @@
     {
       value:  item[:label],
       label:  item[:label],
-      checked: session.fetch("are_you_a_manufacturer", []).include?(item[:label]),
+      checked: @form_responses.fetch(:are_you_a_manufacturer, []).include?(item[:label]),
     }
   end
 } %>

--- a/app/views/coronavirus_form/business_details.html.erb
+++ b/app/views/coronavirus_form/business_details.html.erb
@@ -26,7 +26,7 @@
     text: t('coronavirus_form.questions.business_details.company_name.label'),
   },
   error_message: error_items('company_name'),
-  value: session.dig("business_details", "company_name"),
+  value: @form_responses.dig(:business_details, :company_name),
 } %>
 
 <%= render "govuk_publishing_components/components/input", {
@@ -35,7 +35,7 @@
     text: t('coronavirus_form.questions.business_details.company_number.label'),
   },
   error_message: error_items('company_number'),
-  value: session.dig("business_details", "company_number"),
+  value: @form_responses.dig(:business_details, :company_number),
 } %>
 
 <%= render "govuk_publishing_components/components/radio", {
@@ -48,7 +48,7 @@
       id: ("business_details_company_size" if index == 0),
       value:  item[:label],
       text:  item[:label],
-      checked: session.dig("business_details", "company_size") == item[:label],
+      checked: @form_responses.dig(:business_details, :company_size) == item[:label],
     }
   end
 } %>
@@ -63,7 +63,7 @@
       id: ("business_details_company_location" if index == 0),
       value:  item[:label],
       text:  item[:label],
-      checked: session.dig("business_details", "company_location") == item[:label],
+      checked: @form_responses.dig(:business_details, :company_location) == item[:label],
       conditional: item[:label] != t("coronavirus_form.questions.business_details.company_location.options.united_kingdom.label") ? nil :
         render("govuk_publishing_components/components/input", {
           label: {
@@ -72,7 +72,7 @@
           id: "company_postcode",
           name: "company_postcode",
           error_message: error_items("company_postcode"),
-          value: session.dig("business_details", "company_postcode"),
+          value: @form_responses.dig(:business_details, :company_postcode),
           width: 10
         })
     }

--- a/app/views/coronavirus_form/contact_details.html.erb
+++ b/app/views/coronavirus_form/contact_details.html.erb
@@ -25,7 +25,7 @@
   id: "contact_name",
   name: "contact_name",
   error_message: error_items("contact_name"),
-  value: session[:contact_details]["contact_name"],
+  value: @form_responses.dig(:contact_details, :contact_name),
 } %>
 <%= render "govuk_publishing_components/components/input", {
   label: {
@@ -33,7 +33,7 @@
   },
   name: "role",
   error_message: error_items('role'),
-  value: session[:contact_details]["role"],
+  value: @form_responses.dig(:contact_details, :role),
 } %>
 <%= render "govuk_publishing_components/components/input", {
   label: {
@@ -42,7 +42,7 @@
   id: "phone_number",
   name: "phone_number",
   error_message: error_items('phone_number'),
-  value: session[:contact_details]["phone_number"],
+  value: @form_responses.dig(:contact_details, :phone_number),
 } %>
 <%= render "govuk_publishing_components/components/input", {
   label: {
@@ -51,7 +51,7 @@
   id: "email",
   name: "email",
   error_message: error_items('email'),
-  value: session[:contact_details]["email"],
+  value: @form_responses.dig(:contact_details, :email),
   type: "email"
 } %>
 

--- a/app/views/coronavirus_form/expert_advice_type.html.erb
+++ b/app/views/coronavirus_form/expert_advice_type.html.erb
@@ -23,37 +23,37 @@
         {
           value: t("coronavirus_form.questions.expert_advice_type.options.medical.label"),
           label: t("coronavirus_form.questions.expert_advice_type.options.medical.label"),
-          checked: session.fetch(:expert_advice_type, []).include?(t("coronavirus_form.questions.expert_advice_type.options.medical.label")),
+          checked: @form_responses.fetch(:expert_advice_type, []).include?(t("coronavirus_form.questions.expert_advice_type.options.medical.label")),
         },
         {
           value: t("coronavirus_form.questions.expert_advice_type.options.engineering.label"),
           label: t("coronavirus_form.questions.expert_advice_type.options.engineering.label"),
-          checked: session.fetch(:expert_advice_type, []).include?(t("coronavirus_form.questions.expert_advice_type.options.engineering.label")),
+          checked: @form_responses.fetch(:expert_advice_type, []).include?(t("coronavirus_form.questions.expert_advice_type.options.engineering.label")),
         },
         {
           value: t("coronavirus_form.questions.expert_advice_type.options.construction.label"),
           label: t("coronavirus_form.questions.expert_advice_type.options.construction.label"),
-          checked: session.fetch(:expert_advice_type, []).include?(t("coronavirus_form.questions.expert_advice_type.options.construction.label")),
+          checked: @form_responses.fetch(:expert_advice_type, []).include?(t("coronavirus_form.questions.expert_advice_type.options.construction.label")),
         },
         {
           value: t("coronavirus_form.questions.expert_advice_type.options.project_management.label"),
           label: t("coronavirus_form.questions.expert_advice_type.options.project_management.label"),
-          checked: session.fetch(:expert_advice_type, []).include?(t("coronavirus_form.questions.expert_advice_type.options.project_management.label")),
+          checked: @form_responses.fetch(:expert_advice_type, []).include?(t("coronavirus_form.questions.expert_advice_type.options.project_management.label")),
         },
         {
           value: t("coronavirus_form.questions.expert_advice_type.options.it.label"),
           label: t("coronavirus_form.questions.expert_advice_type.options.it.label"),
-          checked: session.fetch(:expert_advice_type, []).include?(t("coronavirus_form.questions.expert_advice_type.options.it.label")),
+          checked: @form_responses.fetch(:expert_advice_type, []).include?(t("coronavirus_form.questions.expert_advice_type.options.it.label")),
         },
         {
           value: t("coronavirus_form.questions.expert_advice_type.options.manufacturing.label"),
           label: t("coronavirus_form.questions.expert_advice_type.options.manufacturing.label"),
-          checked: session.fetch(:expert_advice_type, []).include?(t("coronavirus_form.questions.expert_advice_type.options.manufacturing.label")),
+          checked: @form_responses.fetch(:expert_advice_type, []).include?(t("coronavirus_form.questions.expert_advice_type.options.manufacturing.label")),
         },
         {
           value: t("coronavirus_form.questions.expert_advice_type.options.other.label"),
           label: t("coronavirus_form.questions.expert_advice_type.options.other.label"),
-          checked: session.fetch(:expert_advice_type, []).include?(t("coronavirus_form.questions.expert_advice_type.options.other.label")),
+          checked: @form_responses.fetch(:expert_advice_type, []).include?(t("coronavirus_form.questions.expert_advice_type.options.other.label")),
           conditional: render("govuk_publishing_components/components/textarea", {
             label: {
               text: t("coronavirus_form.questions.expert_advice_type.options.other.input.label"),
@@ -61,7 +61,7 @@
             id: "expert_advice_type_other",
             name: "expert_advice_type_other",
             error_message: error_items("expert_advice_type_other"),
-            value: session[:expert_advice_type_other],
+            value: @form_responses[:expert_advice_type_other],
           })
         },
       ]
@@ -73,7 +73,7 @@
         {
           value: t("coronavirus_form.questions.expert_advice_type.options.no_expertise.label"),
           label: t("coronavirus_form.questions.expert_advice_type.options.no_expertise.label"),
-          checked: session.fetch(:expert_advice_type, []).include?(t("coronavirus_form.questions.expert_advice_type.options.no_expertise.label")),
+          checked: @form_responses.fetch(:expert_advice_type, []).include?(t("coronavirus_form.questions.expert_advice_type.options.no_expertise.label")),
         },
       ],
     }%>

--- a/app/views/coronavirus_form/hotel_rooms.html.erb
+++ b/app/views/coronavirus_form/hotel_rooms.html.erb
@@ -22,7 +22,7 @@
     {
       value: item[:label],
       text: item[:label],
-      checked: session[:hotel_rooms] == item[:label],
+      checked: @form_responses[:hotel_rooms] == item[:label],
     }
   end
 } %>

--- a/app/views/coronavirus_form/hotel_rooms_number.html.erb
+++ b/app/views/coronavirus_form/hotel_rooms_number.html.erb
@@ -23,7 +23,7 @@
   id: "hotel_rooms_number",
   name: "hotel_rooms_number",
   width: 10,
-  value: session[:hotel_rooms_number],
+  value: @form_responses[:hotel_rooms_number],
   error_message: error_items("hotel_rooms_number")
 } %>
 <%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>

--- a/app/views/coronavirus_form/location.html.erb
+++ b/app/views/coronavirus_form/location.html.erb
@@ -23,7 +23,7 @@
     {
       value:  item[:label],
       label:  item[:label],
-      checked: session.fetch(:location, []).include?(item[:label]),
+      checked: @form_responses.fetch(:location, []).include?(item[:label]),
     }
   end
 } %>

--- a/app/views/coronavirus_form/medical_equipment.html.erb
+++ b/app/views/coronavirus_form/medical_equipment.html.erb
@@ -22,7 +22,7 @@
     {
       value: item[:label],
       text: item[:label],
-      checked: session[:medical_equipment] == item[:label],
+      checked: @form_responses[:medical_equipment] == item[:label],
     }
   end
 } %>

--- a/app/views/coronavirus_form/offer_care.html.erb
+++ b/app/views/coronavirus_form/offer_care.html.erb
@@ -23,7 +23,7 @@
     {
       value: item[:label],
       text: item[:label],
-      checked: session[:offer_care] == item[:label],
+      checked: @form_responses[:offer_care] == item[:label],
     }
   end
 } %>

--- a/app/views/coronavirus_form/offer_care_qualifications.erb
+++ b/app/views/coronavirus_form/offer_care_qualifications.erb
@@ -23,7 +23,7 @@
     {
       value: item[:label],
       label: item[:label],
-      checked: session.fetch(:offer_care_type, []).include?(item[:label]),
+      checked: @form_responses.fetch(:offer_care_type, []).include?(item[:label]),
     }
   end
 }
@@ -39,12 +39,12 @@
       {
         value: t('coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.dbs_check.label'),
         label: t('coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.dbs_check.label'),
-        checked: session.fetch(:offer_care_qualifications, []).include?(t('coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.dbs_check.label')),
+        checked: @form_responses.fetch(:offer_care_qualifications, []).include?(t('coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.dbs_check.label')),
       },
       {
         value: t('coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.nursing_or_healthcare_qualification.label'),
         label: t('coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.nursing_or_healthcare_qualification.label'),
-        checked: session.fetch(:offer_care_qualifications, []).include?(t('coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.nursing_or_healthcare_qualification.label')),
+        checked: @form_responses.fetch(:offer_care_qualifications, []).include?(t('coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.nursing_or_healthcare_qualification.label')),
         conditional: render("govuk_publishing_components/components/textarea", {
           label: {
             text: t('coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.nursing_or_healthcare_qualification.input.label'),
@@ -52,7 +52,7 @@
           id: "offer_care_qualifications_type",
           name: "offer_care_qualifications_type",
           error_message: error_items("offer_care_qualifications_type"),
-          value: session[:offer_care_qualifications_type],
+          value: @form_responses[:offer_care_qualifications_type],
         })
       }
     ]
@@ -64,7 +64,7 @@
       {
         value: t('coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.no_qualification.label'),
         label: t('coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.no_qualification.label'),
-        checked: session.fetch(:offer_care_qualifications, []).include?(t('coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.no_qualification.label')),
+        checked: @form_responses.fetch(:offer_care_qualifications, []).include?(t('coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.no_qualification.label')),
       },
     ]
   } %>

--- a/app/views/coronavirus_form/offer_other_support.html.erb
+++ b/app/views/coronavirus_form/offer_other_support.html.erb
@@ -22,7 +22,7 @@
   },
   hint: t('coronavirus_form.questions.offer_other_support.hint'),
   name: "offer_other_support",
-  value: session[:offer_other_support]
+  value: @form_responses[:offer_other_support]
 } %>
 <%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
 <% end %>

--- a/app/views/coronavirus_form/offer_space.html.erb
+++ b/app/views/coronavirus_form/offer_space.html.erb
@@ -23,7 +23,7 @@
     {
       value: item[:label],
       text: item[:label],
-      checked: session[:offer_space] == item[:label],
+      checked: @form_responses[:offer_space] == item[:label],
     }
   end
 } %>

--- a/app/views/coronavirus_form/offer_space_type.erb
+++ b/app/views/coronavirus_form/offer_space_type.erb
@@ -23,7 +23,7 @@
       {
         value: t('coronavirus_form.questions.offer_space_type.options.warehouse_space.label'),
         label: t('coronavirus_form.questions.offer_space_type.options.warehouse_space.label'),
-        checked: session.fetch(:offer_space_type, []).include?(t('coronavirus_form.questions.offer_space_type.options.warehouse_space.label')),
+        checked: @form_responses.fetch(:offer_space_type, []).include?(t('coronavirus_form.questions.offer_space_type.options.warehouse_space.label')),
         conditional: render("govuk_publishing_components/components/input", {
           label: {
             text: t('coronavirus_form.questions.offer_space_type.options.warehouse_space.description.label'),
@@ -31,14 +31,14 @@
           id: "warehouse_space_description",
           name: "warehouse_space_description",
           error_message: error_items("warehouse_space_description"),
-          value: session[:warehouse_space_description],
+          value: @form_responses[:warehouse_space_description],
           width: 10,
         })
       },
       {
         value: t('coronavirus_form.questions.offer_space_type.options.office_space.label'),
         label: t('coronavirus_form.questions.offer_space_type.options.office_space.label'),
-        checked: session.fetch(:offer_space_type, []).include?(t('coronavirus_form.questions.offer_space_type.options.office_space.label')),
+        checked: @form_responses.fetch(:offer_space_type, []).include?(t('coronavirus_form.questions.offer_space_type.options.office_space.label')),
         conditional: render("govuk_publishing_components/components/input", {
           label: {
             text: t('coronavirus_form.questions.offer_space_type.options.office_space.description.label'),
@@ -46,14 +46,14 @@
           id: "office_space_description",
           name: "office_space_description",
           error_message: error_items("office_space_description"),
-          value: session[:office_space_description],
+          value: @form_responses[:office_space_description],
           width: 10,
         })
       },
       {
         value: t('coronavirus_form.questions.offer_space_type.options.other.label'),
         label: t('coronavirus_form.questions.offer_space_type.options.other.label'),
-        checked: session.fetch(:offer_space_type, []).include?(t('coronavirus_form.questions.offer_space_type.options.other.label')),
+        checked: @form_responses.fetch(:offer_space_type, []).include?(t('coronavirus_form.questions.offer_space_type.options.other.label')),
         conditional: render("govuk_publishing_components/components/input", {
           label: {
             text: t('coronavirus_form.questions.offer_space_type.options.other.description.label'),
@@ -61,7 +61,7 @@
           id: "offer_space_type_other",
           name: "offer_space_type_other",
           error_message: error_items("offer_space_type_other"),
-          value: session[:offer_space_type_other],
+          value: @form_responses[:offer_space_type_other],
           width: 10,
         })
       },
@@ -74,7 +74,7 @@
     },
     name: "general_space_description",
     error_message: error_items("general_space_description"),
-    value: session[:general_space_description]
+    value: @form_responses[:general_space_description]
   } %>
   <%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
 <% end %>

--- a/app/views/coronavirus_form/offer_transport.html.erb
+++ b/app/views/coronavirus_form/offer_transport.html.erb
@@ -22,7 +22,7 @@
     {
       value: item[:label],
       text: item[:label],
-      checked: session[:offer_transport] == item[:label],
+      checked: @form_responses[:offer_transport] == item[:label],
     }
   end
 } %>

--- a/app/views/coronavirus_form/product_details.html.erb
+++ b/app/views/coronavirus_form/product_details.html.erb
@@ -17,7 +17,7 @@
   "id": "product_details",
   "novalidate": "true"
 ) do %>
-<%= tag.input type: "hidden", name: "product_id", value: @product["product_id"] %>
+<%= tag.input type: "hidden", name: "product_id", value: @product[:product_id] %>
 <%= render "govuk_publishing_components/components/input", {
   label: {
     text: t('coronavirus_form.questions.product_details.product_name.label')
@@ -25,7 +25,7 @@
   id: "product_name",
   name: "product_name",
   error_message: error_items('product_name'),
-  value: @product["product_name"],
+  value: @product[:product_name],
 } %>
 <% if selected_ppe? %>
   <%= render "govuk_publishing_components/components/radio", {
@@ -38,7 +38,7 @@
         id: ("product_details_equipment_type" if index == 0),
         value: item[:label],
         text: item[:label],
-        checked: @product["equipment_type"] == item[:label],
+        checked: @product[:equipment_type] == item[:label],
       }
     end
   } %>
@@ -53,7 +53,7 @@
   name: "product_quantity",
   type: "number",
   error_message: error_items('product_quantity'),
-  value: @product["product_quantity"],
+  value: @product[:product_quantity],
 } %>
 <%= render "govuk_publishing_components/components/input", {
   label: {
@@ -64,7 +64,7 @@
   name: "product_cost",
   type: "number",
   error_message: error_items('product_cost'),
-  value: @product["product_cost"],
+  value: @product[:product_cost],
   width: 10,
 } %>
 <%= render "govuk_publishing_components/components/input", {
@@ -75,7 +75,7 @@
   id: "certification_details",
   name: "certification_details",
   error_message: error_items('certification_details'),
-  value: @product["certification_details"],
+  value: @product[:certification_details],
 } %>
 <%= render "govuk_publishing_components/components/radio", {
   heading: t('coronavirus_form.questions.product_details.product_location.label'),
@@ -87,7 +87,7 @@
       id: "product_details_product_location",
       value: t('coronavirus_form.questions.product_details.product_location.options.option_uk.label'),
       text: t('coronavirus_form.questions.product_details.product_location.options.option_uk.label'),
-      checked: @product["product_location"] == t('coronavirus_form.questions.product_details.product_location.options.option_uk.label'),
+      checked: @product[:product_location] == t('coronavirus_form.questions.product_details.product_location.options.option_uk.label'),
       conditional: render("govuk_publishing_components/components/input", {
         label: {
           text: t('coronavirus_form.questions.product_details.product_location.options.option_uk.input.label'),
@@ -95,19 +95,19 @@
         id: "product_postcode",
         name: "product_postcode",
         error_message: error_items('product_postcode'),
-        value: @product["product_postcode"],
+        value: @product[:product_postcode],
         width: 10
       })
     },
     {
       value: t('coronavirus_form.questions.product_details.product_location.options.option_eu.label'),
       text: t('coronavirus_form.questions.product_details.product_location.options.option_eu.label'),
-      checked: @product["product_location"] == t('coronavirus_form.questions.product_details.product_location.options.option_eu.label'),
+      checked: @product[:product_location] == t('coronavirus_form.questions.product_details.product_location.options.option_eu.label'),
     },
     {
       value: t('coronavirus_form.questions.product_details.product_location.options.option_rest_of_world.label'),
       text: t('coronavirus_form.questions.product_details.product_location.options.option_rest_of_world.label'),
-      checked: @product["product_location"] == t('coronavirus_form.questions.product_details.product_location.options.option_rest_of_world.label'),
+      checked: @product[:product_location] == t('coronavirus_form.questions.product_details.product_location.options.option_rest_of_world.label'),
     },
   ]
 } %>
@@ -117,7 +117,7 @@
   },
   name: "product_url",
   error_message: error_items('product_url'),
-  value: @product["product_url"],
+  value: @product[:product_url],
 } %>
 <%= render "govuk_publishing_components/components/input", {
   label: {
@@ -127,7 +127,7 @@
   name: "lead_time",
   error_message: error_items('lead_time'),
   type: "number",
-  value: @product["lead_time"],
+  value: @product[:lead_time],
   width: 10,
 } %>
 <%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>

--- a/app/views/coronavirus_form/transport_type.html.erb
+++ b/app/views/coronavirus_form/transport_type.html.erb
@@ -24,7 +24,7 @@
     {
       value:  item[:label],
       label:  item[:label],
-      checked: session.fetch(:transport_type, []).include?(item[:label]),
+      checked: @form_responses.fetch(:transport_type, []).include?(item[:label]),
     }
   end
 } %>
@@ -35,7 +35,7 @@
   },
   name: "transport_description",
   error_message: error_items("transport_description"),
-  value: session[:transport_description]
+  value: @form_responses[:transport_description]
 } %>
 
 <%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>

--- a/spec/controllers/coronavirus_form/business_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/business_details_controller_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe CoronavirusForm::BusinessDetailsController, type: :controller do
     it "sets session variables" do
       post :submit, params: params
 
-      expect(session[:business_details]).to eq params.stringify_keys
+      expect(session[:business_details]).to eq params
     end
 
     it "redirects to next step" do

--- a/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/contact_details_controller_spec.rb
@@ -35,10 +35,10 @@ RSpec.describe CoronavirusForm::ContactDetailsController, type: :controller do
     end
     let(:contact_details) do
       {
-        "contact_name" => "John",
-        "role" => "CEO",
-        "phone_number" => "0118 999 881 999 119 7253",
-        "email" => "john@example.org",
+        contact_name: "John",
+        role: "CEO",
+        phone_number: "0118 999 881 999 119 7253",
+        email: "john@example.org",
       }
     end
 
@@ -69,7 +69,7 @@ RSpec.describe CoronavirusForm::ContactDetailsController, type: :controller do
     it "does not require role" do
       post :submit, params: params.except("role")
 
-      expect(session[session_key]).to eq contact_details.merge("role" => nil)
+      expect(session[session_key]).to eq contact_details.merge(role: nil)
       expect(response).to redirect_to(check_your_answers_path)
     end
 

--- a/spec/controllers/coronavirus_form/medical_equipment_type_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/medical_equipment_type_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe CoronavirusForm::MedicalEquipmentTypeController, type: :controlle
     it "sets session variables" do
       post :submit, params: { medical_equipment_type: selected }
 
-      expect(session[session_key][0]["medical_equipment_type"]).to eq selected
+      expect(session[session_key][0][:medical_equipment_type]).to eq selected
     end
 
     it "redirects to next step" do
@@ -73,8 +73,8 @@ RSpec.describe CoronavirusForm::MedicalEquipmentTypeController, type: :controlle
           action: :show,
           params: { product_id: "abcd1234" },
         )
-        expect(session[session_key][0]["medical_equipment_type"]).to eq "Other"
-        expect(session[session_key][0]["medical_equipment_type_other"]).to eq "Demo text"
+        expect(session[session_key][0][:medical_equipment_type]).to eq "Other"
+        expect(session[session_key][0][:medical_equipment_type_other]).to eq "Demo text"
       end
     end
 

--- a/spec/helpers/check_answers_helper_spec.rb
+++ b/spec/helpers/check_answers_helper_spec.rb
@@ -3,26 +3,26 @@ require "spec_helper"
 RSpec.describe CheckAnswersHelper, type: :helper do
   let(:answers_to_skippable_questions) do
     {
-      "are_you_a_manufacturer" => [
+      are_you_a_manufacturer: [
         I18n.t("coronavirus_form.questions.are_you_a_manufacturer.options.manufacturer.label"),
       ],
-      "additional_product" => I18n.t("coronavirus_form.questions.additional_product.options.option_no.label"),
-      "hotel_rooms_number" => "100",
-      "transport_type" => [
+      additional_product: I18n.t("coronavirus_form.questions.additional_product.options.option_no.label"),
+      hotel_rooms_number: "100",
+      transport_type: [
         I18n.t("coronavirus_form.questions.transport_type.options.moving_people.label"),
       ],
-      "offer_space_type" => I18n.t("coronavirus_form.questions.offer_space_type.options.warehouse_space.label"),
-      "offer_care_qualifications" => I18n.t("coronavirus_form.questions.offer_care_qualifications.options.adult_care.label"),
+      offer_space_type: I18n.t("coronavirus_form.questions.offer_space_type.options.warehouse_space.label"),
+      offer_care_qualifications: I18n.t("coronavirus_form.questions.offer_care_qualifications.options.adult_care.label"),
     }
   end
 
   let(:products) do
     {
-      "product_details" => [{
-        "medical_equipment_type" => I18n.t(
+      product_details: [{
+        medical_equipment_type: I18n.t(
           "coronavirus_form.questions.medical_equipment_type.options.number_ppe.label",
         ),
-        "product_name" => "Product name",
+        product_name: "Product name",
       }],
     }
   end
@@ -84,7 +84,7 @@ RSpec.describe CheckAnswersHelper, type: :helper do
 
     it "adds a link to delete each item" do
       helper.product_details.each do |product|
-        expect(product[:delete][:href]).to include("/product-details/#{product['product_id']}/delete")
+        expect(product[:delete][:href]).to include("/product-details/#{product[:product_id]}/delete")
       end
     end
   end
@@ -92,43 +92,43 @@ RSpec.describe CheckAnswersHelper, type: :helper do
   describe "#product_info" do
     it "concatenates product information with a line break" do
       product = {
-        "medical_equipment_type" => I18n.t(
+        medical_equipment_type: I18n.t(
           "coronavirus_form.questions.medical_equipment_type.options.number_ppe.label",
         ),
-        "product_name" => "Product name",
-        "equipment_type" => "Equipment type",
-        "product_quantity" => 100,
-        "product_cost" => 5,
-        "certification_details" => "Certification",
-        "product_location" => "UK",
-        "product_postcode" => "E1 8QS",
-        "product_url" => "https://www.example.com",
-        "lead_time" => 5,
+        product_name: "Product name",
+        equipment_type: "Equipment type",
+        product_quantity: 100,
+        product_cost: 5,
+        certification_details: "Certification",
+        product_location: "UK",
+        product_postcode: "E1 8QS",
+        product_url: "https://www.example.com",
+        lead_time: 5,
       }
 
-      expected_answer = "Type: #{product['medical_equipment_type']}<br>" \
-                          "Product: #{product['product_name']}<br>" \
-                          "Equipment type: #{product['equipment_type']}<br>" \
-                          "Quantity: #{product['product_quantity']}<br>" \
-                          "Cost: #{product['product_cost']}<br>" \
-                          "Certification details: #{product['certification_details']}<br>" \
-                          "Location: #{product['product_location']}<br>" \
-                          "Postcode: #{product['product_postcode']}<br>" \
-                          "URL: #{product['product_url']}<br>" \
-                          "Lead time: #{product['lead_time']}"
+      expected_answer = "Type: #{product[:medical_equipment_type]}<br>" \
+                          "Product: #{product[:product_name]}<br>" \
+                          "Equipment type: #{product[:equipment_type]}<br>" \
+                          "Quantity: #{product[:product_quantity]}<br>" \
+                          "Cost: #{product[:product_cost]}<br>" \
+                          "Certification details: #{product[:certification_details]}<br>" \
+                          "Location: #{product[:product_location]}<br>" \
+                          "Postcode: #{product[:product_postcode]}<br>" \
+                          "URL: #{product[:product_url]}<br>" \
+                          "Lead time: #{product[:lead_time]}"
 
       expect(helper.product_info(product)).to eq(expected_answer)
     end
 
     it "only concatenates the fields that have a value" do
       product = {
-        "medical_equipment_type" => I18n.t(
+        medical_equipment_type: I18n.t(
           "coronavirus_form.questions.medical_equipment_type.options.number_ppe.label",
         ),
-        "product_name" => "Product name",
+        product_name: "Product name",
       }
 
-      expected_answer = "Type: #{product['medical_equipment_type']}<br>Product: #{product['product_name']}"
+      expected_answer = "Type: #{product[:medical_equipment_type]}<br>Product: #{product[:product_name]}"
       expect(helper.product_info(product)).to eq(expected_answer)
     end
   end
@@ -183,17 +183,17 @@ RSpec.describe CheckAnswersHelper, type: :helper do
 
       it "concatenates contact_details with a line break" do
         answer = {
-          "contact_name" => "Snow White",
-          "role" => "COO",
-          "phone_number" => "012101234567",
-          "email" => "me@example.com",
+          contact_name: "Snow White",
+          role: "COO",
+          phone_number: "012101234567",
+          email: "me@example.com",
         }
 
         expected_answer =
-          "Name: #{answer['contact_name']}<br>" \
-            "Role: #{answer['role']}<br>" \
-            "Phone number: #{answer['phone_number']}<br>" \
-            "Email: #{answer['email']}"
+          "Name: #{answer[:contact_name]}<br>" \
+            "Role: #{answer[:role]}<br>" \
+            "Phone number: #{answer[:phone_number]}<br>" \
+            "Email: #{answer[:email]}"
 
         expect(helper.concat_answer(answer, question)).to eq(expected_answer)
       end
@@ -206,10 +206,10 @@ RSpec.describe CheckAnswersHelper, type: :helper do
 
       it "only concatenates the fields that have a value" do
         answer = {
-          "email" => "me@example.com",
+          email: "me@example.com",
         }
 
-        expected_answer = "Email: #{answer['email']}"
+        expected_answer = "Email: #{answer[:email]}"
         expect(helper.concat_answer(answer, question)).to eq(expected_answer)
       end
     end
@@ -219,19 +219,19 @@ RSpec.describe CheckAnswersHelper, type: :helper do
 
       it "concatenates business_details with a line break" do
         answer = {
-          "company_name" => "Snow White Inc",
-          "company_number" => rand(10),
-          "company_size" => 1000,
-          "company_location" => "UK",
-          "company_postcode" => "E1 8QS",
+          company_name: "Snow White Inc",
+          company_number: rand(10),
+          company_size: 1000,
+          company_location: "UK",
+          company_postcode: "E1 8QS",
         }
 
         expected_answer =
-          "Company name: #{answer['company_name']}<br>" \
-            "Company number: #{answer['company_number']}<br>" \
-            "Company size number: #{answer['company_size']}<br>" \
-            "Company location: #{answer['company_location']}<br>" \
-            "Company postcode: #{answer['company_postcode']}"
+          "Company name: #{answer[:company_name]}<br>" \
+            "Company number: #{answer[:company_number]}<br>" \
+            "Company size number: #{answer[:company_size]}<br>" \
+            "Company location: #{answer[:company_location]}<br>" \
+            "Company postcode: #{answer[:company_postcode]}"
 
         expect(helper.concat_answer(answer, question)).to eq(expected_answer)
       end
@@ -244,10 +244,10 @@ RSpec.describe CheckAnswersHelper, type: :helper do
 
       it "only concatenates the fields that have a value" do
         answer = {
-          "company_name" => "Snow White Inc",
+          company_name: "Snow White Inc",
         }
 
-        expected_answer = "Company name: #{answer['company_name']}"
+        expected_answer = "Company name: #{answer[:company_name]}"
         expect(helper.concat_answer(answer, question)).to eq(expected_answer)
       end
     end
@@ -257,9 +257,9 @@ RSpec.describe CheckAnswersHelper, type: :helper do
 
       it "concates other hash questions" do
         answer = {
-          "one" => "One",
-          "two" => "Two",
-          "three" => "Three",
+          one: "One",
+          two: "Two",
+          three: "Three",
         }
 
         expected_answer = "One Two Three"


### PR DESCRIPTION
We are currently saving invalid responses to the session hash before doing validations.  We need to validate first, but still replay the invalid response back to the user.  This also removes all use of the session hash out of the views.

As a side effect of this change we have resolved all string vs symbols issues for the stored values, using symbols in all places now.

This change was made for the vulnerable people registration service in https://github.com/alphagov/govuk-coronavirus-vulnerable-people-form/pull/230.

Whilst this looks like a lot of lines changed, it is mostly the same amendment but in multiple places.

Trello card: https://trello.com/c/PygFKz9a