### PR TITLE
Fix typo in PPE option

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -177,7 +177,7 @@ en:
         hint: "Give details for one product at a time"
         options:
           number_ppe:
-            label: "Personal protection equipment, for example masks, detergent and waste bags"
+            label: "Personal protective equipment, for example masks, detergent and waste bags"
           number_testing_equipment:
             label: "Testing equipment"
           other:


### PR DESCRIPTION
Replaced "Personal protection equipment" with "Personal protective equipment".

Trello card: https://trello.com/c/g9aZheIt