### PR TITLE
ci: Trim GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,8 +27,7 @@ jobs:
         ruby-version: 2.6.5
 
     - name: Install PostgreSQL 11 client
-      run: |
-        sudo apt-get -yqq install libpq-dev
+      run: sudo apt-get -yqq install libpq-dev
 
     - uses: actions/cache@v1
       with:
@@ -44,7 +43,6 @@ jobs:
         RAILS_ENV: test
         DB_USERNAME: postgres
       run: |
-        gem install bundler
         bundle config path vendor/bundle
         bundle install --jobs 4 --retry 3
         bundle exec rake db:create


### PR DESCRIPTION
What
----

This shortens the GitHub Actions runtime slightly, because Ruby 2.6 already ships with Bundler.

How to review
-------------

See the CI build go green.

Links
-----

n/a

