### PR TITLE
Add missing Feature test for Testing Equipment page

### DIFF
--- a/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
+++ b/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
@@ -35,6 +35,15 @@ RSpec.feature "fill in the business volunteer form" do
     end
   end
 
+  scenario "Fill in the form with Testing Equipment" do
+    given_a_business_during_the_covid_19_pandemic
+    that_can_offer_medical_equipment
+    and_is_a_manufacturer_a_distributor_and_agent
+    and_can_offer_testing_equipment
+    then_they_see_the_external_testing_equipment_link
+    and_can_navigate_back_to_offer_another_product
+  end
+
   scenario "ensure we can perform a healthcheck" do
     visit healthcheck_path
 

--- a/spec/support/fill_in_the_form_steps.rb
+++ b/spec/support/fill_in_the_form_steps.rb
@@ -41,6 +41,22 @@ module FillInTheFormSteps
     click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
+  def and_can_offer_testing_equipment
+    choose I18n.t("coronavirus_form.questions.medical_equipment_type.options.number_testing_equipment.label")
+    click_on "Continue"
+  end
+
+  def then_they_see_the_external_testing_equipment_link
+    link = I18n.t("coronavirus_form.testing_equipment.external_link")
+    expect(page.body).to have_content(I18n.t("coronavirus_form.testing_equipment.link.label"))
+    expect(page.body).to have_selector(:css, "a[href='#{link}']")
+  end
+
+  def and_can_navigate_back_to_offer_another_product
+    click_on I18n.t("coronavirus_form.testing_equipment.button.label")
+    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.additional_product.title"))
+  end
+
   def and_has_other_medical_equipment_available
     expect(page.body).to have_content(I18n.t("coronavirus_form.questions.additional_product.title"))
     choose I18n.t("coronavirus_form.questions.additional_product.options.option_yes.label")
@@ -94,7 +110,7 @@ module FillInTheFormSteps
     choose I18n.t("coronavirus_form.questions.offer_space.options.option_yes.label")
     click_on I18n.t("coronavirus_form.submit_and_next")
 
-    expect(page).to have_content(I18n.t("coronavirus_form.questions.offer_space_type.title"))
+    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.offer_space_type.title"))
     check I18n.t("coronavirus_form.questions.offer_space_type.options.warehouse_space.label")
     fill_in "warehouse_space_description", with: "1000"
     check I18n.t("coronavirus_form.questions.offer_space_type.options.office_space.label")


### PR DESCRIPTION
A page for businesses who are offering Testing Equipment with internal and an
external DHSC link, has been added.  However, it was added without a test.

This change adds the missing test.

Trello: https://trello.com/c/kvauoDPX/185-add-link-to-dhsc-forms