### PR TITLE
Add extra validation for product details

### DIFF
--- a/app/controllers/coronavirus_form/product_details_controller.rb
+++ b/app/controllers/coronavirus_form/product_details_controller.rb
@@ -81,55 +81,44 @@ private
     required.each_with_object([]) do |field, invalid_fields|
       next if @product[field.to_sym].present?
 
-      invalid_fields << {
-        field: field,
-        text: t("coronavirus_form.questions.#{controller_name}.#{field}.custom_error",
-                default: t("coronavirus_form.errors.missing_mandatory_text_field",
-                           field: t("coronavirus_form.questions.#{controller_name}.#{field}.label")).humanize),
-      }
+      invalid_fields << error_response(field)
     end
   end
 
   def validate_product_quantity
-    quantity = @product[:product_quantity]
-    error_response = {
-      field: "product_quantity",
-      text: t("coronavirus_form.questions.#{controller_name}.product_quantity.custom_error"),
-    }
+    field = "product_quantity"
+    return error_response(field) unless @product[field.to_sym]
 
-    return if Integer(quantity) && Integer(quantity).positive?
+    quantity = Integer(@product[field.to_sym])
+    return if quantity && quantity.positive?
 
-    error_response
-  rescue TypeError, ArgumentError
-    error_response
+    error_response(field)
+  rescue ArgumentError
+    error_response(field)
   end
 
   def validate_product_cost
-    cost = @product[:product_cost]
-    error_response = {
-      field: "product_cost",
-      text: t("coronavirus_form.questions.#{controller_name}.product_cost.custom_error"),
-    }
+    field = "product_cost"
+    return error_response(field) unless @product[field.to_sym]
 
-    return if Float(cost) && (Float(cost).positive? || Float(cost).zero?)
+    cost = Float(@product[field.to_sym])
+    return if cost && (cost.positive? || cost.zero?)
 
-    error_response
-  rescue TypeError, ArgumentError
-    error_response
+    error_response(field)
+  rescue ArgumentError
+    error_response(field)
   end
 
   def validate_lead_time
-    days = @product[:lead_time]
-    error_response = {
-      field: "lead_time",
-      text: t("coronavirus_form.questions.#{controller_name}.lead_time.custom_error"),
-    }
+    field = "lead_time"
+    return error_response(field) unless @product[field.to_sym]
 
-    return if Integer(days) && (Integer(days).positive? || Integer(days).zero?)
+    days = Integer(@product[field.to_sym])
+    return if days && (days.positive? || days.zero?)
 
-    error_response
-  rescue TypeError, ArgumentError
-    error_response
+    error_response(field)
+  rescue ArgumentError
+    error_response(field)
   end
 
   def sanitized_product(params)
@@ -144,6 +133,15 @@ private
       product_postcode: strip_tags(params[:product_postcode]&.gsub(/[[:space:]]+/, "")).presence,
       product_url: strip_tags(params[:product_url]).presence,
       lead_time: strip_tags(params[:lead_time]&.gsub(/[,a-zA-Z]/, "")&.strip).presence,
+    }
+  end
+
+  def error_response(field)
+    {
+      field: field,
+      text: t("coronavirus_form.questions.#{controller_name}.#{field}.custom_error",
+              default: t("coronavirus_form.errors.missing_mandatory_text_field",
+                         field: t("coronavirus_form.questions.#{controller_name}.#{field}.label")).humanize),
     }
   end
 

--- a/app/controllers/coronavirus_form/product_details_controller.rb
+++ b/app/controllers/coronavirus_form/product_details_controller.rb
@@ -3,6 +3,7 @@
 class CoronavirusForm::ProductDetailsController < ApplicationController
   REQUIRED_FIELDS = %w(product_name certification_details).freeze
   TEXT_FIELDS = %w(product_name product_quantity product_cost certification_details product_postcode product_url lead_time).freeze
+  VALID_FLOAT = /^\d+\.?\d{0,2}$/.freeze
 
   def show
     session[:product_details] ||= []
@@ -102,7 +103,7 @@ private
     return error_response(field) unless @product[field.to_sym]
 
     cost = Float(@product[field.to_sym])
-    return if cost && (cost.positive? || cost.zero?)
+    return if cost && (cost.positive? || cost.zero?) && @product[field.to_sym].match?(VALID_FLOAT)
 
     error_response(field)
   rescue ArgumentError

--- a/app/controllers/coronavirus_form/product_details_controller.rb
+++ b/app/controllers/coronavirus_form/product_details_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::ProductDetailsController < ApplicationController
-  REQUIRED_FIELDS = %w(product_name certification_details lead_time).freeze
+  REQUIRED_FIELDS = %w(product_name certification_details).freeze
   TEXT_FIELDS = %w(product_name product_quantity product_cost certification_details product_postcode product_url lead_time).freeze
 
   def show
