### PR TITLE
PPE update

### DIFF
--- a/app/controllers/coronavirus_form/medical_equipment_type_controller.rb
+++ b/app/controllers/coronavirus_form/medical_equipment_type_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class CoronavirusForm::MedicalEquipmentTypeController < ApplicationController
-  TEXT_FIELDS = %w[medical_equipment_type_other].freeze
-
   def show
     session[:product_details] ||= []
     @product = find_product(params["product_id"], session[:product_details])
@@ -13,12 +11,10 @@ class CoronavirusForm::MedicalEquipmentTypeController < ApplicationController
     session[:product_details] ||= []
     @product = sanitized_product(params)
 
-    invalid_fields = validate_field_response_length(controller_name, TEXT_FIELDS) +
-      validate_radio_field(
-        controller_name,
-        radio: @product[:medical_equipment_type],
-        other: @product[:medical_equipment_type_other],
-      )
+    invalid_fields = validate_radio_field(
+      controller_name,
+      radio: @product[:medical_equipment_type],
+    )
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
@@ -35,10 +31,6 @@ class CoronavirusForm::MedicalEquipmentTypeController < ApplicationController
 
 private
 
-  def selected_other?(medical_equipment_type)
-    medical_equipment_type == I18n.t("coronavirus_form.questions.#{controller_name}.options.other.label")
-  end
-
   def selected_testing_equipment?
     @product[:medical_equipment_type] == I18n.t(
       "coronavirus_form.questions.medical_equipment_type.options.number_testing_equipment.label",
@@ -53,7 +45,6 @@ private
     {
       product_id: strip_tags(params[:product_id]).presence || SecureRandom.uuid,
       medical_equipment_type: strip_tags(params[:medical_equipment_type]).presence,
-      medical_equipment_type_other: strip_tags(params[:medical_equipment_type_other]).presence,
     }
   end
 end

--- a/app/controllers/coronavirus_form/product_details_controller.rb
+++ b/app/controllers/coronavirus_form/product_details_controller.rb
@@ -36,14 +36,6 @@ class CoronavirusForm::ProductDetailsController < ApplicationController
 
 private
 
-  helper_method :selected_ppe?
-
-  def selected_ppe?
-    @product[:medical_equipment_type] == I18n.t(
-      "coronavirus_form.questions.medical_equipment_type.options.number_ppe.label",
-    )
-  end
-
   def selected_made_in_uk?
     @product[:product_location] == I18n.t(
       "coronavirus_form.questions.product_details.product_location.options.option_uk.label",
@@ -54,7 +46,7 @@ private
     [
       validate_field_response_length(controller_name, TEXT_FIELDS),
       validate_missing_fields,
-      selected_ppe? ? validate_radio_field("#{controller_name}.equipment_type", radio: @product[:equipment_type]) : [],
+      validate_radio_field("#{controller_name}.equipment_type", radio: @product[:equipment_type]),
       validate_radio_field("#{controller_name}.product_location", radio: @product[:product_location]),
       validate_product_postcode,
       validate_product_quantity,

--- a/app/helpers/check_answers_helper.rb
+++ b/app/helpers/check_answers_helper.rb
@@ -71,11 +71,7 @@ module CheckAnswersHelper
 
   def product_info(product)
     prod = []
-    prod << if product["medical_equipment_type_other"]
-              "Type: #{product[:medical_equipment_type]} (#{product['medical_equipment_type_other']})"
-            else
-              "Type: #{product[:medical_equipment_type]}"
-            end
+    prod << "Type: #{product[:medical_equipment_type]}"
     prod << "Product: #{product[:product_name]}" if product[:product_name]
     prod << "Equipment type: #{product[:equipment_type]}" if product[:equipment_type]
     prod << "Quantity: #{product[:product_quantity]}" if product[:product_quantity]

--- a/app/views/coronavirus_form/medical_equipment_type.html.erb
+++ b/app/views/coronavirus_form/medical_equipment_type.html.erb
@@ -30,19 +30,6 @@
       text: t('coronavirus_form.questions.medical_equipment_type.options.number_testing_equipment.label'),
       checked: @product["medical_equipment_type"] == t('coronavirus_form.questions.medical_equipment_type.options.number_testing_equipment.label'),
     },
-    {
-      value: t('coronavirus_form.questions.medical_equipment_type.options.other.label'),
-      text: t('coronavirus_form.questions.medical_equipment_type.options.other.label'),
-      checked: @product["medical_equipment_type"] == t('coronavirus_form.questions.medical_equipment_type.options.other.label'),
-      conditional: render("govuk_publishing_components/components/textarea", {
-        label: {
-          text: t('coronavirus_form.questions.medical_equipment_type.options.other.input.label'),
-        },
-        id: "medical_equipment_type_other",
-        name: "medical_equipment_type_other",
-        value: @product["medical_equipment_type_other"]
-      })
-    },
   ]
 } %>
 <%= render "govuk_publishing_components/components/button", text: t("coronavirus_form.submit_and_next"), margin_bottom: true %>

