### PR TITLE
Add suffix to product detail inputs

### DIFF
--- a/app/views/coronavirus_form/product_details.html.erb
+++ b/app/views/coronavirus_form/product_details.html.erb
@@ -47,6 +47,7 @@
     text: t('coronavirus_form.questions.product_details.product_quantity.label'),
   },
   hint: t('coronavirus_form.questions.product_details.product_quantity.hint'),
+  suffix: t('coronavirus_form.questions.product_details.product_quantity.suffix'),
   id: "product_quantity",
   name: "product_quantity",
   type: "number",
@@ -122,6 +123,7 @@
   label: {
     text: t('coronavirus_form.questions.product_details.lead_time.label')
   },
+  suffix: t('coronavirus_form.questions.product_details.lead_time.suffix'),
   id: "lead_time",
   name: "lead_time",
   error_message: error_items('lead_time'),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -227,6 +227,7 @@ en:
           label: "Quantity of this product"
           hint: "Approximate amount, for example 10, 500, 10000."
           custom_error: "Enter the approximate total number of items, do not include words or symbols"
+          suffix: "items"
         product_cost:
           label: "Cost per item, in pounds"
           hint: "For example, 23.99. Enter 0 if you will donate it."
@@ -253,6 +254,7 @@ en:
         lead_time:
           label: "Lead time in days"
           custom_error: "Enter the approximate lead time in days, do not include words or symbols. If the product is available now, enter 0"
+          suffix: "days"
         equipment_type:
           label: "What type of equipment is it?"
           options:


### PR DESCRIPTION
What
----

Add suffixes to the product_quantity and lead_time fields (See attached screenshot).

Cabinet Office told us they couldn't use these fields, as users were treating these fields as free text rather than numbers. E.g. users would enter 'about 3 weeks' for the lead time in days field.

The intention behind the suffixes is to better indicate to users how we would like them to input data.

No suffix was added to the product cost field as desired in the [initial design](https://trello-attachments.s3.amazonaws.com/5e8346012feac37ef24b2a9e/5e983fb16ed1383ba60e8ad4/1ec551844ac2fce3eb0b2c0a4ca68c31/suffixes.png) for this ticket, as it had been decided that a prefix is more appropriate in this instance. We are developing that as part of this future [ticket ](https://trello.com/c/GCGNaCSH/367-add-prefix-to-input-fields-on-product-details-question). 

**BEFORE**
<img width="595" alt="Screenshot 2020-05-06 at 10 39 10" src="https://user-images.githubusercontent.com/41922771/81163357-8819c000-8f86-11ea-98b3-82334d3f6cab.png">

**AFTER**
<img width="565" alt="Screenshot 2020-05-06 at 10 37 57" src="https://user-images.githubusercontent.com/41922771/81163372-8e0fa100-8f86-11ea-9952-918e948a273a.png">


Links
-----

[Trello Card](https://trello.com/c/7VVBYT7z/257-add-suffix-to-input-fields-on-product-details-question)

