### PR TITLE
Fix error validations for /offer-care-qualifications

### DIFF
--- a/app/views/coronavirus_form/offer_care_qualifications.erb
+++ b/app/views/coronavirus_form/offer_care_qualifications.erb
@@ -18,7 +18,7 @@
   is_page_heading: true,
   id: "offer_care_qualifications_offer_care_type",
   name: "offer_care_type[]",
-  error: error_items("offer_care_type"),
+  error: error_items("offer_care_qualifications_offer_care_type"),
   items: t("coronavirus_form.questions.offer_care_qualifications.offer_care_type.options").map do |_, item|
     {
       value: item[:label],
@@ -34,7 +34,7 @@
     hint_text: t('coronavirus_form.questions.offer_care_qualifications.care_qualifications.hint'),
     id: "offer_care_qualifications_care_qualifications",
     name: "offer_care_qualifications[]",
-    error: error_items("offer_care_qualifications"),
+    error: error_items("offer_care_qualifications_care_qualifications"),
     items: [
       {
         value: t('coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.dbs_check.label'),
@@ -60,6 +60,7 @@
   <%= tag.p t("coronavirus_form.questions.offer_care_qualifications.care_qualifications.or"), class: "govuk-body" %>
   <%= render "govuk_publishing_components/components/checkboxes", {
     name: "offer_care_qualifications[]",
+    error: error_items("offer_care_qualifications_care_qualifications"),
     items: [
       {
         value: t('coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.no_qualification.label'),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -443,6 +443,7 @@ en:
               label: "I do not have a qualification"
           or: "Or"
           custom_select_error: "Select the qualifications that you or people in your company have. If you do not have any select ‘I do not have a qualification’"
+          custom_select_error_qualification_or_not: "You cannot select a qualification as well as ’I do not have a qualification’"
           offer_care_qualifications_type:
             custom_length_error: "Description of your qualification must be 1000 characters or fewer"
       offer_other_support:


### PR DESCRIPTION
What
----

- Previously the 'Select if you can offer care for adults or children' error message incorrectly also displayed in the 'What qualifications or certificates do you have?' section
- It was possible to select a qualification and 'I do not have a qualification'

Before screenshot:

![before-dont-select-offer-care](https://user-images.githubusercontent.com/5963488/81061931-1cbfe780-8ecd-11ea-8dd9-dea281d5095d.png)



Describe what you have changed and why.

- The correct error message now displays in the 'What qualification or certificates do you have?' section
- New validation added to make it impossible to select a qualification and 'I do not have a qualification'

After screen shots:

![after-dont-select-offer-care](https://user-images.githubusercontent.com/5963488/81061945-23e6f580-8ecd-11ea-9507-c77720e055bc.png)

![after-qualifications-section-not-selected](https://user-images.githubusercontent.com/5963488/81061961-29dcd680-8ecd-11ea-9b38-217ec972a1b8.png)

![after-qualification-and-no-qualification-selected](https://user-images.githubusercontent.com/5963488/81061981-2cd7c700-8ecd-11ea-8ab3-baffb3de61cd.png)


Links
-----
[Trello](https://trello.com/c/Hch0J2Zp/272-fix-error-summary-on-what-kind-of-care-can-you-offer)


