### PR TITLE
Fix paths and i18n in feature tests

### DIFF
--- a/app/views/coronavirus_form/additional_product.html.erb
+++ b/app/views/coronavirus_form/additional_product.html.erb
@@ -31,5 +31,5 @@
     },
   ]
 } %>
-<%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
+<%= render "govuk_publishing_components/components/button", text: t("coronavirus_form.submit_and_next"), margin_bottom: true %>
 <% end %>

--- a/app/views/coronavirus_form/are_you_a_manufacturer.html.erb
+++ b/app/views/coronavirus_form/are_you_a_manufacturer.html.erb
@@ -27,5 +27,5 @@
     }
   end
 } %>
-<%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
+<%= render "govuk_publishing_components/components/button", text: t("coronavirus_form.submit_and_next"), margin_bottom: true %>
 <% end %>

--- a/app/views/coronavirus_form/business_details.html.erb
+++ b/app/views/coronavirus_form/business_details.html.erb
@@ -79,5 +79,5 @@
   end
 } %>
 
-<%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
+<%= render "govuk_publishing_components/components/button", text: t("coronavirus_form.submit_and_next"), margin_bottom: true %>
 <% end %>

--- a/app/views/coronavirus_form/contact_details.html.erb
+++ b/app/views/coronavirus_form/contact_details.html.erb
@@ -55,5 +55,5 @@
   type: "email"
 } %>
 
-<%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
+<%= render "govuk_publishing_components/components/button", text: t("coronavirus_form.submit_and_next"), margin_bottom: true %>
 <% end %>

--- a/app/views/coronavirus_form/expert_advice_type.html.erb
+++ b/app/views/coronavirus_form/expert_advice_type.html.erb
@@ -77,5 +77,5 @@
         },
       ],
     }%>
-    <%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
+    <%= render "govuk_publishing_components/components/button", text: t("coronavirus_form.submit_and_next"), margin_bottom: true %>
     <% end %>

--- a/app/views/coronavirus_form/hotel_rooms.html.erb
+++ b/app/views/coronavirus_form/hotel_rooms.html.erb
@@ -26,5 +26,5 @@
     }
   end
 } %>
-<%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
+<%= render "govuk_publishing_components/components/button", text: t("coronavirus_form.submit_and_next"), margin_bottom: true %>
 <% end %>

--- a/app/views/coronavirus_form/hotel_rooms_number.html.erb
+++ b/app/views/coronavirus_form/hotel_rooms_number.html.erb
@@ -26,5 +26,5 @@
   value: @form_responses[:hotel_rooms_number],
   error_message: error_items("hotel_rooms_number")
 } %>
-<%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
+<%= render "govuk_publishing_components/components/button", text: t("coronavirus_form.submit_and_next"), margin_bottom: true %>
 <% end %>

--- a/app/views/coronavirus_form/location.html.erb
+++ b/app/views/coronavirus_form/location.html.erb
@@ -27,5 +27,5 @@
     }
   end
 } %>
-<%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
+<%= render "govuk_publishing_components/components/button", text: t("coronavirus_form.submit_and_next"), margin_bottom: true %>
 <% end %>

--- a/app/views/coronavirus_form/medical_equipment.html.erb
+++ b/app/views/coronavirus_form/medical_equipment.html.erb
@@ -26,5 +26,5 @@
     }
   end
 } %>
-<%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
+<%= render "govuk_publishing_components/components/button", text: t("coronavirus_form.submit_and_next"), margin_bottom: true %>
 <% end %>

--- a/app/views/coronavirus_form/medical_equipment_type.html.erb
+++ b/app/views/coronavirus_form/medical_equipment_type.html.erb
@@ -45,5 +45,5 @@
     },
   ]
 } %>
-<%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
+<%= render "govuk_publishing_components/components/button", text: t("coronavirus_form.submit_and_next"), margin_bottom: true %>
 <% end %>

--- a/app/views/coronavirus_form/offer_care.html.erb
+++ b/app/views/coronavirus_form/offer_care.html.erb
@@ -27,5 +27,5 @@
     }
   end
 } %>
-<%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
+<%= render "govuk_publishing_components/components/button", text: t("coronavirus_form.submit_and_next"), margin_bottom: true %>
 <% end %>

