### PR TITLE
Make offer_other_support optional in the schema

### DIFF
--- a/config/schemas/form_response.json
+++ b/config/schemas/form_response.json
@@ -8,7 +8,6 @@
     "offer_space",
     "expert_advice_type",
     "offer_care",
-    "offer_other_support",
     "business_details",
     "contact_details"
   ],

--- a/spec/helpers/schema_helper_spec.rb
+++ b/spec/helpers/schema_helper_spec.rb
@@ -185,9 +185,9 @@ RSpec.describe SchemaHelper, type: :helper do
     end
 
     describe "offer_other_support" do
-      it "returns a list of errors when offer_other_support is missing" do
+      it "allows offer_other_support to be blank" do
         data = valid_data.except(:offer_other_support)
-        expect(validate_against_form_response_schema(data).first).to include("offer_other_support")
+        expect(validate_against_form_response_schema(data)).to be_empty
       end
     end
 


### PR DESCRIPTION
Users don't have to answer this question as they can click continue without providing an answer in the form,
so we should also make this question optional in the schema.

Fixes:

https://sentry.io/organizations/govuk/issues/1639294230/events/80be6cc2ce454a15b1e040c26c935273/?project=5172100&query=is%3Aunresolved

