### PR TITLE
Use consistent quotes for translations in views

### DIFF
--- a/app/views/coronavirus_form/accessibility_statement.html.erb
+++ b/app/views/coronavirus_form/accessibility_statement.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %><%= t('accessibility_statement.title') %><% end %>
+<% content_for :title do %><%= t("accessibility_statement.title") %><% end %>
 
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", { href: "/" } %>
@@ -9,4 +9,4 @@
   margin_top: 0
 } %>
 
-<%= sanitize(t('accessibility_statement.body_text')) %>
+<%= sanitize(t("accessibility_statement.body_text")) %>

--- a/app/views/coronavirus_form/additional_product.html.erb
+++ b/app/views/coronavirus_form/additional_product.html.erb
@@ -1,6 +1,6 @@
-<% content_for :title do %><%= t('coronavirus_form.questions.additional_product.title') %><% end %>
+<% content_for :title do %><%= t("coronavirus_form.questions.additional_product.title") %><% end %>
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('coronavirus_form.questions.additional_product.title') %>" />
+  <meta name="description" content="<%= t("coronavirus_form.questions.additional_product.title") %>" />
 <% end %>
 
 <% content_for :back_link do %>
@@ -14,20 +14,20 @@
   "novalidate": "true"
 ) do %>
 <%= render "govuk_publishing_components/components/radio", {
-  heading: t('coronavirus_form.questions.additional_product.title'),
+  heading: t("coronavirus_form.questions.additional_product.title"),
   is_page_heading: true,
   name: "additional_product",
   error_message: error_items('additional_product'),
   items: [
     {
-      value: t('coronavirus_form.questions.additional_product.options.option_yes.label'),
-      text: t('coronavirus_form.questions.additional_product.options.option_yes.label'),
-      checked: @form_responses[:additional_product] == t('coronavirus_form.questions.additional_product.options.option_yes.label'),
+      value: t("coronavirus_form.questions.additional_product.options.option_yes.label"),
+      text: t("coronavirus_form.questions.additional_product.options.option_yes.label"),
+      checked: @form_responses[:additional_product] == t("coronavirus_form.questions.additional_product.options.option_yes.label"),
     },
     {
-      value: t('coronavirus_form.questions.additional_product.options.option_no.label'),
-      text: t('coronavirus_form.questions.additional_product.options.option_no.label'),
-      checked: @form_responses[:additional_product] == t('coronavirus_form.questions.additional_product.options.option_no.label'),
+      value: t("coronavirus_form.questions.additional_product.options.option_no.label"),
+      text: t("coronavirus_form.questions.additional_product.options.option_no.label"),
+      checked: @form_responses[:additional_product] == t("coronavirus_form.questions.additional_product.options.option_no.label"),
     },
   ]
 } %>

--- a/app/views/coronavirus_form/are_you_a_manufacturer.html.erb
+++ b/app/views/coronavirus_form/are_you_a_manufacturer.html.erb
@@ -1,6 +1,6 @@
-<% content_for :title do %><%= t('coronavirus_form.questions.are_you_a_manufacturer.title') %><% end %>
+<% content_for :title do %><%= t("coronavirus_form.questions.are_you_a_manufacturer.title") %><% end %>
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('coronavirus_form.questions.are_you_a_manufacturer.title') %>" />
+  <meta name="description" content="<%= t("coronavirus_form.questions.are_you_a_manufacturer.title") %>" />
 <% end %>
 
 <% content_for :back_link do %>
