### PR TITLE
Redirect GET /start to first_question

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,10 +4,12 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   get "/healthcheck", to: proc { [200, {}, %w[OK]] }
 
-  # Start page
+  # Root redirects to start page
   get "/", to: redirect("https://www.gov.uk/coronavirus-support-from-business")
 
   scope module: "coronavirus_form" do
+    first_question = "/medical-equipment"
+
     # Question 1.0: Can you offer medical equipment?
     get "/medical-equipment", to: "medical_equipment#show"
     post "/medical-equipment", to: "medical_equipment#submit"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,8 @@ Rails.application.routes.draw do
   scope module: "coronavirus_form" do
     first_question = "/medical-equipment"
 
+    get "/start", to: redirect(first_question)
+
     # Question 1.0: Can you offer medical equipment?
     get "/medical-equipment", to: "medical_equipment#show"
     post "/medical-equipment", to: "medical_equipment#submit"

--- a/spec/requests/start_spec.rb
+++ b/spec/requests/start_spec.rb
@@ -1,0 +1,8 @@
+RSpec.describe "start" do
+  describe "GET /start" do
+    it "redirects to the first question" do
+      get start_path
+      expect(response).to redirect_to medical_equipment_path
+    end
+  end
+end


### PR DESCRIPTION
What
----

- Aliased "/medical_equipment" as a `first_question` variable so it can be changed once in future
- Add a redirect from `/start` to `first_question` with request test.

How to review
-------------

Once this is up we'll be able to point start pages at the `/start` route permenantly. Start routes are outside of the app and so easy to miss whenever we update a first question.

This has occured in the past and this ticket is a follow on action from a previous incidnet.

Links
-----

[Trello Create a `/start` path to redirect to first question](https://trello.com/c/HoPfPgbX/396-create-a-start-path-to-redirect-to-first-question),