@@ -58,6 +58,7 @@ private
       validate_product_postcode,
       validate_product_quantity,
       validate_product_cost,
+      validate_lead_time,
     ].compact.flatten
   end
 
@@ -117,6 +118,20 @@ private
     error_response
   end
 
+  def validate_lead_time
+    days = @product[:lead_time]
+    error_response = {
+      field: "lead_time",
+      text: t("coronavirus_form.questions.#{controller_name}.lead_time.custom_error"),
+    }
+
+    return if Integer(days) && (Integer(days).positive? || Integer(days).zero?)
+
+    error_response
+  rescue TypeError, ArgumentError
+    error_response
+  end
+
   def sanitized_product(params)
     {
       product_id: strip_tags(params[:product_id]).presence || SecureRandom.uuid,
@@ -128,7 +143,7 @@ private
       product_location: strip_tags(params[:product_location]).presence,
       product_postcode: strip_tags(params[:product_postcode]&.gsub(/[[:space:]]+/, "")).presence,
       product_url: strip_tags(params[:product_url]).presence,
-      lead_time: strip_tags(params[:lead_time]).presence,
+      lead_time: strip_tags(params[:lead_time]&.gsub(/[,a-zA-Z]/, "")&.strip).presence,
     }
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -233,7 +233,7 @@ en:
         product_cost:
           label: "Cost per item, in pounds"
           hint: "For example, 23.99. Enter 0 if you will donate it."
-          custom_error: "Enter a cost, like 23.99, or 0 if you will donate it. Do not put the £ symbol."
+          custom_error: "Enter the cost per item in pounds, do not include words or symbols. If you are giving it for free, enter 0"
         certification_details:
           label: "Certification details"
           hint: "For example, CE marking or EN standards."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -229,7 +229,7 @@ en:
         product_quantity:
           label: "Quantity of this product"
           hint: "Approximate amount, for example 10, 500, 10000."
-          custom_error: "Enter the quantity of the product"
+          custom_error: "Enter the approximate total number of items, do not include words or symbols"
         product_cost:
           label: "Cost per item, in pounds"
           hint: "For example, 23.99. Enter 0 if you will donate it."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -255,7 +255,7 @@ en:
           label: "URL of product specification document (optional)"
         lead_time:
           label: "Lead time in days"
-          custom_error: "Enter a number"
+          custom_error: "Enter the approximate lead time in days, do not include words or symbols. If the product is available now, enter 0"
         equipment_type:
           label: "What type of equipment is it?"
           options:

--- a/spec/controllers/coronavirus_form/product_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/product_details_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CoronavirusForm::ProductDetailsController, type: :controller do
       product_id: product_id,
       product_name: "Defibrillator",
       product_quantity: "100",
-      product_cost: "£10.99",
+      product_cost: "10.99",
       certification_details: "CE",
       product_location: "United Kingdom",
       product_postcode: "SW1A2AA",
@@ -222,6 +222,42 @@ RSpec.describe CoronavirusForm::ProductDetailsController, type: :controller do
         it "errors if the product quantity is below zero" do
           post :submit, params: params.merge(product_quantity: "-10")
           expect(response).to render_template(current_template)
+        end
+      end
+
+      context "product_cost" do
+        before do
+          params.merge!(equipment_type: "Gloves")
+        end
+
+        it "errors if the user doesn't provide a product_cost" do
+          post :submit, params: params.except(:product_cost)
+          expect(response).to render_template(current_template)
+        end
+
+        it "errors if the user enters an invalid product_cost" do
+          post :submit, params: params.merge(product_cost: "Ten pounds")
+          expect(response).to render_template(current_template)
+        end
+
+        it "errors if the product_cost is below zero" do
+          post :submit, params: params.merge(product_cost: "-10")
+          expect(response).to render_template(current_template)
+        end
+
+        it "allows the product_cost to be zero" do
+          post :submit, params: params.merge(product_cost: "0")
+          expect(response).to redirect_to(additional_product_path)
+        end
+
+        it "removes £ from product_cost" do
+          post :submit, params: params.merge(product_cost: "£10.99")
+          expect(session[:product_details].first[:product_cost]).to eq("10.99")
+        end
+
+        it "removes words from product_cost" do
+          post :submit, params: params.merge(product_cost: "10.99 GBP")
+          expect(session[:product_details].first[:product_cost]).to eq("10.99")
         end
       end
     end

--- a/spec/controllers/coronavirus_form/product_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/product_details_controller_spec.rb
@@ -203,6 +203,27 @@ RSpec.describe CoronavirusForm::ProductDetailsController, type: :controller do
 
         expect(response).to render_template(current_template)
       end
