### PR TITLE
Authenticate before before_actions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,15 +9,15 @@ class ApplicationController < ActionController::Base
 
   rescue_from ActionController::InvalidAuthenticityToken, with: :session_expired
 
-  before_action :check_first_question_answered, only: :show
-  before_action :set_session_history, only: :show
-
   if ENV["REQUIRE_BASIC_AUTH"]
     http_basic_authenticate_with(
       name: ENV.fetch("BASIC_AUTH_USERNAME"),
       password: ENV.fetch("BASIC_AUTH_PASSWORD"),
     )
   end
+
+  before_action :check_first_question_answered, only: :show
+  before_action :set_session_history, only: :show
 
   def show
     @form_responses = session.to_hash.with_indifferent_access


### PR DESCRIPTION
This fixes an issue where we would attempt to redirect a user
prior to authenticating them. This had the effect of making
them enter their basic auth credentials twice.

This broke the smoke tests when testing redirects to the first
question were answered because the before_action that redirected
a user to the first page when they hadn't answered it came before
we had authenticated their initial request.

Co-Authored-By: Graham Lewis