### PR TITLE
Update description fields

### DIFF
--- a/app/controllers/coronavirus_form/offer_space_type_controller.rb
+++ b/app/controllers/coronavirus_form/offer_space_type_controller.rb
@@ -47,7 +47,6 @@ private
     [
       validate_field_response_length(controller_name, TEXT_FIELDS),
       validate_checkbox_field(controller_name, values: @form_responses[:offer_space_type], allowed_values: ALLOWED_VALUES),
-      validate_mandatory_text_fields(controller_name, TEXT_FIELDS),
       validate_description_fields(@form_responses[:offer_space_type]),
       validate_descriptions_response_length(@form_responses[:offer_space_type]),
       validate_charge_field("space_cost", @form_responses[:space_cost]),

--- a/app/controllers/coronavirus_form/rooms_number_controller.rb
+++ b/app/controllers/coronavirus_form/rooms_number_controller.rb
@@ -2,15 +2,18 @@
 
 class CoronavirusForm::RoomsNumberController < ApplicationController
   REQUIRED_FIELDS = %w[rooms_number].freeze
+  TEXT_FIELDS = %w[accommodation_description].freeze
 
   def submit
     @form_responses = {
       rooms_number: strip_tags(params[:rooms_number]).presence,
+      accommodation_description: strip_tags(params[:accommodation_description]).presence,
       accommodation_cost: strip_tags(params[:accommodation_cost]).presence,
     }
 
     invalid_fields = validate_mandatory_text_fields(controller_name, REQUIRED_FIELDS) +
-      validate_charge_field("accommodation_cost", @form_responses[:accommodation_cost])
+      validate_charge_field("accommodation_cost", @form_responses[:accommodation_cost]) +
+      validate_field_response_length(controller_name, TEXT_FIELDS)
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields
@@ -29,6 +32,7 @@ private
   def update_session_store
     session[:rooms_number] = @form_responses[:rooms_number]
     session[:accommodation_cost] = @form_responses[:accommodation_cost]
+    session[:accommodation_description] = @form_responses[:accommodation_description]
   end
 
   def previous_path

--- a/app/controllers/coronavirus_form/transport_type_controller.rb
+++ b/app/controllers/coronavirus_form/transport_type_controller.rb
@@ -16,7 +16,6 @@ class CoronavirusForm::TransportTypeController < ApplicationController
       values: @form_responses[:transport_type],
       allowed_values: I18n.t("coronavirus_form.questions.#{controller_name}.options").map { |_, item| item.dig(:label) },
     ) +
-      validate_mandatory_text_fields(controller_name, REQUIRED_FIELDS) +
       validate_field_response_length(controller_name, TEXT_FIELDS) +
       validate_charge_field("transport_cost", @form_responses[:transport_cost])
 

--- a/app/views/coronavirus_form/offer_space_type.erb
+++ b/app/views/coronavirus_form/offer_space_type.erb
@@ -74,6 +74,7 @@
         text: t("coronavirus_form.questions.offer_space_type.general_space_description.label"),
         heading_size: "m"
       },
+      hint: t("coronavirus_form.questions.offer_space_type.general_space_description.hint"),
       name: "general_space_description",
       error_message: error_items("general_space_description"),
       value: @form_responses[:general_space_description]

--- a/app/views/coronavirus_form/offer_space_type.erb
+++ b/app/views/coronavirus_form/offer_space_type.erb
@@ -70,7 +70,8 @@
 
   <%= render "govuk_publishing_components/components/textarea", {
     label: {
-      text: t("coronavirus_form.questions.offer_space_type.general_space_description.label")
+      text: t("coronavirus_form.questions.offer_space_type.general_space_description.label"),
+      heading_size: "m"
     },
     name: "general_space_description",
     error_message: error_items("general_space_description"),

--- a/app/views/coronavirus_form/offer_space_type.erb
+++ b/app/views/coronavirus_form/offer_space_type.erb
@@ -68,14 +68,17 @@
     ]
   } %>
 
