### PR TITLE
Fix smoke test builds

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -122,18 +122,19 @@ jobs:
 
   - name: smoke-test-staging
     plan:
-      - get: git-master
-        trigger: true
-        passed: [deploy-to-staging]
       - get: tests-image
         passed:
           - build-tests-image
+      - get: git-master
+        trigger: true
+        passed: [deploy-to-staging]
       - task: smoke-test
         file: git-master/concourse/tasks/smoke-test.yml
         params:
           URL: 'https://govuk-coronavirus-business-volunteer-form-stg.cloudapps.digital/medical-equipment'
           MESSAGE: "Checks that the application deployed to staging is not serving HTTP error codes"
       - task: run-smoke-tests
+        image: tests-image
         file: git-master/concourse/tasks/run-smoke-tests.yml
         params:
           TEST_URL: 'https://gds:((basic-auth-password))@govuk-coronavirus-business-volunteer-form-stg.cloudapps.digital'
@@ -173,6 +174,7 @@ jobs:
           URL: 'https://coronavirus-business-volunteers.service.gov.uk/medical-equipment'
           MESSAGE: "Checks that the application deployed to production is not serving HTTP error codes"
       - task: run-smoke-tests
+        image: tests-image
         file: git-master/concourse/tasks/run-smoke-tests.yml
         params:
           TEST_URL: 'https://coronavirus-business-volunteers.service.gov.uk'

--- a/concourse/tasks/run-smoke-tests.yml
+++ b/concourse/tasks/run-smoke-tests.yml
@@ -1,15 +1,16 @@
 platform: linux
-image_resource:
-  type: docker-image
-  source:
-    repository: ((readonly_private_ecr_repo_url))
-    tag: govuk-coronavirus-business-volunteer-form-feature-tests
 params:
   TEST_URL:
   RAILS_ENV: smoke_test
 inputs:
   - name: git-master
 run:
-  path: bundle
   dir: git-master
-  args: ['exec', 'rspec', 'spec/features']
+  path: sh
+  args:
+    - '-c'
+    - |
+      echo "Checking dependencies"
+      bundle
+      echo "Running smoke tests..."
+      bundle exec rspec spec/features


### PR DESCRIPTION
This fixes a couple of issues with the smoke tests:
- It ensures dependencies are loaded, by running bundle before smoke tests
  This'll help in situations where we run smoke tests before a new test image
  is ready
- It uses the test image for running the smoke tests in, so dependencies should
  be installed if we're using the latest image.

Co-Authored-By: Huw

https://trello.com/c/Sccs2vSS/287-ensure-smoke-tests-use-an-image-with-required-dependencies