--- a/app/views/coronavirus_form/offer_care_qualifications.erb
+++ b/app/views/coronavirus_form/offer_care_qualifications.erb
@@ -68,5 +68,5 @@
       },
     ]
   } %>
-  <%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
+  <%= render "govuk_publishing_components/components/button", text: t("coronavirus_form.submit_and_next"), margin_bottom: true %>
 <% end %>

--- a/app/views/coronavirus_form/offer_other_support.html.erb
+++ b/app/views/coronavirus_form/offer_other_support.html.erb
@@ -27,5 +27,5 @@
     },
     maxlength: 1000
   } %>
-<%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
+<%= render "govuk_publishing_components/components/button", text: t("coronavirus_form.submit_and_next"), margin_bottom: true %>
 <% end %>

--- a/app/views/coronavirus_form/offer_space.html.erb
+++ b/app/views/coronavirus_form/offer_space.html.erb
@@ -27,5 +27,5 @@
     }
   end
 } %>
-<%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
+<%= render "govuk_publishing_components/components/button", text: t("coronavirus_form.submit_and_next"), margin_bottom: true %>
 <% end %>

--- a/app/views/coronavirus_form/offer_space_type.erb
+++ b/app/views/coronavirus_form/offer_space_type.erb
@@ -76,5 +76,5 @@
     error_message: error_items("general_space_description"),
     value: @form_responses[:general_space_description]
   } %>
-  <%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
+  <%= render "govuk_publishing_components/components/button", text: t("coronavirus_form.submit_and_next"), margin_bottom: true %>
 <% end %>

--- a/app/views/coronavirus_form/offer_transport.html.erb
+++ b/app/views/coronavirus_form/offer_transport.html.erb
@@ -26,5 +26,5 @@
     }
   end
 } %>
-<%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
+<%= render "govuk_publishing_components/components/button", text: t("coronavirus_form.submit_and_next"), margin_bottom: true %>
 <% end %>

--- a/app/views/coronavirus_form/product_details.html.erb
+++ b/app/views/coronavirus_form/product_details.html.erb
@@ -130,5 +130,5 @@
   value: @product[:lead_time],
   width: 10,
 } %>
-<%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
+<%= render "govuk_publishing_components/components/button", text: t("coronavirus_form.submit_and_next"), margin_bottom: true %>
 <% end %>

--- a/app/views/coronavirus_form/transport_type.html.erb
+++ b/app/views/coronavirus_form/transport_type.html.erb
@@ -38,5 +38,5 @@
   value: @form_responses[:transport_description]
 } %>
 
-<%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
+<%= render "govuk_publishing_components/components/button", text: t("coronavirus_form.submit_and_next"), margin_bottom: true %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,6 +85,7 @@ en:
       <p class="govuk-body">Your session has ended because you have not done anything for 4 hours. You'll have to start again.</p>
       <p class="govuk-body">We do this for your security. We've deleted all the details you entered to protect your data.</p>
   coronavirus_form:
+    submit_and_next: "Continue"
     errors:
       heading: "There is a problem"
       radio_field: "Select %{field}"

--- a/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
+++ b/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
@@ -32,18 +32,18 @@ RSpec.feature "Fill in the form" do
   scenario "Ensure the privacy notice page is visible" do
     visit privacy_path
 
-    expect(page).to have_content("Privacy")
+    expect(page).to have_content(I18n.t("privacy_page.title"))
   end
 
   scenario "Ensure the accessibility statement page is visible" do
     visit accessibility_statement_path
 
-    expect(page).to have_content("Accessibility statement")
+    expect(page).to have_content(I18n.t("accessibility_statement.title"))
   end
 
   scenario "Ensure the session expired page is visible" do
     visit session_expired_path
 
-    expect(page).to have_content("Your session has ended due to inactivity")
+    expect(page).to have_content(I18n.t("session_expired.title"))
   end
 end

--- a/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
+++ b/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
@@ -24,25 +24,25 @@ RSpec.feature "Fill in the form" do
   end
 
   scenario "Ensure we can perform a healthcheck" do
-    visit "/healthcheck"
+    visit healthcheck_path
 
     expect(page).to have_content("OK")
   end
 
   scenario "Ensure the privacy notice page is visible" do
