### PR TITLE
Remove whitespace from postcodes

### DIFF
--- a/app/controllers/coronavirus_form/business_details_controller.rb
+++ b/app/controllers/coronavirus_form/business_details_controller.rb
@@ -55,7 +55,7 @@ private
       company_number: strip_tags(params[:company_number]).presence,
       company_size: strip_tags(params[:company_size]).presence,
       company_location: strip_tags(params[:company_location]).presence,
-      company_postcode: strip_tags(params[:company_postcode]).presence,
+      company_postcode: strip_tags(params[:company_postcode]&.gsub(/[[:space:]]+/, "")).presence,
     }
   end
 

--- a/app/controllers/coronavirus_form/product_details_controller.rb
+++ b/app/controllers/coronavirus_form/product_details_controller.rb
@@ -96,7 +96,7 @@ private
       product_cost: strip_tags(params[:product_cost]).presence,
       certification_details: strip_tags(params[:certification_details]).presence,
       product_location: strip_tags(params[:product_location]).presence,
-      product_postcode: strip_tags(params[:product_postcode]).presence,
+      product_postcode: strip_tags(params[:product_postcode]&.gsub(/[[:space:]]+/, "")).presence,
       product_url: strip_tags(params[:product_url]).presence,
       lead_time: strip_tags(params[:lead_time]).presence,
     }

--- a/spec/controllers/coronavirus_form/business_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/business_details_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe CoronavirusForm::BusinessDetailsController, type: :controller do
         company_number: "1234",
         company_size: "under_50_people",
         company_location: "united_kingdom",
-        company_postcode: "AB1 1AA",
+        company_postcode: "AB11AA",
       }
     end
 
@@ -39,6 +39,12 @@ RSpec.describe CoronavirusForm::BusinessDetailsController, type: :controller do
       post :submit, params: params
 
       expect(session[:business_details]).to eq params
+    end
+
+    it "removes extra whitespace from the postcode" do
+      post :submit, params: params.merge(company_postcode: "AB1 1AA")
+
+      expect(session[:business_details][:company_postcode]).to eq "AB11AA"
     end
 
     it "redirects to next step" do

--- a/spec/controllers/coronavirus_form/product_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/product_details_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe CoronavirusForm::ProductDetailsController, type: :controller do
       product_cost: "£10.99",
       certification_details: "CE",
       product_location: "United Kingdom",
-      product_postcode: "SW1A 2AA",
+      product_postcode: "SW1A2AA",
       product_url: nil,
       lead_time: "2",
     }
@@ -188,8 +188,14 @@ RSpec.describe CoronavirusForm::ProductDetailsController, type: :controller do
         post :submit, params: params.merge(product_postcode: nil)
         expect(response).to render_template(current_template)
 
-        post :submit, params: params.merge(product_postcode: "SW1A 2AA")
+        post :submit, params: params.merge(product_postcode: "SW1A2AA")
         expect(response).to redirect_to(additional_product_path)
+      end
+
+      it "removes extra whitespace from the product postcode" do
+        post :submit, params: params.merge(product_postcode: "SW1A 2AA")
+
+        expect(session[:product_details].first[:product_postcode]).to eq("SW1A2AA")
       end
 
       it "validates valid text is provided" do


### PR DESCRIPTION
Trello: https://trello.com/c/hUsoCjYe

## Motivation
Users sometimes enter their postcode with extra spaces, e.g "e1 8 qs" which fails validation. This caused quite a few users to contact support.

We need to update the validator so we accept valid postcodes that are entered in the incorrect format, so users are not being rejected when they enter a valid postcode.