### PR TITLE
Add smoke_test environment

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -141,7 +141,7 @@ jobs:
       - task: run-smoke-tests
         file: govuk-coronavirus-business-volunteer-form/concourse/tasks/run-smoke-tests.yml
         params:
-          TEST_URL: 'https://coronavirus-business-volunteers.service.gov.uk/medical-equipment'
+          TEST_URL: 'https://coronavirus-business-volunteers.service.gov.uk'
 
   - name: export-form-responses-periodically
     plan:

--- a/concourse/tasks/run-smoke-tests.yml
+++ b/concourse/tasks/run-smoke-tests.yml
@@ -6,9 +6,10 @@ image_resource:
     tag: govuk-coronavirus-business-volunteer-form-feature-tests
 params:
   TEST_URL:
+  RAILS_ENV: smoke_test
 inputs:
   - name: govuk-coronavirus-business-volunteer-form
 run:
   path: bundle
   dir: govuk-coronavirus-business-volunteer-form
-  args: ['exec', 'rake', 'spec:features']
+  args: ['exec', 'rspec', 'spec/features']

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,7 +6,8 @@ require "rails"
 # Pick the frameworks you want:
 require "active_model/railtie"
 require "active_job/railtie"
-require "active_record/railtie"
+# Disables ActiveRecord for smoke tests
+require "active_record/railtie" unless ENV["RAILS_ENV"] == "smoke_test"
 # require "active_storage/engine"
 require "action_controller/railtie"
 # require "action_mailer/railtie"

--- a/config/environments/smoke_test.rb
+++ b/config/environments/smoke_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# The test environment is used exclusively to run your application's
+# test suite. You never need to work with it otherwise. Remember that
+# your test database is "scratch space" for the test suite and is wiped
+# and recreated between test runs. Don't rely on the data there!
+
+Rails.application.configure do
+  # Settings specified here will take precedence over those in
+  # config/application.rb.
+
+  config.cache_classes = true
+
+  # Do not eager load code on boot. This avoids loading your whole application
+  # just for the purpose of running a single test. If you are using a tool that
+  # preloads Rails for running tests, you may have to set it to true.
+  config.eager_load = false
+
+  # Configure public file server for tests with Cache-Control for performance.
+  config.public_file_server.enabled = true
+  config.public_file_server.headers = {
+    "Cache-Control" => "public, max-age=#{1.hour.to_i}",
+  }
+
+  # Show full error reports and disable caching.
+  config.consider_all_requests_local       = true
+  config.action_controller.perform_caching = false
+  config.cache_store = :null_store
+
+  # Raise exceptions instead of rendering exception templates.
+  config.action_dispatch.show_exceptions = false
+
+  # Disable request forgery protection in test environment.
+  config.action_controller.allow_forgery_protection = false
+
+  # Print deprecation notices to the stderr.
+  config.active_support.deprecation = :stderr
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,7 +15,11 @@ SimpleCov.start
 Capybara.javascript_driver = :apparition
 
 RSpec.configure do |config|
-  config.expose_dsl_globally = false
-  config.infer_spec_type_from_file_location!
-  config.use_transactional_fixtures = true
+  if ENV["RAILS_ENV"] == "smoke_test"
+    config.use_active_record = false
+  else
+    config.expose_dsl_globally = false
+    config.infer_spec_type_from_file_location!
+    config.use_transactional_fixtures = true
+  end
 end

--- a/spec/support/env.rb
+++ b/spec/support/env.rb
@@ -5,13 +5,6 @@ require "capybara/rspec"
 
 test_url = ENV["TEST_URL"]
 
-if test_url
-  Capybara.app_host = test_url
-  Capybara.run_server = false
-else
-  Capybara.server = :puma, { Silent: true }
-end
-
 Capybara.register_driver :apparition do |app|
   options = { browser_options: {}, timeout: 10, skip_image_loading: true }
   if ENV.key? "CHROME_NO_SANDBOX"
@@ -21,7 +14,6 @@ Capybara.register_driver :apparition do |app|
 end
 
 Capybara.javascript_driver = :apparition
-Capybara.use_default_driver
 Capybara.default_max_wait_time = 10
 Capybara.exact = true
 Capybara.match = :one
@@ -29,3 +21,13 @@ Capybara.match = :one
 Capybara.configure do |config|
   config.automatic_label_click = true
 end
+
+if test_url
+  Capybara.default_driver = Capybara.javascript_driver
+  Capybara.app_host = test_url
+  Capybara.run_server = false
+else
+  Capybara.server = :puma, { Silent: true }
+end
+
+Capybara.use_default_driver


### PR DESCRIPTION
This will get the smoke tests working in concourse.

This new environment will be used for smoke testing only.
E.g. `RAILS_ENV=smoke_test TEST_URL=... bundle exec rake spec:features`

A new environment is required since RSpec requires a DB to be running
and connected to in order to run the tests. We could delete the constant
ActiveRecord e.g. `Object.send(:remove_const, :ActiveRecord)`, but I decided
to use a new env that doesn't load it instead.

I applied this branch to the pipeline and ran a build with it: https://cd.gds-reliability.engineering/teams/govuk-tools/pipelines/govuk-corona-business-volunteer-form/jobs/smoke-test-staging/builds/124

Alternative approaches:

- We could use https://github.com/nulldb/nulldb rather than not requiring
  ActiveRecord
- There might be a way to use rspec/rspec-rails#2266 but I don't think it helps our situations, since we need ActiveRecord for other cases.
- Rewrite the specs using cucumber

https://trello.com/c/g66yEmsa/44-run-feature-tests-against-staging-in-the-business-volunteers-pipeline