-    visit "/privacy"
+    visit privacy_path
 
     expect(page).to have_content("Privacy")
   end
 
   scenario "Ensure the accessibility statement page is visible" do
-    visit "/accessibility-statement"
+    visit accessibility_statement_path
 
     expect(page).to have_content("Accessibility statement")
   end
 
   scenario "Ensure the session expired page is visible" do
-    visit "/session-expired"
+    visit session_expired_path
 
     expect(page).to have_content("Your session has ended due to inactivity")
   end

--- a/spec/support/fill_in_the_form_steps.rb
+++ b/spec/support/fill_in_the_form_steps.rb
@@ -2,7 +2,7 @@
 
 module FillInTheFormSteps
   def given_a_business_during_the_covid_19_pandemic
-    visit "/medical-equipment"
+    visit medical_equipment_path
   end
 
   def that_can_offer_medical_equipment

--- a/spec/support/fill_in_the_form_steps.rb
+++ b/spec/support/fill_in_the_form_steps.rb
@@ -6,174 +6,174 @@ module FillInTheFormSteps
   end
 
   def that_can_offer_medical_equipment
-    expect(page).to have_content("Can you offer medical equipment?")
-    choose "Yes"
-    click_on "Continue"
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.medical_equipment.title"))
+    choose I18n.t("coronavirus_form.questions.medical_equipment.options.option_yes.label")
+    click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
   def and_is_a_manufacturer_a_distributor_and_agent
-    expect(page).to have_content("What kind of business are you?")
-    check "Manufacturer"
-    check "Distributor"
-    check "Agent"
-    click_on "Continue"
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.are_you_a_manufacturer.title"))
+    check I18n.t("coronavirus_form.questions.are_you_a_manufacturer.options.manufacturer.label")
+    check I18n.t("coronavirus_form.questions.are_you_a_manufacturer.options.distributor.label")
+    check I18n.t("coronavirus_form.questions.are_you_a_manufacturer.options.agent.label")
+    click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
   def and_has_personal_protection_equipment_available
-    expect(page).to have_content("Tell us about the medical equipment you can offer")
-    choose "Personal protection equipment"
-    click_on "Continue"
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.medical_equipment_type.title"))
+    choose I18n.t("coronavirus_form.questions.medical_equipment_type.options.number_ppe.label")
+    click_on I18n.t("coronavirus_form.submit_and_next")
 
-    expect(page).to have_content("Tell us about the product you’re offering")
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.product_details.title"))
     fill_in "product_name", with: "Testing"
-    choose "Type IIR face masks"
+    choose I18n.t("coronavirus_form.questions.product_details.equipment_type.options.iir_face_masks.label")
     fill_in "product_quantity", with: "500"
     fill_in "product_cost", with: "0"
     fill_in "certification_details", with: "CE marking"
-    choose "United Kingdom"
+    choose I18n.t("coronavirus_form.questions.product_details.product_location.options.option_uk.label")
     fill_in "product_postcode", with: "E1 8QS"
     fill_in "product_url", with: "https://example.com"
     fill_in "lead_time", with: "10"
-    click_on "Continue"
+    click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
   def and_has_other_medical_equipment_available
-    expect(page).to have_content("Can you offer another product?")
-    choose "Yes"
-    click_on "Continue"
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.additional_product.title"))
+    choose I18n.t("coronavirus_form.questions.additional_product.options.option_yes.label")
+    click_on I18n.t("coronavirus_form.submit_and_next")
 
-    expect(page).to have_content("Tell us about the medical equipment you can offer")
-    choose "Other"
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.medical_equipment_type.title"))
+    choose I18n.t("coronavirus_form.questions.medical_equipment_type.options.other.label")
     fill_in "medical_equipment_type_other", with: "Some text about medical equipment"
-    click_on "Continue"
+    click_on I18n.t("coronavirus_form.submit_and_next")
 
     fill_in "product_name", with: "Testing"
     fill_in "product_quantity", with: "500"
     fill_in "product_cost", with: "0"
     fill_in "certification_details", with: "CE marking"
