### PR TITLE
Use exclusive checkboxes

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,11 +1,20 @@
 //= require jquery
-// = require govuk/all.js
-//= require govuk_publishing_components/components/cookie-banner
+//= require govuk_publishing_components/modules
 //= require govuk_publishing_components/lib/cookie-functions
+//= require govuk_publishing_components/components/button
+//= require govuk_publishing_components/components/character-count
+//= require govuk_publishing_components/components/checkboxes
+//= require govuk_publishing_components/components/cookie-banner
+//= require govuk_publishing_components/components/error-summary
+//= require govuk_publishing_components/components/radio
 //= require analytics
 //= require cookies
 window.CookieSettings.start()
-window.GOVUKFrontend.initAll()
+
 if (window.GOVUK.analyticsInit) {
   window.GOVUK.analyticsInit()
 }
+
+$(document).ready(function () {
+  window.GOVUK.modules.start()
+})

--- a/app/controllers/coronavirus_form/expert_advice_type_controller.rb
+++ b/app/controllers/coronavirus_form/expert_advice_type_controller.rb
@@ -15,6 +15,8 @@ class CoronavirusForm::ExpertAdviceTypeController < ApplicationController
         values: @form_responses[:expert_advice_type],
         allowed_values: I18n.t("coronavirus_form.questions.#{controller_name}.options").map { |_, item| item.dig(:label) },
         other: @form_responses[:expert_advice_type_other],
+        exclusive: selected_exclusive?,
+        exclusive_values: exclusive_values,
       )
 
     if invalid_fields.any?
@@ -50,6 +52,14 @@ private
     @form_responses[:expert_advice_type].include?(
       I18n.t("coronavirus_form.questions.#{controller_name}.options.other.label"),
     )
+  end
+
+  def selected_exclusive?
+    @form_responses[:expert_advice_type].include?(exclusive_values.first)
+  end
+
+  def exclusive_values
+    I18n.t("coronavirus_form.questions.#{controller_name}.options").map { |_, item| item.dig(:label) if item.dig(:exclusive) == true }.compact
   end
 
   def previous_path

--- a/app/controllers/coronavirus_form/offer_care_qualifications_controller.rb
+++ b/app/controllers/coronavirus_form/offer_care_qualifications_controller.rb
@@ -60,7 +60,11 @@ private
   def update_session_store
     session[:offer_care_type] = @form_responses[:offer_care_type]
     session[:offer_care_qualifications] = @form_responses[:offer_care_qualifications]
-    session[:offer_care_qualifications_type] = @form_responses[:offer_care_qualifications_type]
+
+    session[:offer_care_qualifications_type] = if @form_responses[:offer_care_qualifications].include?(I18n.t("coronavirus_form.questions.#{controller_name}.care_qualifications.options.nursing_or_healthcare_qualification.label"))
+                                                 @form_responses[:offer_care_qualifications_type]
+                                               end
+
     session[:care_cost] = @form_responses[:care_cost]
   end
 

--- a/app/controllers/coronavirus_form/offer_care_qualifications_controller.rb
+++ b/app/controllers/coronavirus_form/offer_care_qualifications_controller.rb
@@ -33,7 +33,6 @@ private
       validate_field_response_length("#{controller_name}.care_qualifcations", TEXT_FIELDS),
       validate_missing_offer_care_type_fields,
       validate_missing_offer_care_qualifications_fields,
-      validate_selecting_of_offer_care_qualifications_fields,
       validate_charge_field("care_cost", @form_responses[:care_cost]),
     ].flatten.compact
   end
@@ -53,22 +52,9 @@ private
       allowed_values: I18n.t("coronavirus_form.questions.#{controller_name}.care_qualifications.options").map { |_, item| item.dig(:label) },
       other: @form_responses[:offer_care_qualifications_type],
       other_field: "nursing_or_healthcare_qualification",
+      exclusive: selected_exclusive?,
+      exclusive_values: exclusive_values,
     )
-  end
-
-  def validate_selecting_of_offer_care_qualifications_fields
-    validate_qualification_or_not("#{controller_name}.care_qualifications", values: @form_responses[:offer_care_qualifications])
-  end
-
-  def validate_qualification_or_not(page, values:)
-    if values.length > 1 && values.include?(t("coronavirus_form.questions.#{page}.options.no_qualification.label"))
-      [{ field: page.to_s.sub(".", "_"),
-         text: t(
-           "coronavirus_form.questions.#{page}.custom_select_error_qualification_or_not",
-         ) }]
-    else
-      []
-    end
   end
 
   def update_session_store
@@ -76,6 +62,14 @@ private
     session[:offer_care_qualifications] = @form_responses[:offer_care_qualifications]
     session[:offer_care_qualifications_type] = @form_responses[:offer_care_qualifications_type]
     session[:care_cost] = @form_responses[:care_cost]