-  <%= render "govuk_publishing_components/components/textarea", {
-    label: {
-      text: t("coronavirus_form.questions.offer_space_type.general_space_description.label"),
-      heading_size: "m"
+  <%= render "govuk_publishing_components/components/character_count", {
+    textarea: {
+      label: {
+        text: t("coronavirus_form.questions.offer_space_type.general_space_description.label"),
+        heading_size: "m"
+      },
+      name: "general_space_description",
+      error_message: error_items("general_space_description"),
+      value: @form_responses[:general_space_description]
     },
-    name: "general_space_description",
-    error_message: error_items("general_space_description"),
-    value: @form_responses[:general_space_description]
+    maxlength: 1000
   } %>
 
   <%= render partial: "coronavirus_form/how_much_charge", locals: { cost_field: "space_cost" } %>

--- a/app/views/coronavirus_form/rooms_number.html.erb
+++ b/app/views/coronavirus_form/rooms_number.html.erb
@@ -27,6 +27,20 @@
   error_message: error_items("rooms_number")
 } %>
 
+<%= render "govuk_publishing_components/components/character_count", {
+  textarea: {
+    label: {
+      text: t("coronavirus_form.questions.rooms_number.accommodation_description.label"),
+      heading_size: "m"
+    },
+    hint: t("coronavirus_form.questions.rooms_number.accommodation_description.hint"),
+    name: "accommodation_description",
+    error_message: error_items("accommodation_description"),
+    value: @form_responses[:accommodation_description]
+  },
+  maxlength: 1000
+} %>
+
 <%= render partial: "coronavirus_form/how_much_charge", locals: { cost_field: "accommodation_cost" } %>
 
 <%= render "govuk_publishing_components/components/button", text: t("coronavirus_form.submit_and_next"), margin_bottom: true %>

--- a/app/views/coronavirus_form/transport_type.html.erb
+++ b/app/views/coronavirus_form/transport_type.html.erb
@@ -35,6 +35,7 @@
       text: t("coronavirus_form.questions.transport_type.transport_description.label"),
       heading_size: "m"
     },
+    hint: t("coronavirus_form.questions.transport_type.transport_description.hint"),
     name: "transport_description",
     error_message: error_items("transport_description"),
     value: @form_responses[:transport_description]

--- a/app/views/coronavirus_form/transport_type.html.erb
+++ b/app/views/coronavirus_form/transport_type.html.erb
@@ -29,14 +29,17 @@
   end
 } %>
 
