### PR TITLE
ci: Use the `ruby/setup-ruby` action that still ships with 2.6.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,8 +21,8 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
-    - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+    - name: Set up Ruby 2.6.5
+      uses: ruby/setup-ruby
       with:
         ruby-version: 2.6.5
 


### PR DESCRIPTION
- For reasons relating to CloudFoundry buildpacks not shipping with
  2.6.6 yet (https://github.com/cloudfoundry/ruby-buildpack/releases),
  we can't use Ruby 2.6.6 in this project.

- GitHub Actions, in their
  [ubuntu-latest](https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-README.md)
  images, stopped supporting Ruby 2.6.6. The docs say:

  > Virtual environments contain only one Ruby version within a
  > 'major.minor' release, and are updated with new releases. Hence, a
  > workflow should only be bound to minor versions.

- Obviously, we don't want to run CI on a Ruby version that our app
  doesn't support - and I don't believe `bundler` would even work as the
  `.ruby-version` file states 2.6.5.

- This switches to use the
  [ruby/setup-ruby](https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby)
  Action, which supports a lot more Ruby versions than the latest and
  greatest official GitHub one.