--- a/app/views/coronavirus_form/product_details.html.erb
+++ b/app/views/coronavirus_form/product_details.html.erb
@@ -27,22 +27,20 @@
   error_message: error_items('product_name'),
   value: @product[:product_name],
 } %>
-<% if selected_ppe? %>
-  <%= render "govuk_publishing_components/components/radio", {
-    heading: t('coronavirus_form.questions.product_details.equipment_type.label'),
-    heading_size: 's',
-    name: "equipment_type",
-    error_message: error_items('equipment_type'),
-    items: t('coronavirus_form.questions.product_details.equipment_type.options').map.with_index do |(_, item), index|
-      {
-        id: ("product_details_equipment_type" if index == 0),
-        value: item[:label],
-        text: item[:label],
-        checked: @product[:equipment_type] == item[:label],
-      }
-    end
-  } %>
-<% end %>
+<%= render "govuk_publishing_components/components/radio", {
+  heading: t('coronavirus_form.questions.product_details.equipment_type.label'),
+  heading_size: 's',
+  name: "equipment_type",
+  error_message: error_items('equipment_type'),
+  items: t('coronavirus_form.questions.product_details.equipment_type.options').map.with_index do |(_, item), index|
+    {
+      id: ("product_details_equipment_type" if index == 0),
+      value: item[:label],
+      text: item[:label],
+      checked: @product[:equipment_type] == item[:label],
+    }
+  end
+} %>
 
 <%= render "govuk_publishing_components/components/input", {
   label: {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -204,14 +204,7 @@ en:
             label: "Personal protective equipment, for example masks, detergent and waste bags"
           number_testing_equipment:
             label: "Testing equipment"
-          other:
-            label: "Other"
-            input:
-              label: "Give a summary of the type of equipment – you can give more details later"
         custom_select_error: "Select the type of medical equipment you can offer"
-        custom_enter_error: "Enter a description of the type of equipment"
-        medical_equipment_type_other:
-          custom_length_error: "Description of the equipment must be 1000 characters or fewer"
       are_you_a_manufacturer:
         title: "What kind of business are you?"
         hint: "Select the best ways to describe your work"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -276,18 +276,10 @@ en:
               label: "Face fit test kit"
             face_fit_test_solution:
               label: "Face fit test solution"
-            swabs:
-              label: "Swabs"
             general_purpose_detergent:
               label: "General purpose detergent"
-            body_bags:
-              label: Body Bags
             cleaning_equipment:
               label: Cleaning Equipment
-            clinical_waste_bags:
-              label: Clinical Waste Bags
-            other:
-              label: "Something else"
           custom_select_error: "Select a type of equipment, or ‘something else’"
       additional_product:
         title: "Can you offer another product?"

--- a/config/schemas/form_response.json
+++ b/config/schemas/form_response.json
@@ -42,12 +42,8 @@
             "type": "string",
             "enum": [
               "Personal protective equipment, for example masks, detergent and waste bags",
-              "Testing equipment",
-              "Other"
+              "Testing equipment"
             ]
-          },
-          "medical_equipment_type_other": {
-            "type": ["string", "null"]
           },
           "product_id": {
             "type": "string",

--- a/config/schemas/form_response.json
+++ b/config/schemas/form_response.json
@@ -80,7 +80,7 @@
             "$ref": "#/definitions/whole_number"
           },
           "equipment_type": {
-            "type": ["string", "null"],
+            "type": ["string"],
             "enum": [
               "FFP3 respirators",
               "FFP2 respirators",
@@ -92,13 +92,8 @@
               "Gowns",
               "Face fit test kit",
               "Face fit test solution",
-              "Swabs",
               "General purpose detergent",
-              "Body Bags",
-              "Cleaning Equipment",
-              "Clinical Waste Bags",
-              "Something else",
-              null
+              "Cleaning Equipment"
             ]
           }
         }