+  end
+
+  def selected_exclusive?
+    @form_responses[:offer_care_qualifications].include?(exclusive_values.first)
+  end
+
+  def exclusive_values
+    I18n.t("coronavirus_form.questions.#{controller_name}.care_qualifications.options").map { |_, item| item.dig(:label) if item.dig(:exclusive) == true }.compact
   end
 
   def previous_path

--- a/app/helpers/field_validation_helper.rb
+++ b/app/helpers/field_validation_helper.rb
@@ -50,7 +50,7 @@ module FieldValidationHelper
     []
   end
 
-  def validate_checkbox_field(page, values:, allowed_values:, other: false, other_field: "other")
+  def validate_checkbox_field(page, values:, allowed_values:, other: false, other_field: "other", exclusive: false, exclusive_values: [])
     if values.blank? || values.empty?
       return [{ field: page.to_s.sub(".", "_"),
                 text: t(
@@ -72,6 +72,14 @@ module FieldValidationHelper
                 text: t(
                   "coronavirus_form.questions.#{page}.options.#{other_field}.error_message",
                   default: t("coronavirus_form.errors.missing_mandatory_text_field", field: t("coronavirus_form.questions.#{page}.title")).humanize,
+                ) }]
+    end
+
+    if exclusive && (values - exclusive_values).any?
+      return [{ field: page.to_s.sub(".", "_"),
+                text: t(
+                  "coronavirus_form.questions.#{page}.exclusive_select_error",
+                  default: t("coronavirus_form.errors.checkbox_field", field: t("coronavirus_form.questions.#{page}.title")).humanize,
                 ) }]
     end
 

--- a/app/views/coronavirus_form/expert_advice_type.html.erb
+++ b/app/views/coronavirus_form/expert_advice_type.html.erb
@@ -64,18 +64,14 @@
             value: @form_responses[:expert_advice_type_other],
           })
         },
-      ]
-    } %>
-    <%= tag.p t("coronavirus_form.questions.expert_advice_type.or"), class: "govuk-body" %>
-    <%= render "govuk_publishing_components/components/checkboxes", {
-      name: "expert_advice_type[]",
-      items: [
+        :or,
         {
           value: t("coronavirus_form.questions.expert_advice_type.options.no_expertise.label"),
           label: t("coronavirus_form.questions.expert_advice_type.options.no_expertise.label"),
           checked: @form_responses.fetch(:expert_advice_type, []).include?(t("coronavirus_form.questions.expert_advice_type.options.no_expertise.label")),
+          exclusive: true,
         },
-      ],
-    }%>
+      ]
+    } %>
     <%= render "govuk_publishing_components/components/button", text: t("coronavirus_form.submit_and_next"), margin_bottom: true %>
     <% end %>

--- a/app/views/coronavirus_form/offer_care_qualifications.erb
+++ b/app/views/coronavirus_form/offer_care_qualifications.erb
@@ -54,18 +54,13 @@
           error_message: error_items("offer_care_qualifications_type"),
           value: @form_responses[:offer_care_qualifications_type],
         })
-      }
-    ]
-  } %>
-  <%= tag.p t("coronavirus_form.questions.offer_care_qualifications.care_qualifications.or"), class: "govuk-body" %>
-  <%= render "govuk_publishing_components/components/checkboxes", {
-    name: "offer_care_qualifications[]",
-    error: error_items("offer_care_qualifications_care_qualifications"),
-    items: [
+      },
+      :or,
       {
         value: t('coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.no_qualification.label'),
         label: t('coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.no_qualification.label'),
         checked: @form_responses.fetch(:offer_care_qualifications, []).include?(t('coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.no_qualification.label')),
+        exclusive: true,
       },
     ]
   } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -474,7 +474,6 @@ en:
       expert_advice_type:
         title: "What kind of services or expertise can you offer?"
         hint: "Select all that apply."
-        or: "Or"
         options:
           medical:
             label: "Medical"
@@ -575,7 +574,6 @@ en:
               error_message: "Enter the type of qualification that you or people in your business have"
             no_qualification:
               label: "I do not have a qualification"
-          or: "Or"
           custom_select_error: "Select the qualifications that you or people in your company have. If you do not have any select ‘I do not have a qualification’"
           custom_select_error_qualification_or_not: "You cannot select a qualification as well as ’I do not have a qualification’"
           offer_care_qualifications_type:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -494,7 +494,9 @@ en:
             error_message: "Select the best way to describe the services or expertise you can offer"
           no_expertise:
             label: "I cannot offer expertise"
+            exclusive: true
         custom_select_error: "Select the best way to describe your expertise or consultancy experience"
+        exclusive_select_error: "You cannot select an expertise as well as ‘I cannot offer expertise’"
         expert_advice_type_other:
           custom_length_error: "Description of your expertise must be 1000 characters or fewer"
       construction_services:
@@ -574,8 +576,9 @@ en:
               error_message: "Enter the type of qualification that you or people in your business have"
             no_qualification:
               label: "I do not have a qualification"
+              exclusive: true
           custom_select_error: "Select the qualifications that you or people in your company have. If you do not have any select ‘I do not have a qualification’"
