### PR TITLE
Prevent users submitting the same FormResponse twice

### DIFF
--- a/app/controllers/coronavirus_form/check_answers_controller.rb
+++ b/app/controllers/coronavirus_form/check_answers_controller.rb
@@ -1,25 +1,29 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::CheckAnswersController < ApplicationController
+  before_action :set_reference_number
+
   def show
     session[:check_answers_seen] = true
     super
   end
 
   def submit
-    submission_reference = reference_number
-
-    session[:reference_number] = submission_reference
     FormResponse.create(form_response: session) unless smoke_tester?
 
     send_confirmation_email
 
+    ref_number = session[:reference_number]
     reset_session
 
-    redirect_to thank_you_url(reference_number: submission_reference)
+    redirect_to thank_you_url(reference_number: ref_number)
   end
 
 private
+
+  def set_reference_number
+    session[:reference_number] ||= reference_number
+  end
 
   def send_confirmation_email
     mailer = CoronavirusFormMailer.with(name: session.dig(:contact_details, :contact_name))
@@ -40,9 +44,11 @@ private
   end
 
   def reference_number
-    timestamp = Time.zone.now.strftime("%Y%m%d-%H%M%S")
-    random_id = SecureRandom.hex(3).upcase
-    "#{timestamp}-#{random_id}"
+    @reference_number ||= begin
+      timestamp = Time.zone.now.strftime("%Y%m%d-%H%M%S")
+      random_id = SecureRandom.hex(3).upcase
+      "#{timestamp}-#{random_id}"
+    end
   end
 
   def previous_path

--- a/app/views/coronavirus_form/check_answers.html.erb
+++ b/app/views/coronavirus_form/check_answers.html.erb
@@ -46,5 +46,7 @@
 ) do %>
   <%= render "govuk_publishing_components/components/button",
     text: t("check_your_answers.submit"),
+    "module": "govuk-button",
+    "prevent-double-click": "true",
     margin_bottom: true %>
 <% end %>


### PR DESCRIPTION
Currently a user can submit the form twice if they click the submit button on the check your answers page twice in quite succession.

This adds two fixes for this:

- The frontend fix is to disable the button with javascript when the form is submitted; this prevents users with javascript enabled clicking the submit button multiple times
- The backend fix uses the unique constraint we have on FormResponse data; it sets reference_id on show, before submit is clicked, so the reference_id doesn't change when users click 'submit' multiple times. This means that subsequent requests will return an error, rather than creating duplicate records in the DB.

https://trello.com/c/cQxG2uZz/284