### PR TITLE
Use `mini_racer` in preference to `therubyracer`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,8 +23,8 @@ end
 
 group :test do
   gem "capybara", "~> 3.32.1"
+  gem "mini_racer", "~> 0.2"
   gem "simplecov", "~> 0.16"
-  gem "therubyracer", "~> 0.12"
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,7 +142,7 @@ GEM
     jmespath (1.4.0)
     kgio (2.11.3)
     kramdown (2.1.0)
-    libv8 (3.16.14.19)
+    libv8 (7.3.492.27.1)
     link_header (0.0.8)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -171,6 +171,8 @@ GEM
     mimemagic (0.3.4)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
+    mini_racer (0.2.9)
+      libv8 (>= 6.9.411)
     minitest (5.14.0)
     msgpack (1.3.3)
     multipart-post (2.1.1)
@@ -234,7 +236,6 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     redis (4.1.3)
-    ref (2.0.0)
     regexp_parser (1.7.0)
     request_store (1.5.0)
       rack (>= 1.4)
@@ -318,9 +319,6 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     statsd-ruby (1.4.0)
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -358,6 +356,7 @@ DEPENDENCIES
   govuk_publishing_components (~> 21.41.1)
   listen (~> 3)
   lograge
+  mini_racer (~> 0.2)
   pg (~> 1)
   pry (~> 0.13.1)
   pry-rails (~> 0.3.9)
@@ -371,7 +370,6 @@ DEPENDENCIES
   scss_lint-govuk (~> 0)
   sentry-raven (~> 3.0)
   simplecov (~> 0.16)
-  therubyracer (~> 0.12)
   uglifier (~> 4.2)
 
 RUBY VERSION


### PR DESCRIPTION
The gem 'therubyracer' is dependent on an old version of libv8 with
multiple security vulnerabilities and doesn't build easily on the latest
version of macOS. Rails replaced it with the 'mini_racer' gem in the PR
rails/rails PR 29285.

Commit message shamelessly copied from https://github.com/alphagov/govuk-coronavirus-vulnerable-people-form/pull/197.

I also hit build errors with `therubyracer` on macOS Catalina while
trying to debug a flaky test, and we should be consistent with all of
these apps.