-          custom_select_error_qualification_or_not: "You cannot select a qualification as well as ’I do not have a qualification’"
+          exclusive_select_error: "You cannot select a qualification as well as ‘I do not have a qualification’"
           offer_care_qualifications_type:
             custom_length_error: "Description of your qualification must be 1000 characters or fewer"
       care_cost:

--- a/spec/controllers/coronavirus_form/expert_advice_type_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/expert_advice_type_controller_spec.rb
@@ -179,6 +179,13 @@ RSpec.describe CoronavirusForm::ExpertAdviceTypeController, type: :controller do
       expect(response).to render_template(current_template)
     end
 
+    it "validates only the exclusive option is selected" do
+      post :submit, params: { expert_advice_type: [I18n.t("coronavirus_form.questions.expert_advice_type.options.no_expertise.label")] + selected }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to render_template(current_template)
+    end
+
     described_class::TEXT_FIELDS.each do |field|
       it "validates that #{field} is 1000 or fewer characters" do
         params = { expert_advice_type: %w[Other] }

--- a/spec/controllers/coronavirus_form/offer_care_qualifications_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/offer_care_qualifications_controller_spec.rb
@@ -118,6 +118,22 @@ RSpec.describe CoronavirusForm::OfferCareQualificationsController, type: :contro
         ]
         expect(session[:offer_care_qualifications_type]).to eq "Registered Nurse"
       end
+
+      it "clears previously entered 'Type of qualification' data if 'Nursing or other healthcare qualification' is no longer selected" do
+        session[:offer_care_type] = selected_type
+        session[:offer_care_qualifications] = [I18n.t("coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.nursing_or_healthcare_qualification.label")]
+        session[:offer_care_qualifications_type] = "Registered Nurse"
+        session[:care_cost] = selected_care_cost
+
+        post :submit, params: {
+          offer_care_type: selected_type,
+          offer_care_qualifications: [I18n.t("coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.dbs_check.label")],
+          offer_care_qualifications_type: "Registered Nurse",
+          care_cost: selected_care_cost,
+        }
+
+        expect(session[:offer_care_qualifications_type]).to be nil
+      end
     end
 
     it "validates a valid care type is chosen" do

--- a/spec/controllers/coronavirus_form/offer_care_qualifications_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/offer_care_qualifications_controller_spec.rb
@@ -150,6 +150,20 @@ RSpec.describe CoronavirusForm::OfferCareQualificationsController, type: :contro
       expect(response).to render_template(current_template)
     end
 
+    it "validates only the exclusive option is selected" do
+      post :submit,
+           params: {
+             offer_care_type: selected_type,
+             offer_care_qualifications: [
+               I18n.t("coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.dbs_check.label"),
+               I18n.t("coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.no_qualification.label"),
+             ],
+             care_cost: selected_care_cost,
+           }
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to render_template(current_template)
+    end
+
     it "validates a care cost option is chosen" do
       post :submit,
            params: {


### PR DESCRIPTION
### What

Use 'exclusive' checkboxes on 'expert-advice-type' and 'offer-care-qualifications' pages, by using a single fieldset for all items and de-select items when the 'no/none' option is selected.

~~This PR is still draft as it's dependent on us [being able to import component scripts individually](https://github.com/alphagov/govuk_publishing_components/pull/1472) hence **not yet ready for review** and with a test failing.~~

### How to review

Check those pages in your browser/device of choice or check the code and trust the screen captures below.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

![localhost_5000_expert-advice-type (1)](https://user-images.githubusercontent.com/788096/82438973-c9839280-9a91-11ea-9eb1-07c0188e3e8e.png)

</td><td valign="top">

![localhost_5000_expert-advice-type](https://user-images.githubusercontent.com/788096/82438996-d30cfa80-9a91-11ea-86bb-53cf60659fa6.png)

</td></tr>
<tr><td valign="top">

![localhost_5000_offer-care-qualifications](https://user-images.githubusercontent.com/788096/82439162-1a938680-9a92-11ea-8cdc-8a3f4c4cbb21.png)


</td><td valign="top">

![localhost_5000_offer-care-qualifications (1)](https://user-images.githubusercontent.com/788096/82439172-1e270d80-9a92-11ea-855b-00e437d49102.png)


</td></tr>
<tr><td valign="top">

n/a

</td><td valign="top">
JavaScript disabled

![localhost_5000_expert-advice-type](https://user-images.githubusercontent.com/788096/82495188-a46b4000-9ae2-11ea-9a65-fc650c9adc8c.png)


</td></tr>
<tr><td valign="top">

n/a

</td><td valign="top">

JavaScript disabled
![localhost_5000_offer-care-qualifications](https://user-images.githubusercontent.com/788096/82495199-a92ff400-9ae2-11ea-8c1e-cdac8a380b85.png)


</td></tr>
</table>


### Links

[Trello](https://trello.com/c/kJe25doD) [cards](https://trello.com/c/TUIIAq8f)