### PR TITLE
Confirmation emails

### DIFF
--- a/app/controllers/coronavirus_form/check_answers_controller.rb
+++ b/app/controllers/coronavirus_form/check_answers_controller.rb
@@ -12,6 +12,9 @@ class CoronavirusForm::CheckAnswersController < ApplicationController
     session[:reference_number] = submission_reference
     FormResponse.create(form_response: session)
 
+    mailer = CoronavirusFormMailer.with(name: session.dig(:contact_details, :contact_name))
+    mailer.thank_you(session.dig(:contact_details, :email)).deliver_later
+
     reset_session
 
     redirect_to thank_you_url(reference_number: submission_reference)

--- a/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
@@ -37,6 +37,18 @@ RSpec.describe CoronavirusForm::CheckAnswersController, type: :controller do
       )
     end
 
+    it "sends an email" do
+      ActiveJob::Base.queue_adapter = :test
+      session[:contact_details] = {
+        contact_name: "Harry Potter",
+        email: "harry@example.org",
+      }
+      expect {
+        post :submit
+      }.to have_enqueued_mail(CoronavirusFormMailer, :thank_you)
+        .with(a_hash_including(name: "Harry Potter"), "harry@example.org").on_queue("mailers")
+    end
+
     it "resets session" do
       post :submit
       expect(session.to_hash).to eq({})


### PR DESCRIPTION
Should be merged after 3a099627d9c2d8e9fb061cf01aba1ea69170c41b is deployed.

This will send an email to people. We need to first merge the above commit,
and add the required secrets so they can be picked up as envvars.

https://trello.com/c/PFxx7Q7I/148-send-confirmation-email-to-users-upon-completion-business-form

Co-Authored-By: @GDSNewt 