### PR TITLE
Add link to DHSC forms

### DIFF
--- a/app/controllers/coronavirus_form/medical_equipment_type_controller.rb
+++ b/app/controllers/coronavirus_form/medical_equipment_type_controller.rb
@@ -24,6 +24,9 @@ class CoronavirusForm::MedicalEquipmentTypeController < ApplicationController
       flash.now[:validation] = invalid_fields
       log_validation_error(invalid_fields)
       render controller_path
+    elsif selected_testing_equipment?
+      add_product_to_session(@product)
+      redirect_to testing_equipment_url
     else
       add_product_to_session(@product)
       redirect_to product_details_url(product_id: @product[:product_id])
@@ -34,6 +37,12 @@ private
 
   def selected_other?(medical_equipment_type)
     medical_equipment_type == I18n.t("coronavirus_form.questions.#{controller_name}.options.other.label")
+  end
+
+  def selected_testing_equipment?
+    @product[:medical_equipment_type] == I18n.t(
+      "coronavirus_form.questions.medical_equipment_type.options.number_testing_equipment.label",
+    )
   end
 
   def previous_path

--- a/app/controllers/coronavirus_form/testing_equipment_controller.rb
+++ b/app/controllers/coronavirus_form/testing_equipment_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CoronavirusForm::TestingEquipmentController < ApplicationController
+  def show
+    super
+  end
+
+private
+
+  def previous_path
+    return check_your_answers_url if session["check_answers_seen"]
+
+    medical_equipment_type_url
+  end
+end

--- a/app/views/coronavirus_form/testing_equipment.html.erb
+++ b/app/views/coronavirus_form/testing_equipment.html.erb
@@ -1,0 +1,25 @@
+<% content_for :title do %><%= t('coronavirus_form.testing_equipment.title') %><% end %>
+<% content_for :meta_tags do %>
+  <meta name="description" content="<%= t('coronavirus_form.testing_equipment.title') %>" />
+<% end %>
+
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", { href: previous_path } %>
+<% end %>
+
+<%= render "govuk_publishing_components/components/title", {
+  title: t('coronavirus_form.testing_equipment.title'),
+  margin_top: 0
+} %>
+
+<p class="govuk-body govuk-!-margin-bottom-8">
+  <a class="govuk-link" href="<%= t('coronavirus_form.testing_equipment.external_link') %>" target="_blank">
+    <%= t('coronavirus_form.testing_equipment.link.label') %>
+  </a>
+</p>
+
+<%= render "govuk_publishing_components/components/button", {
+  text: t('coronavirus_form.testing_equipment.button.label'),
+  href: additional_product_url,
+  margin_bottom: true
+} %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -99,6 +99,13 @@ en:
       date_order: "The end date must be after the start date"
       email_format: "Enter an email address in the correct format, like name@example.com"
       postcode_format: "Enter a real postcode"
+    testing_equipment:
+      title: "Testing equipment"
+      button:
+        label: "Continue offering other services"
+      link:
+        label: "Offer testing equipment (opens in a new tab)"
+      external_link: "https://www.gov.uk/guidance/help-the-government-increase-coronavirus-covid-19-testing-capacity"
     questions:
       medical_equipment:
         title: "Can you offer medical equipment?"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,10 @@ Rails.application.routes.draw do
     get "/product-details/:id/delete", to: "product_details#destroy"
     post "/product-details", to: "product_details#submit"
 
-    # Question 1.4: Can you offer another product?
+    # Question 1.4: Testing equipment
+    get "/testing-equipment", to: "testing_equipment#show"
+
+    # Question 1.5: Can you offer another product?
     get "/additional-product", to: "additional_product#show"
     post "/additional-product", to: "additional_product#submit"
 


### PR DESCRIPTION
Compromise fix to link to DHSC forms in order to maintain the full CTA.  

Pending a long-term fix.

- Given I've checked 'Testing equipment'
- When I go to 'Tell us more about this product'
- Then I should see a new page with a link to [here](https://www.gov.uk/guidance/help-the-government-increase-coronavirus-covid-19-testing-capacity) - clicking on the "Continue..." button takes you to "Can you offer another product?".

Trello: https://trello.com/c/kvauoDPX/185-add-link-to-dhsc-forms