### PR TITLE
Don't submit data for smoke tester

### DIFF
--- a/app/controllers/coronavirus_form/check_answers_controller.rb
+++ b/app/controllers/coronavirus_form/check_answers_controller.rb
@@ -10,7 +10,7 @@ class CoronavirusForm::CheckAnswersController < ApplicationController
     submission_reference = reference_number
 
     session[:reference_number] = submission_reference
-    FormResponse.create(form_response: session)
+    FormResponse.create(form_response: session) unless smoke_tester?
 
     send_confirmation_email
 
@@ -32,6 +32,11 @@ private
     else
       session.dig(:contact_details, :email)
     end
+  end
+
+  def smoke_tester?
+    email = session.dig(:contact_details, :email)
+    email.present? && email == Rails.application.config.courtesy_copy_email
   end
 
   def reference_number

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,6 +40,8 @@ module CoronavirusForm
     # Don't generate system test files.
     config.generators.system_tests = nil
 
+    config.courtesy_copy_email = "coronavirus-services-smoke-tests@digital.cabinet-office.gov.uk"
+
     config.active_job.queue_adapter = :sidekiq
 
     config.courtesy_copy_email = "coronavirus-services-smoke-tests@digital.cabinet-office.gov.uk"

--- a/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
@@ -63,5 +63,14 @@ RSpec.describe CoronavirusForm::CheckAnswersController, type: :controller do
         params: { reference_number: "abc" },
       })
     end
+
+    it "doesn't create a FormResponse if the user is the smoke tester" do
+      session[:contact_details] = { email: Rails.application.config.courtesy_copy_email }
+      session["medical_equipment"] = "Yes"
+
+      expect {
+        post :submit
+      }.to_not(change { FormResponse.count })
+    end
   end
 end


### PR DESCRIPTION
If the user is a smoke tester, don't create a FormResponse for them.

https://trello.com/c/yEHNJoNp/256-stop-smoke-tests-putting-test-data-into-the-production-database