### PR TITLE
Fix smoke test task

### DIFF
--- a/concourse/tasks/run-smoke-tests.yml
+++ b/concourse/tasks/run-smoke-tests.yml
@@ -9,6 +9,6 @@ params:
 inputs:
   - name: govuk-coronavirus-business-volunteer-form
 run:
-  path: rails
+  path: bundle
   dir: govuk-coronavirus-business-volunteer-form
-  args: ['bundle exec rake spec:features']
+  args: ['exec rake spec:features']

--- a/concourse/tasks/run-smoke-tests.yml
+++ b/concourse/tasks/run-smoke-tests.yml
@@ -11,4 +11,4 @@ inputs:
 run:
   path: bundle
   dir: govuk-coronavirus-business-volunteer-form
-  args: ['exec rake spec:features']
+  args: ['exec', 'rake', 'spec:features']


### PR DESCRIPTION
This would run `rails 'bundle exec rake spec:features'`, but we really want `bundle 'exec rake spec:features'`.