### PR TITLE
Fix business details specs

### DIFF
--- a/spec/controllers/coronavirus_form/business_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/business_details_controller_spec.rb
@@ -58,31 +58,35 @@ RSpec.describe CoronavirusForm::BusinessDetailsController, type: :controller do
     end
 
     it "validates company name is entered" do
-      post :submit, params: { company_name: "" }
+      post :submit, params: params.merge(company_name: "")
 
       expect(response).to render_template(current_template)
     end
 
     it "validates company size option is chosen" do
-      post :submit, params: { company_size: "" }
+      post :submit, params: params.merge(company_size: "")
 
       expect(response).to render_template(current_template)
     end
 
     it "validates company location option is chosen" do
-      post :submit, params: { company_location: "" }
+      post :submit, params: params.merge(company_location: "")
 
       expect(response).to render_template(current_template)
     end
 
-    it "does not validate postcode is provided if company location is not UK" do
-      post :submit, params: { company_location: I18n.t("coronavirus_form.questions.business_details.company_location.options.european_union.label") }
+    it "does not require postcode is provided if company location is not UK" do
+      post :submit, params: params.merge(
+        company_location: I18n.t("coronavirus_form.questions.business_details.company_location.options.european_union.label"),
+      ).except(:company_postcode)
 
-      expect(response).to render_template(current_template)
+      expect(response).to redirect_to(contact_details_path)
     end
 
     it "validates postcode is provided if company location is UK" do
-      post :submit, params: { company_location: I18n.t("coronavirus_form.questions.business_details.company_location.options.united_kingdom.label") }
+      post :submit, params: params.merge(
+        company_location: I18n.t("coronavirus_form.questions.business_details.company_location.options.united_kingdom.label"),
+      ).except(:company_postcode)
 
       expect(response).to render_template(current_template)
     end
@@ -100,23 +104,20 @@ RSpec.describe CoronavirusForm::BusinessDetailsController, type: :controller do
     ]
 
       valid_postcodes.each do |postcode|
-        params[:postcode] = postcode
-        post :submit, params: params
-
-        post :submit, params: {
+        post :submit, params: params.merge(
           company_location: I18n.t("coronavirus_form.questions.business_details.company_location.options.united_kingdom.label"),
           company_postcode: postcode,
-        }
+        )
 
-        expect(response).to render_template(current_template)
+        expect(response).to redirect_to(contact_details_path)
       end
     end
 
     it "does not redirect to next step when postcode is invalid" do
-      post :submit, params: {
+      post :submit, params: params.merge(
         company_location: I18n.t("coronavirus_form.questions.business_details.company_location.options.united_kingdom.label"),
         company_postcode: "AAA1 1AA",
-      }
+      )
 
       expect(response).to render_template(current_template)
     end


### PR DESCRIPTION
These specs weren't working correctly as they need to
have default params that would result in a successful
response.