-<%= render "govuk_publishing_components/components/textarea", {
-  label: {
-    text: t("coronavirus_form.questions.transport_type.transport_description.label"),
-    heading_size: "m"
+<%= render "govuk_publishing_components/components/character_count", {
+  textarea: {
+    label: {
+      text: t("coronavirus_form.questions.transport_type.transport_description.label"),
+      heading_size: "m"
+    },
+    name: "transport_description",
+    error_message: error_items("transport_description"),
+    value: @form_responses[:transport_description]
   },
-  name: "transport_description",
-  error_message: error_items("transport_description"),
-  value: @form_responses[:transport_description]
+  maxlength: 1000
 } %>
 
 <%= render partial: "coronavirus_form/how_much_charge", locals: { cost_field: "transport_cost" } %>

--- a/app/views/coronavirus_form/transport_type.html.erb
+++ b/app/views/coronavirus_form/transport_type.html.erb
@@ -31,7 +31,8 @@
 
 <%= render "govuk_publishing_components/components/textarea", {
   label: {
-    text: t("coronavirus_form.questions.transport_type.transport_description.label")
+    text: t("coronavirus_form.questions.transport_type.transport_description.label"),
+    heading_size: "m"
   },
   name: "transport_description",
   error_message: error_items("transport_description"),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -368,7 +368,8 @@ en:
               custom_length_error: "Description of other space must be 1000 characters or fewer"
               error_message: Enter the approximate total size of the spaces, in square feet
         general_space_description:
-          label: Give a description, for example whether you have one space, or multiple units
+          label: "Give a description of the space (optional)"
+          hint: "For example whether you have one space, or multiple units."
           custom_error: Enter a description
           custom_length_error: Description of space must be 1000 characters or fewer
         custom_select_error: Select the kind of space you can offer

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -310,7 +310,7 @@ en:
           label: "Give a description of the rooms (optional)"
           hint: "For example whether they’re in one location, or in different places."
           custom_error: "Enter a description"
-          custom_length_error: "Description of the support you can offer must be 1000 characters or fewer"
+          custom_length_error: "Description must be 1000 characters or fewer"
       accommodation_cost:
         title: "How much would you charge for the accommodation?"
       offer_transport:
@@ -336,7 +336,7 @@ en:
           label: "Give a description of the transport or logistics services (optional)"
           hint: "For example how many vehicles you can offer."
           custom_error: "Enter a description"
-          custom_length_error: "Description of the support you can offer must be 1000 characters or fewer"
+          custom_length_error: "Description must be 1000 characters or fewer"
       transport_cost:
         title: "How much would you charge for the transport or logistics services?"
       offer_space:
@@ -365,7 +365,7 @@ en:
               id: office_space_description
               label: Approximate total size of all offices, in square feet
               error_message: Enter the approximate total size of the office space, in square feet
-              custom_length_error: "Description of office space must be 1000 characters or fewer"
+              custom_length_error: "Description must be 1000 characters or fewer"
           other:
             label: "Other"
             description:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -306,6 +306,11 @@ en:
         hint: "Approximate amount, for example 10, 500, 10000."
         rooms_number:
           custom_error: "Enter the approximate amount of rooms you think you can offer"
+        accommodation_description:
+          label: "Give a description of the rooms (optional)"
+          hint: "For example whether they’re in one location, or in different places."
+          custom_error: "Enter a description"
+          custom_length_error: "Description of the support you can offer must be 1000 characters or fewer"
       accommodation_cost:
         title: "How much would you charge for the accommodation?"
       offer_transport:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -328,7 +328,8 @@ en:
             label: "Other"
         custom_select_error: "Select what kind of transport or logistics services you can you offer"
         transport_description:
-          label: "Give a description, for example how many vehicles you can offer"
+          label: "Give a description of the transport or logistics services (optional)"
+          hint: "For example how many vehicles you can offer."
           custom_error: "Enter a description"
           custom_length_error: "Description of the support you can offer must be 1000 characters or fewer"
       transport_cost:

--- a/config/schemas/form_response.json
+++ b/config/schemas/form_response.json
@@ -111,6 +111,9 @@
     "rooms_number": {
       "type": "string"
     },
+    "accommodation_description": {
+      "type": "string"
+    },
     "accommodation_cost": {
       "$ref": "#/definitions/how_much_charge"
     },

--- a/spec/controllers/coronavirus_form/rooms_number_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/rooms_number_controller_spec.rb
@@ -25,15 +25,18 @@ RSpec.describe CoronavirusForm::RoomsNumberController, type: :controller do
     let(:cost) do
       I18n.t("coronavirus_form.questions.how_much_charge.options").map { |_, item| item[:label] }.sample
     end
+    let(:description) { "Hotel rooms" }
 
     it "sets session variables" do
       post :submit,
            params: {
              rooms_number: selected,
              accommodation_cost: cost,
+             accommodation_description: description,
            }
       expect(session[:rooms_number]).to eq selected
       expect(session[:accommodation_cost]).to eq cost
+      expect(session[:accommodation_description]).to eq description
     end
 
     it "redirects to check your answers if check your answers previously seen" do
@@ -66,6 +69,21 @@ RSpec.describe CoronavirusForm::RoomsNumberController, type: :controller do
 
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response).to render_template(current_template)
+    end
+
+    described_class::TEXT_FIELDS.each do |field|
+      it "validates that #{field} is 1000 or fewer characters" do
+        params = {
+          rooms_number: selected,
+          accommodation_cost: cost,
+          accommodation_description: description,
+        }
+        params[field] = SecureRandom.hex(1001)
+        post :submit, params: params
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to render_template(current_template)
+      end
     end
   end
 end

--- a/spec/controllers/coronavirus_form/transport_type_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/transport_type_controller_spec.rb
@@ -93,18 +93,6 @@ RSpec.describe CoronavirusForm::TransportTypeController, type: :controller do
       expect(response).to render_template(current_template)
     end
 
-    it "validates a description is entered" do
-      session[:check_answers_seen] = true
-      post :submit,
-           params: {
-             transport_type: selected,
-             transport_description: "",
-             transport_cost: cost,
-           }
-      expect(response).to have_http_status(:unprocessable_entity)
-      expect(response).to render_template(current_template)
-    end
-
     it "validates a transport cost option is chosen" do
       post :submit,
            params: {


### PR DESCRIPTION
What
----

Updates the "give a description of ..." fields throughout the form to:
- adds a description field to the accommodation details view
- ensures heading format is the same weight and size for all similar questions
- makes these fields optional in all questions
- updates question content to identify these as optional
- adds hint text for all questions

What kind of transport view:
![Screenshot 2020-05-14 at 11 20 11](https://user-images.githubusercontent.com/6329861/81923159-1fa98f00-95d5-11ea-809f-62d60fc4c2d5.png)

What kind of space view:
![Screenshot 2020-05-14 at 11 20 31](https://user-images.githubusercontent.com/6329861/81923163-21735280-95d5-11ea-9c34-03f1d31c9490.png)

How many rooms view:
![Screenshot 2020-05-14 at 11 20 54](https://user-images.githubusercontent.com/6329861/81923167-220be900-95d5-11ea-8e71-16309f517097.png)

Not to be merged until confirmation has been received that downstream processing of the data has been updated.

How to review
-------------

- Review code
- Run app locally and visit `/offer-space-type`, `/transport-type` and `/rooms-number` to check frontend changes and validation changes

Links
-----

Trello card: https://trello.com/c/SWlMCAGx