+
+      context "product_quantity" do
+        before do
+          params.merge!(equipment_type: "Gloves")
+        end
+
+        it "errors if the user doesn't provide a product_quantity" do
+          post :submit, params: params.except(:product_quantity)
+          expect(response).to render_template(current_template)
+        end
+
+        it "errors if the user enters an invalid product quantity" do
+          post :submit, params: params.merge(product_quantity: "Ten")
+          expect(response).to render_template(current_template)
+        end
+
+        it "errors if the product quantity is below zero" do
+          post :submit, params: params.merge(product_quantity: "-10")
+          expect(response).to render_template(current_template)
+        end
+      end
     end
 
     context "when the user has selected PPE" do

--- a/spec/controllers/coronavirus_form/product_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/product_details_controller_spec.rb
@@ -245,6 +245,11 @@ RSpec.describe CoronavirusForm::ProductDetailsController, type: :controller do
           expect(response).to render_template(current_template)
         end
 
+        it "errors if the product_cost has more than two decimal places" do
+          post :submit, params: params.merge(product_cost: "10.99999")
+          expect(response).to render_template(current_template)
+        end
+
         it "allows the product_cost to be zero" do
           post :submit, params: params.merge(product_cost: "0")
           expect(response).to redirect_to(additional_product_path)

--- a/spec/controllers/coronavirus_form/product_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/product_details_controller_spec.rb
@@ -260,6 +260,37 @@ RSpec.describe CoronavirusForm::ProductDetailsController, type: :controller do
           expect(session[:product_details].first[:product_cost]).to eq("10.99")
         end
       end
+
+      context "lead_time" do
+        before do
+          params.merge!(equipment_type: "Gloves")
+        end
+
+        it "errors if the user doesn't provide a lead_time" do
+          post :submit, params: params.except(:lead_time)
+          expect(response).to render_template(current_template)
+        end
+
+        it "errors if the user enters an invalid lead_time" do
+          post :submit, params: params.merge(lead_time: "Ten days")
+          expect(response).to render_template(current_template)
+        end
+
+        it "errors if the lead_time is below zero" do
+          post :submit, params: params.merge(lead_time: "-10")
+          expect(response).to render_template(current_template)
+        end
+
+        it "allows the lead_time to be zero" do
+          post :submit, params: params.merge(lead_time: "0")
+          expect(response).to redirect_to(additional_product_path)
+        end
+
+        it "removes words from lead_time" do
+          post :submit, params: params.merge(lead_time: "10 days")
+          expect(session[:product_details].first[:lead_time]).to eq("10")
+        end
+      end
     end
 
     context "when the user has selected PPE" do


### PR DESCRIPTION
Trello: https://trello.com/c/hjNli4xS

# What

Add validation to Product Price, Product Quantity and Product lead time on the Business Volunteering form.

Requirements:

**General validation notes:**

- Strip whitespace from the start and end of fields before validating

**These all apply to the product details page:**

Quantity

- Strip commas
- Validate for a positive integer
- Validation error message: "Enter the approximate total number of items, do not include words or symbols"

Cost

- Strip £ and 'GBP' (case insensitive)
- Validate for a positive integer, optionally with 2 decimal places
- Validation error message: "Enter the cost per item in pounds, do not include words or symbols. If you are giving it for free, enter 0"

Lead time

- Strip 'days' (case insensitive)
- Validate for a positive integer
- Validation error message: "Enter the approximate lead time in days, do not include words or symbols. If the product is available now, enter 0"

# Why

Cabinet Office told us they couldn't use these fields, since folks are treating these fields as free text rather than numbers. E.g. users would enter 'about 3 weeks' for the lead time in days field.

**Details of fields**

Volumes:
- Need in order to prioritise the buying of PPE/Testing and other medical equipment
- Need for daily reporting numbers to number 10

Values:
- Need for daily reporting to number 10

Lead times:
- Needed to co-ordinate logistics to get PPE/Medical equipment to the NHS
- Needed to prioritise the buying of PPE/Testing and other medical equipment
- Needed for daily reporting to number 10

# Expected changes
## Product quantity
![quantity_error](https://user-images.githubusercontent.com/5793815/79365163-272c3880-7f42-11ea-9f4d-d3828a8135fa.png)

## Product cost
![cost_error](https://user-images.githubusercontent.com/5793815/79365208-37dcae80-7f42-11ea-9150-3f976204c2d4.png)

## Lead time
![lead_time_error](https://user-images.githubusercontent.com/5793815/79365218-3d39f900-7f42-11ea-8057-51420b797b3e.png)
