### PR TITLE
Access products with indifferent access

### DIFF
--- a/app/helpers/product_helper.rb
+++ b/app/helpers/product_helper.rb
@@ -1,9 +1,7 @@
 module ProductHelper
   def add_product_to_session(product)
     session[:product_details] ||= []
-    products = session[:product_details].reject do |prod|
-      prod[:product_id] == product[:product_id]
-    end
+    products = products_except(product.with_indifferent_access[:product_id])
     session[:product_details] = products << product
   end
 
@@ -17,7 +15,11 @@ module ProductHelper
 
   def remove_product_from_session(product_id)
     session[:product_details] ||= []
-    session[:product_details] = session[:product_details].reject do |prod|
+    session[:product_details] = products_except(product_id)
+  end
+
+  def products_except(product_id)
+    session.to_h.with_indifferent_access[:product_details].reject do |prod|
       prod[:product_id] == product_id
     end
   end


### PR DESCRIPTION
This will prevent issues when using strings or symbols for keys in the product hashes that we store in the session.

https://trello.com/c/5uLlrPfX/184