### PR TITLE
Bugfix: Init GOVUKFrontend components

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -6,3 +6,4 @@
 //= require cookies
 window.CookieSettings.start()
 window.GOVUK.analyticsInit()
+window.GOVUKFrontend.initAll()


### PR DESCRIPTION
This was erroneously removed in fa87d58f43459fe9936c444bb9b60408fdcdb225, which prevented people from seeing the conditional elements.