@@ -14,12 +14,12 @@
   "novalidate": "true"
 ) do %>
 <%= render "govuk_publishing_components/components/checkboxes", {
-  heading: t('coronavirus_form.questions.are_you_a_manufacturer.title'),
-  hint_text: t('coronavirus_form.questions.are_you_a_manufacturer.hint'),
+  heading: t("coronavirus_form.questions.are_you_a_manufacturer.title"),
+  hint_text: t("coronavirus_form.questions.are_you_a_manufacturer.hint"),
   is_page_heading: true,
   name: "are_you_a_manufacturer[]",
   error: error_items('are_you_a_manufacturer'),
-  items: t('coronavirus_form.questions.are_you_a_manufacturer.options').map do |_, item|
+  items: t("coronavirus_form.questions.are_you_a_manufacturer.options").map do |_, item|
     {
       value:  item[:label],
       label:  item[:label],

--- a/app/views/coronavirus_form/business_details.html.erb
+++ b/app/views/coronavirus_form/business_details.html.erb
@@ -1,6 +1,6 @@
-<% content_for :title do %><%= t('coronavirus_form.questions.business_details.title') %><% end %>
+<% content_for :title do %><%= t("coronavirus_form.questions.business_details.title") %><% end %>
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('coronavirus_form.questions.business_details.title') %>" />
+  <meta name="description" content="<%= t("coronavirus_form.questions.business_details.title") %>" />
 <% end %>
 
 <% content_for :back_link do %>
@@ -15,7 +15,7 @@
 ) do %>
 
 <%= render "govuk_publishing_components/components/title", {
-  title: t('coronavirus_form.questions.business_details.title'),
+  title: t("coronavirus_form.questions.business_details.title"),
   margin_top: 0,
 } %>
 
@@ -23,7 +23,7 @@
   id: "company_name",
   name: "company_name",
   label: {
-    text: t('coronavirus_form.questions.business_details.company_name.label'),
+    text: t("coronavirus_form.questions.business_details.company_name.label"),
   },
   error_message: error_items('company_name'),
   value: @form_responses.dig(:business_details, :company_name),
@@ -32,18 +32,18 @@
 <%= render "govuk_publishing_components/components/input", {
   name: "company_number",
   label: {
-    text: t('coronavirus_form.questions.business_details.company_number.label'),
+    text: t("coronavirus_form.questions.business_details.company_number.label"),
   },
   error_message: error_items('company_number'),
   value: @form_responses.dig(:business_details, :company_number),
 } %>
 
 <%= render "govuk_publishing_components/components/radio", {
-  heading: t('coronavirus_form.questions.business_details.company_size.label'),
+  heading: t("coronavirus_form.questions.business_details.company_size.label"),
   heading_size: "s",
   name: "company_size",
   error_message: error_items('company_size'),
-  items: t('coronavirus_form.questions.business_details.company_size.options').map.with_index do |(_, item), index|
+  items: t("coronavirus_form.questions.business_details.company_size.options").map.with_index do |(_, item), index|
     {
       id: ("business_details_company_size" if index == 0),
       value:  item[:label],
@@ -54,11 +54,11 @@
 } %>
 
 <%= render "govuk_publishing_components/components/radio", {
-  heading: t('coronavirus_form.questions.business_details.company_location.label'),
+  heading: t("coronavirus_form.questions.business_details.company_location.label"),
   heading_size: "s",
   name: "company_location",
   error_message: error_items('company_location'),
-  items: t('coronavirus_form.questions.business_details.company_location.options').map.with_index do |(_, item), index|
+  items: t("coronavirus_form.questions.business_details.company_location.options").map.with_index do |(_, item), index|
     {
       id: ("business_details_company_location" if index == 0),
       value:  item[:label],

--- a/app/views/coronavirus_form/check_answers.html.erb
+++ b/app/views/coronavirus_form/check_answers.html.erb
@@ -1,6 +1,6 @@
-<% content_for :title do %><%= t('check_your_answers.title') %><% end %>
+<% content_for :title do %><%= t("check_your_answers.title") %><% end %>
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('check_your_answers.title') %>" />
+  <meta name="description" content="<%= t("check_your_answers.title") %>" />
 <% end %>
 
 <% content_for :back_link do %>
@@ -8,12 +8,12 @@
 <% end %>
 
 <%= render "govuk_publishing_components/components/title", {
-  title: t('check_your_answers.title'),
+  title: t("check_your_answers.title"),
   margin_top: 0,
   margin_bottom: 3,
 } %>
 
-<%= tag.p t('check_your_answers.description'), class: "govuk-body" %>
+<%= tag.p t("check_your_answers.description"), class: "govuk-body" %>
 
 <%= render "govuk_publishing_components/components/summary_list", {
   items: items_part_1,
@@ -32,12 +32,12 @@
 } %>
 
 <%= render "govuk_publishing_components/components/heading", {
-  text: t('check_your_answers.heading'),
+  text: t("check_your_answers.heading"),
   heading_level: 2,
   margin_bottom: 3,
 } %>
 
-<%= tag.p t('check_your_answers.confirmation'), class: "govuk-body" %>
+<%= tag.p t("check_your_answers.confirmation"), class: "govuk-body" %>
 
 <%= form_tag({},
   "data-module": "track-coronavirus-form-business-check-your-answers",

--- a/app/views/coronavirus_form/contact_details.html.erb
+++ b/app/views/coronavirus_form/contact_details.html.erb
@@ -1,6 +1,6 @@
-<% content_for :title do %><%= t('coronavirus_form.questions.contact_details.title') %><% end %>
+<% content_for :title do %><%= t("coronavirus_form.questions.contact_details.title") %><% end %>
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('coronavirus_form.questions.contact_details.title') %>" />
+  <meta name="description" content="<%= t("coronavirus_form.questions.contact_details.title") %>" />
 <% end %>
 
 <% content_for :back_link do %>
@@ -20,7 +20,7 @@
 ) do %>
 <%= render "govuk_publishing_components/components/input", {
   label: {
-    text: t('coronavirus_form.questions.contact_details.contact_name.label')
+    text: t("coronavirus_form.questions.contact_details.contact_name.label")
   },
   id: "contact_name",
   name: "contact_name",
@@ -29,7 +29,7 @@
 } %>
 <%= render "govuk_publishing_components/components/input", {
   label: {
-    text: t('coronavirus_form.questions.contact_details.role.label')
+    text: t("coronavirus_form.questions.contact_details.role.label")
   },
   name: "role",
   error_message: error_items('role'),
@@ -37,7 +37,7 @@
 } %>
 <%= render "govuk_publishing_components/components/input", {
   label: {
-    text: t('coronavirus_form.questions.contact_details.phone_number.label')
+    text: t("coronavirus_form.questions.contact_details.phone_number.label")
   },
   id: "phone_number",
   name: "phone_number",
@@ -46,7 +46,7 @@
 } %>
 <%= render "govuk_publishing_components/components/input", {
   label: {
-    text: t('coronavirus_form.questions.contact_details.email.label')
+    text: t("coronavirus_form.questions.contact_details.email.label")
   },
   id: "email",
   name: "email",

--- a/app/views/coronavirus_form/cookies.html.erb
+++ b/app/views/coronavirus_form/cookies.html.erb
@@ -25,7 +25,7 @@
     margin_top: 0,
   } %>
 
-  <%= tag.p t('cookies.settings_page.intro_html'), class: "govuk-body" %>
+  <%= tag.p t("cookies.settings_page.intro_html"), class: "govuk-body" %>
 
   <div class="cookie-settings__no-js">
     <%= render "govuk_publishing_components/components/govspeak", {
@@ -38,7 +38,7 @@
     <% end %>
   </div>
 
-  <% t('cookies.settings_page.tables').map do |table| %>
+  <% t("cookies.settings_page.tables").map do |table| %>
     <div class="cookie-settings__table-wrapper">
       <%= render "govuk_publishing_components/components/heading", {
         text: sanitize(table.dig(:header)),
@@ -63,7 +63,7 @@
         inline: false,
         heading: t("cookies.settings_page.cookie_options.header"),
         # hint: (cookies_usage_hint),
-        items: t('cookies.settings_page.cookie_options').fetch(:options, []),
+        items: t("cookies.settings_page.cookie_options").fetch(:options, []),
         margin_top: 0,
       } %>
 

--- a/app/views/coronavirus_form/hotel_rooms.html.erb
+++ b/app/views/coronavirus_form/hotel_rooms.html.erb
@@ -1,6 +1,6 @@
-<% content_for :title do %><%= t('coronavirus_form.questions.hotel_rooms.title') %><% end %>
+<% content_for :title do %><%= t("coronavirus_form.questions.hotel_rooms.title") %><% end %>
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('coronavirus_form.questions.hotel_rooms.title') %>" />
+  <meta name="description" content="<%= t("coronavirus_form.questions.hotel_rooms.title") %>" />
 <% end %>
 
 <% content_for :back_link do %>
@@ -14,11 +14,11 @@
   "novalidate": "true"
 ) do %>
 <%= render "govuk_publishing_components/components/radio", {
-  heading: t('coronavirus_form.questions.hotel_rooms.title'),
+  heading: t("coronavirus_form.questions.hotel_rooms.title"),
   is_page_heading: true,
   name: "hotel_rooms",
   error_message: error_items('hotel_rooms'),
-  items: t('coronavirus_form.questions.hotel_rooms.options').map do |_, item|
+  items: t("coronavirus_form.questions.hotel_rooms.options").map do |_, item|
     {
       value: item[:label],
       text: item[:label],

--- a/app/views/coronavirus_form/hotel_rooms_number.html.erb
+++ b/app/views/coronavirus_form/hotel_rooms_number.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title do %><%= t("coronavirus_form.questions.hotel_rooms_number.title") %><% end %>
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('coronavirus_form.questions.hotel_rooms_number.title') %>" />
+  <meta name="description" content="<%= t("coronavirus_form.questions.hotel_rooms_number.title") %>" />
 <% end %>
 
 <% content_for :back_link do %>

--- a/app/views/coronavirus_form/location.html.erb
+++ b/app/views/coronavirus_form/location.html.erb
@@ -1,6 +1,6 @@
-<% content_for :title do %><%= t('coronavirus_form.questions.location.title') %><% end %>
+<% content_for :title do %><%= t("coronavirus_form.questions.location.title") %><% end %>
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('coronavirus_form.questions.location.title') %>" />
+  <meta name="description" content="<%= t("coronavirus_form.questions.location.title") %>" />
 <% end %>
 
 <% content_for :back_link do %>
@@ -14,12 +14,12 @@
   "novalidate": "true"
 ) do %>
 <%= render "govuk_publishing_components/components/checkboxes", {
-  heading: t('coronavirus_form.questions.location.title'),
-  hint_text: t('coronavirus_form.questions.location.hint'),
+  heading: t("coronavirus_form.questions.location.title"),
+  hint_text: t("coronavirus_form.questions.location.hint"),
   is_page_heading: true,
   name: "location[]",
   error: error_items('location'),
-  items: t('coronavirus_form.questions.location.options').map do |_, item|
+  items: t("coronavirus_form.questions.location.options").map do |_, item|
     {
       value:  item[:label],
       label:  item[:label],

--- a/app/views/coronavirus_form/medical_equipment.html.erb
+++ b/app/views/coronavirus_form/medical_equipment.html.erb
@@ -1,6 +1,6 @@
-<% content_for :title do %><%= t('coronavirus_form.questions.medical_equipment.title') %><% end %>
+<% content_for :title do %><%= t("coronavirus_form.questions.medical_equipment.title") %><% end %>
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('coronavirus_form.questions.medical_equipment.title') %>" />
+  <meta name="description" content="<%= t("coronavirus_form.questions.medical_equipment.title") %>" />
 <% end %>
 
 <% content_for :back_link do %>
@@ -14,11 +14,11 @@
   "novalidate": "true"
 ) do %>
 <%= render "govuk_publishing_components/components/radio", {
-  heading: t('coronavirus_form.questions.medical_equipment.title'),
+  heading: t("coronavirus_form.questions.medical_equipment.title"),
   is_page_heading: true,
   name: "medical_equipment",
   error_message: error_items('medical_equipment'),
-  items: t('coronavirus_form.questions.medical_equipment.options').map do |_, item|
+  items: t("coronavirus_form.questions.medical_equipment.options").map do |_, item|
     {
       value: item[:label],
       text: item[:label],

--- a/app/views/coronavirus_form/medical_equipment_type.html.erb
+++ b/app/views/coronavirus_form/medical_equipment_type.html.erb
@@ -1,6 +1,6 @@
-<% content_for :title do %><%= t('coronavirus_form.questions.medical_equipment_type.title') %><% end %>
+<% content_for :title do %><%= t("coronavirus_form.questions.medical_equipment_type.title") %><% end %>
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('coronavirus_form.questions.medical_equipment_type.title') %>" />
+  <meta name="description" content="<%= t("coronavirus_form.questions.medical_equipment_type.title") %>" />
 <% end %>
 
 <% content_for :back_link do %>
@@ -14,21 +14,21 @@
   "novalidate": "true"
 ) do %>
 <%= render "govuk_publishing_components/components/radio", {
-  heading: t('coronavirus_form.questions.medical_equipment_type.title'),
-  hint: t('coronavirus_form.questions.medical_equipment_type.hint'),
+  heading: t("coronavirus_form.questions.medical_equipment_type.title"),
+  hint: t("coronavirus_form.questions.medical_equipment_type.hint"),
   is_page_heading: true,
   name: "medical_equipment_type",
   error_message: error_items('medical_equipment_type'),
   items: [
     {
-      value: t('coronavirus_form.questions.medical_equipment_type.options.number_ppe.label'),
-      text: t('coronavirus_form.questions.medical_equipment_type.options.number_ppe.label'),
-      checked: @product["medical_equipment_type"] == t('coronavirus_form.questions.medical_equipment_type.options.number_ppe.label'),
+      value: t("coronavirus_form.questions.medical_equipment_type.options.number_ppe.label"),
+      text: t("coronavirus_form.questions.medical_equipment_type.options.number_ppe.label"),
+      checked: @product["medical_equipment_type"] == t("coronavirus_form.questions.medical_equipment_type.options.number_ppe.label"),
     },
     {
-      value: t('coronavirus_form.questions.medical_equipment_type.options.number_testing_equipment.label'),
-      text: t('coronavirus_form.questions.medical_equipment_type.options.number_testing_equipment.label'),
-      checked: @product["medical_equipment_type"] == t('coronavirus_form.questions.medical_equipment_type.options.number_testing_equipment.label'),
+      value: t("coronavirus_form.questions.medical_equipment_type.options.number_testing_equipment.label"),
+      text: t("coronavirus_form.questions.medical_equipment_type.options.number_testing_equipment.label"),
+      checked: @product["medical_equipment_type"] == t("coronavirus_form.questions.medical_equipment_type.options.number_testing_equipment.label"),
     },
   ]
 } %>

--- a/app/views/coronavirus_form/offer_care.html.erb
+++ b/app/views/coronavirus_form/offer_care.html.erb
@@ -1,6 +1,6 @@
-<% content_for :title do %><%= t('coronavirus_form.questions.offer_care.title') %><% end %>
+<% content_for :title do %><%= t("coronavirus_form.questions.offer_care.title") %><% end %>
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('coronavirus_form.questions.offer_care.title') %>" />
+  <meta name="description" content="<%= t("coronavirus_form.questions.offer_care.title") %>" />
 <% end %>
 
 <% content_for :back_link do %>
@@ -14,12 +14,12 @@
   "novalidate": "true"
 ) do %>
 <%= render "govuk_publishing_components/components/radio", {
-  heading: t('coronavirus_form.questions.offer_care.title'),
-  hint: t('coronavirus_form.questions.offer_care.hint'),
+  heading: t("coronavirus_form.questions.offer_care.title"),
+  hint: t("coronavirus_form.questions.offer_care.hint"),
   is_page_heading: true,
   name: "offer_care",
   error_message: error_items('offer_care'),
-  items: t('coronavirus_form.questions.offer_care.options').map do |_, item|
+  items: t("coronavirus_form.questions.offer_care.options").map do |_, item|
     {
       value: item[:label],
       text: item[:label],

--- a/app/views/coronavirus_form/offer_other_support.html.erb
+++ b/app/views/coronavirus_form/offer_other_support.html.erb
@@ -1,6 +1,6 @@
-<% content_for :title do %><%= t('coronavirus_form.questions.offer_other_support.title') %><% end %>
+<% content_for :title do %><%= t("coronavirus_form.questions.offer_other_support.title") %><% end %>
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('coronavirus_form.questions.offer_other_support.title') %>" />
+  <meta name="description" content="<%= t("coronavirus_form.questions.offer_other_support.title") %>" />
 <% end %>
 
 <% content_for :back_link do %>
@@ -19,9 +19,9 @@
       label: {
         is_page_heading: true,
         heading_size: "xl",
-        text: t('coronavirus_form.questions.offer_other_support.title')
+        text: t("coronavirus_form.questions.offer_other_support.title")
       },
-      hint: t('coronavirus_form.questions.offer_other_support.hint'),
+      hint: t("coronavirus_form.questions.offer_other_support.hint"),
       name: "offer_other_support",
       value: @form_responses[:offer_other_support]
     },

--- a/app/views/coronavirus_form/offer_space.html.erb
+++ b/app/views/coronavirus_form/offer_space.html.erb
@@ -1,6 +1,6 @@
-<% content_for :title do %><%= t('coronavirus_form.questions.offer_space.title') %><% end %>
+<% content_for :title do %><%= t("coronavirus_form.questions.offer_space.title") %><% end %>
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('coronavirus_form.questions.offer_space.title') %>" />
+  <meta name="description" content="<%= t("coronavirus_form.questions.offer_space.title") %>" />
 <% end %>
 
 <% content_for :back_link do %>
@@ -14,12 +14,12 @@
   "novalidate": "true"
 ) do %>
 <%= render "govuk_publishing_components/components/radio", {
-  heading: t('coronavirus_form.questions.offer_space.title'),
-  hint: t('coronavirus_form.questions.offer_space.hint'),
+  heading: t("coronavirus_form.questions.offer_space.title"),
+  hint: t("coronavirus_form.questions.offer_space.hint"),
   is_page_heading: true,
   name: "offer_space",
   error_message: error_items('offer_space'),
-  items: t('coronavirus_form.questions.offer_space.options').map do |_, item|
+  items: t("coronavirus_form.questions.offer_space.options").map do |_, item|
     {
       value: item[:label],
       text: item[:label],

--- a/app/views/coronavirus_form/offer_transport.html.erb
+++ b/app/views/coronavirus_form/offer_transport.html.erb
@@ -1,6 +1,6 @@
-<% content_for :title do %><%= t('coronavirus_form.questions.offer_transport.title') %><% end %>
+<% content_for :title do %><%= t("coronavirus_form.questions.offer_transport.title") %><% end %>
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('coronavirus_form.questions.offer_transport.title') %>" />
+  <meta name="description" content="<%= t("coronavirus_form.questions.offer_transport.title") %>" />
 <% end %>
 
 <% content_for :back_link do %>
@@ -14,11 +14,11 @@
   "novalidate": "true"
 ) do %>
 <%= render "govuk_publishing_components/components/radio", {
-  heading: t('coronavirus_form.questions.offer_transport.title'),
+  heading: t("coronavirus_form.questions.offer_transport.title"),
   is_page_heading: true,
   name: "offer_transport",
   error_message: error_items('offer_transport'),
-  items: t('coronavirus_form.questions.offer_transport.options').map do |_, item|
+  items: t("coronavirus_form.questions.offer_transport.options").map do |_, item|
     {
       value: item[:label],
       text: item[:label],

--- a/app/views/coronavirus_form/privacy.html.erb
+++ b/app/views/coronavirus_form/privacy.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %><%= t('privacy_page.title') %><% end %>
+<% content_for :title do %><%= t("privacy_page.title") %><% end %>
 
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", { href: "/" } %>
@@ -9,4 +9,4 @@
   margin_top: 0
 } %>
 
-<%= sanitize(t('privacy_page.body_text')) %>
+<%= sanitize(t("privacy_page.body_text")) %>

--- a/app/views/coronavirus_form/product_details.html.erb
+++ b/app/views/coronavirus_form/product_details.html.erb
@@ -1,6 +1,6 @@
-<% content_for :title do %><%= t('coronavirus_form.questions.product_details.title') %><% end %>
+<% content_for :title do %><%= t("coronavirus_form.questions.product_details.title") %><% end %>
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('coronavirus_form.questions.product_details.title') %>" />
+  <meta name="description" content="<%= t("coronavirus_form.questions.product_details.title") %>" />
 <% end %>
 
 <% content_for :back_link do %>
@@ -20,7 +20,7 @@
 <%= tag.input type: "hidden", name: "product_id", value: @product[:product_id] %>
 <%= render "govuk_publishing_components/components/input", {
   label: {
-    text: t('coronavirus_form.questions.product_details.product_name.label')
+    text: t("coronavirus_form.questions.product_details.product_name.label")
   },
   id: "product_name",
   name: "product_name",
@@ -28,11 +28,11 @@
   value: @product[:product_name],
 } %>
 <%= render "govuk_publishing_components/components/radio", {
-  heading: t('coronavirus_form.questions.product_details.equipment_type.label'),
+  heading: t("coronavirus_form.questions.product_details.equipment_type.label"),
   heading_size: 's',
   name: "equipment_type",
   error_message: error_items('equipment_type'),
-  items: t('coronavirus_form.questions.product_details.equipment_type.options').map.with_index do |(_, item), index|
+  items: t("coronavirus_form.questions.product_details.equipment_type.options").map.with_index do |(_, item), index|
     {
       id: ("product_details_equipment_type" if index == 0),
       value: item[:label],
@@ -44,10 +44,10 @@
 
 <%= render "govuk_publishing_components/components/input", {
   label: {
-    text: t('coronavirus_form.questions.product_details.product_quantity.label'),
+    text: t("coronavirus_form.questions.product_details.product_quantity.label"),
   },
-  hint: t('coronavirus_form.questions.product_details.product_quantity.hint'),
-  suffix: t('coronavirus_form.questions.product_details.product_quantity.suffix'),
+  hint: t("coronavirus_form.questions.product_details.product_quantity.hint"),
+  suffix: t("coronavirus_form.questions.product_details.product_quantity.suffix"),
   id: "product_quantity",
   name: "product_quantity",
   type: "number",
@@ -56,9 +56,9 @@
 } %>
 <%= render "govuk_publishing_components/components/input", {
   label: {
-    text: t('coronavirus_form.questions.product_details.product_cost.label'),
+    text: t("coronavirus_form.questions.product_details.product_cost.label"),
   },
-  hint: t('coronavirus_form.questions.product_details.product_cost.hint'),
+  hint: t("coronavirus_form.questions.product_details.product_cost.hint"),
   id: "product_cost",
   name: "product_cost",
   inputmode: "decimal",
@@ -69,28 +69,28 @@
 } %>
 <%= render "govuk_publishing_components/components/input", {
   label: {
-    text: t('coronavirus_form.questions.product_details.certification_details.label'),
+    text: t("coronavirus_form.questions.product_details.certification_details.label"),
   },
-  hint: t('coronavirus_form.questions.product_details.certification_details.hint'),
+  hint: t("coronavirus_form.questions.product_details.certification_details.hint"),
   id: "certification_details",
   name: "certification_details",
   error_message: error_items('certification_details'),
   value: @product[:certification_details],
 } %>
 <%= render "govuk_publishing_components/components/radio", {
-  heading: t('coronavirus_form.questions.product_details.product_location.label'),
+  heading: t("coronavirus_form.questions.product_details.product_location.label"),
   heading_size: "s",
   name: "product_location",
   error_message: error_items('product_location'),
   items: [
     {
       id: "product_details_product_location",
-      value: t('coronavirus_form.questions.product_details.product_location.options.option_uk.label'),
-      text: t('coronavirus_form.questions.product_details.product_location.options.option_uk.label'),
-      checked: @product[:product_location] == t('coronavirus_form.questions.product_details.product_location.options.option_uk.label'),
+      value: t("coronavirus_form.questions.product_details.product_location.options.option_uk.label"),
+      text: t("coronavirus_form.questions.product_details.product_location.options.option_uk.label"),
+      checked: @product[:product_location] == t("coronavirus_form.questions.product_details.product_location.options.option_uk.label"),
       conditional: render("govuk_publishing_components/components/input", {
         label: {
-          text: t('coronavirus_form.questions.product_details.product_location.options.option_uk.input.label'),
+          text: t("coronavirus_form.questions.product_details.product_location.options.option_uk.input.label"),
         },
         id: "product_postcode",
         name: "product_postcode",
@@ -100,20 +100,20 @@
       })
     },
     {
-      value: t('coronavirus_form.questions.product_details.product_location.options.option_eu.label'),
-      text: t('coronavirus_form.questions.product_details.product_location.options.option_eu.label'),
-      checked: @product[:product_location] == t('coronavirus_form.questions.product_details.product_location.options.option_eu.label'),
+      value: t("coronavirus_form.questions.product_details.product_location.options.option_eu.label"),
+      text: t("coronavirus_form.questions.product_details.product_location.options.option_eu.label"),
+      checked: @product[:product_location] == t("coronavirus_form.questions.product_details.product_location.options.option_eu.label"),
     },
     {
-      value: t('coronavirus_form.questions.product_details.product_location.options.option_rest_of_world.label'),
-      text: t('coronavirus_form.questions.product_details.product_location.options.option_rest_of_world.label'),
-      checked: @product[:product_location] == t('coronavirus_form.questions.product_details.product_location.options.option_rest_of_world.label'),
+      value: t("coronavirus_form.questions.product_details.product_location.options.option_rest_of_world.label"),
+      text: t("coronavirus_form.questions.product_details.product_location.options.option_rest_of_world.label"),
+      checked: @product[:product_location] == t("coronavirus_form.questions.product_details.product_location.options.option_rest_of_world.label"),
     },
   ]
 } %>
 <%= render "govuk_publishing_components/components/input", {
   label: {
-    text: t('coronavirus_form.questions.product_details.product_url.label')
+    text: t("coronavirus_form.questions.product_details.product_url.label")
   },
   name: "product_url",
   error_message: error_items('product_url'),
@@ -121,9 +121,9 @@
 } %>
 <%= render "govuk_publishing_components/components/input", {
   label: {
-    text: t('coronavirus_form.questions.product_details.lead_time.label')
+    text: t("coronavirus_form.questions.product_details.lead_time.label")
   },
-  suffix: t('coronavirus_form.questions.product_details.lead_time.suffix'),
+  suffix: t("coronavirus_form.questions.product_details.lead_time.suffix"),
   id: "lead_time",
   name: "lead_time",
   error_message: error_items('lead_time'),

--- a/app/views/coronavirus_form/session_expired.html.erb
+++ b/app/views/coronavirus_form/session_expired.html.erb
@@ -1,6 +1,6 @@
-<% content_for :title do %><%= t('session_expired.title') %><% end %>
+<% content_for :title do %><%= t("session_expired.title") %><% end %>
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('session_expired.title') %>" />
+  <meta name="description" content="<%= t("session_expired.title") %>" />
 <% end %>
 
 <%= render "govuk_publishing_components/components/title", {
@@ -8,7 +8,7 @@
   margin_top: 0
 } %>
 
-<%= sanitize(t('session_expired.body_text')) %>
+<%= sanitize(t("session_expired.body_text")) %>
 
 <%= render "govuk_publishing_components/components/button", {
   text: "Start now",

--- a/app/views/coronavirus_form/testing_equipment.html.erb
+++ b/app/views/coronavirus_form/testing_equipment.html.erb
@@ -1,6 +1,6 @@
-<% content_for :title do %><%= t('coronavirus_form.testing_equipment.title') %><% end %>
+<% content_for :title do %><%= t("coronavirus_form.testing_equipment.title") %><% end %>
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('coronavirus_form.testing_equipment.title') %>" />
+  <meta name="description" content="<%= t("coronavirus_form.testing_equipment.title") %>" />
 <% end %>
 
 <% content_for :back_link do %>
@@ -8,18 +8,18 @@
 <% end %>
 
 <%= render "govuk_publishing_components/components/title", {
-  title: t('coronavirus_form.testing_equipment.title'),
+  title: t("coronavirus_form.testing_equipment.title"),
   margin_top: 0
 } %>
 
 <p class="govuk-body govuk-!-margin-bottom-8">
-  <a class="govuk-link" href="<%= t('coronavirus_form.testing_equipment.external_link') %>" target="_blank">
-    <%= t('coronavirus_form.testing_equipment.link.label') %>
+  <a class="govuk-link" href="<%= t("coronavirus_form.testing_equipment.external_link") %>" target="_blank">
+    <%= t("coronavirus_form.testing_equipment.link.label") %>
   </a>
 </p>
 
 <%= render "govuk_publishing_components/components/button", {
-  text: t('coronavirus_form.testing_equipment.button.label'),
+  text: t("coronavirus_form.testing_equipment.button.label"),
   href: additional_product_url,
   margin_bottom: true
 } %>

--- a/app/views/coronavirus_form/thank_you.html.erb
+++ b/app/views/coronavirus_form/thank_you.html.erb
@@ -1,6 +1,6 @@
-<% content_for :title do %><%= t('coronavirus_form.thank_you.title') %><% end %>
+<% content_for :title do %><%= t("coronavirus_form.thank_you.title") %><% end %>
 <%= render "govuk_publishing_components/components/panel", {
   title: t("coronavirus_form.thank_you.title")
 } %>
 
-<%= sanitize(t('coronavirus_form.thank_you.description')) %>
+<%= sanitize(t("coronavirus_form.thank_you.description")) %>

--- a/app/views/coronavirus_form/transport_type.html.erb
+++ b/app/views/coronavirus_form/transport_type.html.erb
@@ -1,6 +1,6 @@
-<% content_for :title do %><%= t('coronavirus_form.questions.transport_type.title') %><% end %>
+<% content_for :title do %><%= t("coronavirus_form.questions.transport_type.title") %><% end %>
 <% content_for :meta_tags do %>
-  <meta name="description" content="<%= t('coronavirus_form.questions.transport_type.title') %>" />
+  <meta name="description" content="<%= t("coronavirus_form.questions.transport_type.title") %>" />
 <% end %>
 
 <% content_for :back_link do %>
@@ -15,12 +15,12 @@
 ) do %>
 
 <%= render "govuk_publishing_components/components/checkboxes", {
-  heading: t('coronavirus_form.questions.transport_type.title'),
-  hint_text: t('coronavirus_form.questions.transport_type.hint'),
+  heading: t("coronavirus_form.questions.transport_type.title"),
+  hint_text: t("coronavirus_form.questions.transport_type.hint"),
   is_page_heading: true,
   name: "transport_type[]",
   error: error_items('transport_type'),
-  items: t('coronavirus_form.questions.transport_type.options').map do |_, item|
+  items: t("coronavirus_form.questions.transport_type.options").map do |_, item|
     {
       value:  item[:label],
       label:  item[:label],


### PR DESCRIPTION
In some places we are using double quotes, and in other places we are using single quotes when including translations in the views.

In the absence of view linting, updating to make this consistent in all views.