### PR TITLE
Correctly expire sessions after 4 hours

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,7 +36,7 @@ Rails.application.configure do
   end
 
   config.cache_store = :redis_cache_store
-  config.session_store :cache_store, expires_in: 4.hours, key: "_sessions_store"
+  config.session_store :cache_store, expire_after: 4.hours, key: "_sessions_store"
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -104,7 +104,7 @@ Rails.application.configure do
     redis_url = instance.dig("credentials", "uri")
     config.cache_store = :redis_cache_store, { url: redis_url }
     # If you change the expiry here, you should also change it on the privacy policy.
-    config.session_store :cache_store, expires_in: 4.hours, key: "_sessions_store"
+    config.session_store :cache_store, expire_after: 4.hours, key: "_sessions_store"
 
     Sidekiq.configure_server do |config|
       config.redis = { url: redis_url }

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -41,7 +41,7 @@ Rails.application.configure do
   config.analytics_tracking_id = "12345"
 
   config.cache_store = :redis_cache_store
-  config.session_store :cache_store, expires_in: 4.hours, key: "_sessions_store"
+  config.session_store :cache_store, expire_after: 4.hours, key: "_sessions_store"
 
   # Use test delivery method instead of sending emails to Notify.
   config.action_mailer.delivery_method = :test


### PR DESCRIPTION
What
----

We were previously initialising the session store with a `expires_in` value, however we should have been using `expire_after`.  This prevented sessions from being expired after 4 hours, and users would continue to see their data after this time.

How to review
-------------

- Review code
- Run application locally and check responses are deleted after 4 hours (you could lower this to 1 minute to test this more quickly)

Links
-----

Trello card: https://trello.com/c/5xJq4zd6