-    choose "United Kingdom"
+    choose I18n.t("coronavirus_form.questions.product_details.product_location.options.option_uk.label")
     fill_in "product_postcode", with: "E1 8QS"
     fill_in "product_url", with: "https://example.com"
     fill_in "lead_time", with: "10"
-    click_on "Continue"
+    click_on I18n.t("coronavirus_form.submit_and_next")
 
-    expect(page).to have_content("Can you offer another product?")
-    choose "No"
-    click_on "Continue"
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.additional_product.title"))
+    choose I18n.t("coronavirus_form.questions.additional_product.options.option_no.label")
+    click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
   def and_can_offer_hotel_rooms
-    expect(page).to have_content("Can you offer hotel rooms?")
-    choose "Yes – for any use"
-    click_on "Continue"
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.hotel_rooms.title"))
+    choose I18n.t("coronavirus_form.questions.hotel_rooms.options.yes_all_uses.label")
+    click_on I18n.t("coronavirus_form.submit_and_next")
 
-    expect(page).to have_content("How many hotel rooms can you offer?")
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.hotel_rooms_number.title"))
     fill_in "hotel_rooms_number", with: "500"
-    click_on "Continue"
+    click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
   def and_can_offer_transport_or_logistics
-    expect(page).to have_content("Can you offer transport or logistics?")
-    choose "Yes"
-    click_on "Continue"
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.offer_transport.title"))
+    choose I18n.t("coronavirus_form.questions.offer_transport.options.option_yes.label")
+    click_on I18n.t("coronavirus_form.submit_and_next")
 
-    expect(page).to have_content("What kind of services can you offer?")
-    check "Moving people"
-    check "Moving goods"
-    check "Other"
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.transport_type.title"))
+    check I18n.t("coronavirus_form.questions.transport_type.options.moving_people.label")
+    check I18n.t("coronavirus_form.questions.transport_type.options.moving_goods.label")
+    check I18n.t("coronavirus_form.questions.transport_type.options.other.label")
     fill_in "transport_description", with: "Testing"
-    click_on "Continue"
+    click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
   def and_can_offer_space
-    expect(page).to have_content("Can you offer space?")
-    choose "Yes"
-    click_on "Continue"
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.offer_space.title"))
+    choose I18n.t("coronavirus_form.questions.offer_space.options.option_yes.label")
+    click_on I18n.t("coronavirus_form.submit_and_next")
 
-    expect(page).to have_content("What kind of space can you offer?")
-    check "Warehouse space"
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.offer_space_type.title"))
+    check I18n.t("coronavirus_form.questions.offer_space_type.options.warehouse_space.label")
     fill_in "warehouse_space_description", with: "1000"
-    check "Office space"
+    check I18n.t("coronavirus_form.questions.offer_space_type.options.office_space.label")
     fill_in "office_space_description", with: "1000"
-    check "Other"
+    check I18n.t("coronavirus_form.questions.offer_space_type.options.other.label")
     fill_in "offer_space_type_other", with: "1000"
     fill_in "general_space_description", with: "Testing"
-    click_on "Continue"
+    click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
   def and_can_offer_all_types_of_expertise
-    expect(page).to have_content("What kind of expertise can you offer?")
-    check "Medical"
-    check "Engineering"
-    check "Construction"
-    check "Project management or procurement"
-    check "IT services"
-    check "Manufacturing"
-    check "Other"
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.expert_advice_type.title"))
+    check I18n.t("coronavirus_form.questions.expert_advice_type.options.medical.label")
+    check I18n.t("coronavirus_form.questions.expert_advice_type.options.engineering.label")
+    check I18n.t("coronavirus_form.questions.expert_advice_type.options.construction.label")
+    check I18n.t("coronavirus_form.questions.expert_advice_type.options.project_management.label")
+    check I18n.t("coronavirus_form.questions.expert_advice_type.options.it.label")
+    check I18n.t("coronavirus_form.questions.expert_advice_type.options.manufacturing.label")
+    check I18n.t("coronavirus_form.questions.expert_advice_type.options.other.label")
     fill_in "expert_advice_type_other", with: "Testing"
-    click_on "Continue"
+    click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
   def and_can_offer_all_kinds_of_social_and_child_care
