### PR TITLE
Remove Redis from test config

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -40,6 +40,6 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
   config.analytics_tracking_id = "12345"
 
-  config.cache_store = :redis_cache_store
+  config.cache_store = :memory_store
   config.session_store :cache_store, expires_in: 4.hours, key: "_sessions_store"
 end


### PR DESCRIPTION
Use memory store instead

> If you use :memory_store, the tests should behave in the same way, but be slightly faster and not require redis to be running.