### PR TITLE
ci: Oops, pulling the Ruby version from `.ruby-version` is the default

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,10 +20,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-
     - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: .ruby-version
 
     - name: Install PostgreSQL 11 client
       run: sudo apt-get -yqq install libpq-dev


### PR DESCRIPTION
What
----

- We don't need these two lines. But this isn't a clean revert of 8ece15
  because we don't need to specify any kind of Ruby version.

How to review
-------------

Observe that the checks still run under 2.6.5.

Links
-----

n/a