--- a/spec/controllers/coronavirus_form/medical_equipment_type_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/medical_equipment_type_controller_spec.rb
@@ -49,26 +49,6 @@ RSpec.describe CoronavirusForm::MedicalEquipmentTypeController, type: :controlle
       expect(session[session_key]).to eq []
     end
 
-    context "when Other option is selected" do
-      it "validates the Other option description is provided" do
-        post :submit, params: { medical_equipment_type: "Other" }
-
-        expect(response).to have_http_status(:unprocessable_entity)
-        expect(response).to render_template(current_template)
-      end
-
-      it "adds the other option description to the session" do
-        post :submit, params: {
-          medical_equipment_type: "Other",
-          medical_equipment_type_other: "Demo text",
-        }
-
-        expect(response).to redirect_to(product_details_path(product_id: "abcd1234"))
-        expect(session[session_key][0][:medical_equipment_type]).to eq "Other"
-        expect(session[session_key][0][:medical_equipment_type_other]).to eq "Demo text"
-      end
-    end
-
     it "validates a valid option is chosen" do
       post :submit, params: {
         medical_equipment_type: "<script></script",
@@ -76,17 +56,6 @@ RSpec.describe CoronavirusForm::MedicalEquipmentTypeController, type: :controlle
 
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response).to render_template(current_template)
-    end
-
-    described_class::TEXT_FIELDS.each do |field|
-      it "validates that #{field} is 1000 or fewer characters" do
-        params = { medical_equipment_type: selected }
-        params[field] = SecureRandom.hex(1001)
-        post :submit, params: params
-
-        expect(response).to have_http_status(:unprocessable_entity)
-        expect(response).to render_template(current_template)
-      end
     end
   end
 end

--- a/spec/controllers/coronavirus_form/product_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/product_details_controller_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe CoronavirusForm::ProductDetailsController, type: :controller do
   let(:params) do
     {
       product_id: product_id,
-      product_name: "Defibrillator",
+      product_name: "Hand sanitizer",
+      equipment_type: I18n.t("coronavirus_form.questions.product_details.equipment_type.options.hand_gel.label"),
       product_quantity: "100",
       product_cost: "10.99",
       certification_details: "CE",
@@ -119,11 +120,10 @@ RSpec.describe CoronavirusForm::ProductDetailsController, type: :controller do
         params.merge(
           product_id: product_id,
           product_name: "My product",
-          equipment_type: nil,
         )
       }
       let(:product_2) {
-        params.merge(product_id: SecureRandom.uuid, equipment_type: nil)
+        params.merge(product_id: SecureRandom.uuid)
       }
 
       before :each do
@@ -205,10 +205,6 @@ RSpec.describe CoronavirusForm::ProductDetailsController, type: :controller do
       end
 
       context "product_quantity" do
-        before do
-          params.merge!(equipment_type: "Gloves")
-        end
-
         it "errors if the user doesn't provide a product_quantity" do
           post :submit, params: params.except(:product_quantity)
           expect(response).to have_http_status(:unprocessable_entity)
@@ -229,10 +225,6 @@ RSpec.describe CoronavirusForm::ProductDetailsController, type: :controller do
       end
 
       context "product_cost" do
-        before do
-          params.merge!(equipment_type: "Gloves")
-        end
-
         it "errors if the user doesn't provide a product_cost" do
           post :submit, params: params.except(:product_cost)
           expect(response).to have_http_status(:unprocessable_entity)
@@ -274,10 +266,6 @@ RSpec.describe CoronavirusForm::ProductDetailsController, type: :controller do
       end
 
       context "lead_time" do
-        before do
-          params.merge!(equipment_type: "Gloves")
-        end
-
         it "errors if the user doesn't provide a lead_time" do
           post :submit, params: params.except(:lead_time)
           expect(response).to have_http_status(:unprocessable_entity)
@@ -319,14 +307,14 @@ RSpec.describe CoronavirusForm::ProductDetailsController, type: :controller do
       end
 
       it "errors if the user has selected has not told us the equipment type" do
-        post :submit, params: params
+        post :submit, params: params.except(:equipment_type)
 
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response).to render_template(current_template)
       end
 
       it "redirects to next step if we're given the equipment type" do
-        post :submit, params: params.merge(equipment_type: "Gloves")
+        post :submit, params: params
 
         expect(response).to redirect_to(additional_product_path)
       end

--- a/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
+++ b/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "fill in the business volunteer form" do
       that_can_offer_medical_equipment
       and_is_a_manufacturer_a_distributor_and_agent
       and_has_personal_protection_equipment_available
