### PR TITLE
Ensure GovUK analytics hasn't been blocked before trying to call it.

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -5,5 +5,7 @@
 //= require analytics
 //= require cookies
 window.CookieSettings.start()
-window.GOVUK.analyticsInit()
 window.GOVUKFrontend.initAll()
+if (window.GOVUK.analyticsInit) {
+  window.GOVUK.analyticsInit()
+}


### PR DESCRIPTION
Previously the call was throwing exception when it had been blocked and this prevented initAll() being called. This in turn meant that the postcode field was not being displayed when the user selected "United Kingdom" on the Product Details page.

What
----

Moved the call to `GOVUK.analyticsInit` to the end of the script and check loading the analytics has worked before trying to call it.

How to review
-------------

Step 1. Block analytics from loading using either a browser privacy plugin - or Brave browser.
Step 2. On the Product Details page, the postcode field displays when you select United Kingdom

Links
-----

https://trello.com/c/8EhDkXdW/408-js-error-when-analytics-is-blocked

