### PR TITLE
Do not send email if address is not provided

### DIFF
--- a/app/controllers/coronavirus_form/check_answers_controller.rb
+++ b/app/controllers/coronavirus_form/check_answers_controller.rb
@@ -11,7 +11,7 @@ class CoronavirusForm::CheckAnswersController < ApplicationController
   def submit
     FormResponse.create(form_response: session) unless smoke_tester?
 
-    send_confirmation_email
+    send_confirmation_email if session.dig(:contact_details, :email).present?
 
     ref_number = session[:reference_number]
     reset_session

--- a/app/jobs/email_delivery_job.rb
+++ b/app/jobs/email_delivery_job.rb
@@ -3,6 +3,8 @@ class EmailDeliveryJob < ActionMailer::DeliveryJob
 
   queue_as :mailers
 
+  discard_on Notifications::Client::BadRequestError
+
   retry_on(Notifications::Client::RequestError,
            wait: :exponentially_longer,
            attempts: 5)

--- a/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
@@ -46,6 +46,17 @@ RSpec.describe CoronavirusForm::CheckAnswersController, type: :controller do
         .with(a_hash_including(name: "Harry Potter"), "harry@example.org").on_queue("mailers")
     end
 
+    it "does not send an email when no email address provided" do
+      ActiveJob::Base.queue_adapter = :test
+      session[:contact_details] = {
+        contact_name: "Harry Potter",
+        email: "",
+      }
+      expect {
+        post :submit
+      }.to have_enqueued_mail(CoronavirusFormMailer, :thank_you).on_queue("mailers").exactly(0).times
+    end
+
     it "resets session" do
       post :submit
       expect(session.to_hash).to eq({})


### PR DESCRIPTION
What
----

Email address is an optional field, therefore we should only attempt to send an email if the address has been provided.

At the moment, we are raising `Notifications::Client::BadRequestError`  with message `ValidationError: email_address None is not of type string` when the form is submitted without an email address.

Additionally, we will now discard a job when a bad request is made, since it will always fail on subsequent attempts.

How to review
-------------

- Review code and tests

Links
-----

Sentry issue: https://sentry.io/organizations/govuk/issues/1615079517/
Trello card: https://trello.com/c/Qdj90X00