-      and_has_other_medical_equipment_available
+      and_has_no_more_testing_equipment_to_offer
       and_can_offer_hotel_rooms
       and_can_offer_transport_or_logistics
       and_can_offer_space

--- a/spec/support/fill_in_the_form_steps.rb
+++ b/spec/support/fill_in_the_form_steps.rb
@@ -46,6 +46,12 @@ module FillInTheFormSteps
     click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
+  def and_has_no_more_testing_equipment_to_offer
+    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.additional_product.title"))
+    choose I18n.t("coronavirus_form.questions.additional_product.options.option_no.label")
+    click_on I18n.t("coronavirus_form.submit_and_next")
+  end
+
   def then_they_see_the_external_testing_equipment_link
     link = I18n.t("coronavirus_form.testing_equipment.external_link")
     expect(page.body).to have_content(I18n.t("coronavirus_form.testing_equipment.link.label"))
@@ -55,31 +61,6 @@ module FillInTheFormSteps
   def and_can_navigate_back_to_offer_another_product
     click_on I18n.t("coronavirus_form.testing_equipment.button.label")
     expect(page.body).to have_content(I18n.t("coronavirus_form.questions.additional_product.title"))
-  end
-
-  def and_has_other_medical_equipment_available
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.additional_product.title"))
-    choose I18n.t("coronavirus_form.questions.additional_product.options.option_yes.label")
-    click_on I18n.t("coronavirus_form.submit_and_next")
-
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.medical_equipment_type.title"))
-    choose I18n.t("coronavirus_form.questions.medical_equipment_type.options.other.label")
-    fill_in "medical_equipment_type_other", with: "Some text about medical equipment"
-    click_on I18n.t("coronavirus_form.submit_and_next")
-
-    fill_in "product_name", with: "Testing"
-    fill_in "product_quantity", with: "500"
-    fill_in "product_cost", with: "0"
-    fill_in "certification_details", with: "CE marking"
-    choose I18n.t("coronavirus_form.questions.product_details.product_location.options.option_uk.label")
-    fill_in "product_postcode", with: "E1 8QS"
-    fill_in "product_url", with: "https://example.com"
-    fill_in "lead_time", with: "10"
-    click_on I18n.t("coronavirus_form.submit_and_next")
-
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.additional_product.title"))
-    choose I18n.t("coronavirus_form.questions.additional_product.options.option_no.label")
-    click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
   def and_can_offer_hotel_rooms

--- a/spec/support/form_response_helper.rb
+++ b/spec/support/form_response_helper.rb
@@ -37,12 +37,10 @@ module FormResponseHelper
         {
           product_id: SecureRandom.uuid,
           medical_equipment_type: I18n.t("coronavirus_form.questions.medical_equipment_type.options.number_testing_equipment.label"),
-          medical_equipment_type_other: nil,
         },
         {
           product_id: SecureRandom.uuid,
           medical_equipment_type: I18n.t("coronavirus_form.questions.medical_equipment_type.options.number_ppe.label"),
-          medical_equipment_type_other: nil,
         },
         {
           lead_time: "12",
@@ -56,12 +54,6 @@ module FormResponseHelper
           product_quantity: "10000",
           certification_details: "None",
           medical_equipment_type: I18n.t("coronavirus_form.questions.medical_equipment_type.options.number_ppe.label"),
-          medical_equipment_type_other: nil,
-        },
-        {
-          product_id: SecureRandom.uuid,
-          medical_equipment_type: I18n.t("coronavirus_form.questions.medical_equipment_type.options.other.label"),
-          medical_equipment_type_other: "A description of other types of medical equipment",
         },
       ],
       are_you_a_manufacturer: I18n.t("coronavirus_form.questions.are_you_a_manufacturer.options").map { |_, item| item[:label] },


### PR DESCRIPTION
What
----

- This removes the 'Other' option from the medical equipment type page
- This removes four options from the 'What type of equipment is it?' section on the product details page

Screenshots
----

<img width="652" alt="Screenshot 2020-05-04 at 16 42 50" src="https://user-images.githubusercontent.com/8124374/80987593-2ba18e00-8e2a-11ea-8265-cd9bfab431bf.png">
<img width="360" alt="Screenshot 2020-05-04 at 17 09 44" src="https://user-images.githubusercontent.com/8124374/80987597-2c3a2480-8e2a-11ea-93e6-ac4a790e8659.png">


Links
-----

https://trello.com/c/5P3nyUfe/361-business-support-form-ppe-list-update