-    expect(page).to have_content("Can you offer social care or childcare?")
-    choose "Yes"
-    click_on "Continue"
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.offer_care.title"))
+    choose I18n.t("coronavirus_form.questions.offer_care.options.option_yes.label")
+    click_on I18n.t("coronavirus_form.submit_and_next")
 
-    expect(page).to have_content("What kind of care can you offer?")
-    check "Care for adults"
-    check "Care for children"
-    check "DBS check"
-    check "Nursing or other healthcare qualification"
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.offer_care_qualifications.title"))
+    check I18n.t("coronavirus_form.questions.offer_care_qualifications.offer_care_type.options.adult_care.label")
+    check I18n.t("coronavirus_form.questions.offer_care_qualifications.offer_care_type.options.child_care.label")
+    check I18n.t("coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.dbs_check.label")
+    check I18n.t("coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.nursing_or_healthcare_qualification.label")
     fill_in "offer_care_qualifications_type", with: "Testing"
-    click_on "Continue"
+    click_on I18n.t("coronavirus_form.submit_and_next")
 
-    expect(page).to have_content("Can you offer any other kind of support?")
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.offer_other_support.title"))
     fill_in "offer_other_support", with: "Testing"
-    click_on "Continue"
+    click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
   def and_offers_these_across_the_uk
-    expect(page).to have_content("Where can you offer your services?")
-    check "East of England"
-    check "East Midlands"
-    check "West Midlands"
-    check "London"
-    check "North East"
-    check "North West"
-    check "South East"
-    check "South West"
-    check "Yorkshire and the Humber"
-    check "Northern Ireland"
-    check "Scotland"
-    check "Wales"
-    click_on "Continue"
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.location.title"))
+    check I18n.t("coronavirus_form.questions.location.options.east_of_england.label")
+    check I18n.t("coronavirus_form.questions.location.options.east_midlands.label")
+    check I18n.t("coronavirus_form.questions.location.options.west_midland.label")
+    check I18n.t("coronavirus_form.questions.location.options.london.label")
+    check I18n.t("coronavirus_form.questions.location.options.north_east.label")
+    check I18n.t("coronavirus_form.questions.location.options.north_west.label")
+    check I18n.t("coronavirus_form.questions.location.options.south_east.label")
+    check I18n.t("coronavirus_form.questions.location.options.south_west.label")
+    check I18n.t("coronavirus_form.questions.location.options.yorkshire.label")
+    check I18n.t("coronavirus_form.questions.location.options.northern_ireland.label")
+    check I18n.t("coronavirus_form.questions.location.options.scotland.label")
+    check I18n.t("coronavirus_form.questions.location.options.wales.label")
+    click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
   def and_has_given_their_business_details
-    expect(page).to have_content("Your business details")
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.business_details.title"))
     fill_in "company_name", with: "Government Digital Service"
     fill_in "company_number", with: "020 3451 9000"
-    choose "Under 50 people"
-    choose "United Kingdom"
+    choose I18n.t("coronavirus_form.questions.business_details.company_size.options.under_50_people.label")
+    choose I18n.t("coronavirus_form.questions.business_details.company_location.options.united_kingdom.label")
     fill_in "company_postcode", with: "E1 8QS"
-    click_on "Continue"
+    click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
   def and_has_supplied_a_contact
-    expect(page).to have_content("Contact details")
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.contact_details.title"))
     fill_in "contact_name", with: "John Doe"
     fill_in "role", with: "CEO"
     fill_in "phone_number", with: "020 1234 5678"
     fill_in "email", with: "john.doe@gds.org"
-    click_on "Continue"
+    click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
   def and_has_accepted_the_terms_and_conditions
-    expect(page).to have_content("Are you ready to send the form?")
-    click_on "Accept and send"
+    expect(page).to have_content(I18n.t("check_your_answers.title"))
+    click_on I18n.t("check_your_answers.submit")
   end
 
   def then_they_are_thanked
-    expect(page).to have_content("Thank you for offering support")
+    expect(page).to have_content(I18n.t("coronavirus_form.thank_you.title"))
   end
 end


### PR DESCRIPTION
Initially, Feature tests were added with static strings and string type URL's.  

In order to clean up and make the code more maintainable and less brittle, this change converts static strings to I18N strings and string URL's to Rails paths.