### PR TITLE
Add Character count to 'other support' form

### DIFF
--- a/app/views/coronavirus_form/offer_other_support.html.erb
+++ b/app/views/coronavirus_form/offer_other_support.html.erb
@@ -14,15 +14,18 @@
   "novalidate": "true"
 ) do %>
 
-<%= render "govuk_publishing_components/components/textarea", {
-  label: {
-    is_page_heading: true,
-    heading_size: "xl",
-    text: t('coronavirus_form.questions.offer_other_support.title')
-  },
-  hint: t('coronavirus_form.questions.offer_other_support.hint'),
-  name: "offer_other_support",
-  value: @form_responses[:offer_other_support]
-} %>
+  <%= render "govuk_publishing_components/components/character_count", {
+    textarea: {
+      label: {
+        is_page_heading: true,
+        heading_size: "xl",
+        text: t('coronavirus_form.questions.offer_other_support.title')
+      },
+      hint: t('coronavirus_form.questions.offer_other_support.hint'),
+      name: "offer_other_support",
+      value: @form_responses[:offer_other_support]
+    },
+    maxlength: 1000
+  } %>
 <%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
 <% end %>


### PR DESCRIPTION
This PR adds a character count component to screen 9 - 'Can you offer any other kind of support?'

<img width="600" alt="Screenshot 2020-04-08 at 15 50 21" src="https://user-images.githubusercontent.com/41922771/78798337-c4222b00-79b0-11ea-86da-0d0f1bb53c78.png">

<img width="634" alt="Screenshot 2020-04-08 at 15 50 37" src="https://user-images.githubusercontent.com/41922771/78798332-c2586780-79b0-11ea-8cb1-16d448f97431.png">

It also ensures a user gets an error should they exceed the 1000 character count limit.