### PR TITLE
Task/autocreate schema from meta schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+/config/schemas/form_response.json
 
 coverage
 tmp

--- a/README.md
+++ b/README.md
@@ -82,6 +82,56 @@ The template should have a Message of `((body))` only.
 
     bundle exec rake
 
+### Updating the form response schema
+
+The form response schema is automatically generated from the meta-schema and
+the `en.yml` locale file whenever rake is invoked. i.e when the server is started, 
+or the tests are ran.  
+
+The generated file appears at 
+
+    config/schemas/form_response.json
+
+If you want to generate it manually you can run:
+
+    bundle exec rake generate-schema
+
+If you want to edit the schema, edit the meta-schema file
+
+    config/form_response_metaschema.json
+
+This json file is almost identical to a json schema, the only difference is
+that it goes through a processing step that replaces any enums with the prefix
+`meta_i18n_enum:` with values found in `config/locales/en.yml`.
+
+#### Example
+
+Specifying an enum like so:
+
+    "enum" [
+        "meta_i18n_enum:department.options"
+    ]
+
+Will result in the processing step looking at `department.options` in `en.yml`
+path, and adding each of the labels of the options to the enum. i.e When the
+above enum is processed together with an `en.yml` file with the following
+structure:
+
+    department:
+        options:
+          medical:
+            label: "Medical"
+          engineering:
+            label: "Engineering"
+
+The enum in the schema will look like the following:
+
+    "enum" [
+        "Medical",
+        "Engineering",
+    ]
+
+
 ## Deployment pipeline
 
 Every commit to master is deployed to GOV.UK PaaS by

--- a/Rakefile
+++ b/Rakefile
@@ -7,5 +7,6 @@
 require_relative "config/application"
 
 Rails.application.load_tasks
+Rake::Task["generate-schema"].invoke
 
 task default: %i[spec lint]

--- a/config/form_response_meta_schema.json
+++ b/config/form_response_meta_schema.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "This is a meta-schema.",
   "type": "object",
   "required": [
     "medical_equipment",
@@ -20,12 +21,7 @@
       "type": "array",
       "items": {
         "type": "string",
-        "enum": [
-          "Manufacturer",
-          "Distributor",
-          "Agent",
-          "Individual"
-        ]
+        "enum": [ "meta_i18n_enum:coronavirus_form.questions.are_you_a_manufacturer.options" ]
       }
     },
     "product_details": {
@@ -40,10 +36,7 @@
         "properties": {
           "medical_equipment_type": {
             "type": "string",
-            "enum": [
-              "Personal protective equipment, for example masks, detergent and waste bags",
-              "Testing equipment"
-            ]
+            "enum": [ "meta_i18n_enum:coronavirus_form.questions.medical_equipment_type.options" ]
           },
           "product_id": {
             "type": "string",
@@ -57,18 +50,14 @@
           },
           "product_cost": {
             "type": "string",
-            "pattern": "^[0-9]*\.?[0-9]{0,2}$"
+            "pattern": "^[0-9]*\\.?[0-9]{0,2}$"
           },
           "certification_details": {
             "type": "string"
           },
           "product_location": {
             "type": "string",
-            "enum": [
-              "United Kingdom",
-              "European Union",
-              "Rest of world"
-            ]
+            "enum": [ "meta_i18n_enum:coronavirus_form.questions.product_details.product_location.options" ]
           },
           "product_postcode": {
             "$ref": "#/definitions/postcode"
@@ -81,31 +70,14 @@
           },
           "equipment_type": {
             "type": ["string"],
-            "enum": [
-              "FFP3 respirators",
-              "FFP2 respirators",
-              "Aprons",
-              "Gloves",
-              "Type IIR face masks",
-              "Safety glasses or visors",
-              "Alcohol hand gel",
-              "Gowns",
-              "Face fit test kit",
-              "Face fit test solution",
-              "General purpose detergent",
-              "Cleaning Equipment"
-            ]
+            "enum": [ "meta_i18n_enum:coronavirus_form.questions.product_details.equipment_type.options" ]
           }
         }
       }
     },
     "accommodation": {
       "type": "string",
-      "enum": [
-        "Yes – for people to stay in",
-        "Yes – for any use",
-        "No"
-      ]
+      "enum": [ "meta_i18n_enum:coronavirus_form.questions.accommodation.options" ]
     },
     "rooms_number": {
       "type": "string"
@@ -114,11 +86,7 @@
       "type": "array",
       "items": {
         "type": "string",
-        "enum": [
-          "Moving people",
-          "Moving goods",
-          "Other"
-        ]
+        "enum": [ "meta_i18n_enum:coronavirus_form.questions.transport_type.options" ]
       }
     },
     "transport_description": {
@@ -134,11 +102,7 @@
       "type": "array",
       "items": {
         "type": "string",
-        "enum": [
-          "Warehouse space",
-          "Office space",
-          "Other"
-        ]
+        "enum": [ "meta_i18n_enum:coronavirus_form.questions.offer_space_type.options" ]
       }
     },
     "warehouse_space_description": {
@@ -157,16 +121,7 @@
       "type": "array",
       "items": {
         "type": "string",
-        "enum": [
-          "Medical",
-          "Engineering",
-          "Construction",
-          "Project management or procurement",
-          "IT services",
-          "Manufacturing",
-          "Other",
-          "I cannot offer expertise"
-        ]
+        "enum": [ "meta_i18n_enum:coronavirus_form.questions.expert_advice_type.options" ]
       }
 
     },
@@ -180,21 +135,14 @@
       "type": "array",
       "items": {
         "type": "string",
-        "enum": [
-          "Care for adults",
-          "Care for children"
-        ]
+        "enum": [ "meta_i18n_enum:coronavirus_form.questions.offer_care_qualifications.offer_care_type.options" ]
       }
     },
     "offer_care_qualifications": {
       "type": "array",
       "items": {
         "type": "string",
-        "enum": [
-          "DBS check",
-          "Nursing or other healthcare qualification",
-          "I do not have a qualification"
-        ]
+        "enum": [ "meta_i18n_enum:coronavirus_form.questions.offer_care_qualifications.care_qualifications.options" ]
       }
     },
     "offer_care_qualifications_type": {
@@ -207,20 +155,7 @@
       "type": "array",
       "items": {
         "type": "string",
-        "enum": [
-          "East of England",
-          "East Midlands",
-          "West Midlands",
-          "London",
-          "North East",
-          "North West",
-          "South East",
-          "South West",
-          "Yorkshire and the Humber",
-          "Northern Ireland",
-          "Scotland",
-          "Wales"
-        ]
+        "enum": [ "meta_i18n_enum:coronavirus_form.questions.location.options" ]
       }
     },
     "business_details": {
@@ -240,19 +175,11 @@
         },
         "company_size": {
           "type": "string",
-          "enum": [
-            "Under 50 people",
-            "50 to 250 people",
-            "More than 250 people"
-          ]
+          "enum": [ "meta_i18n_enum:coronavirus_form.questions.business_details.company_size.options" ]
         },
         "company_location": {
           "type": "string",
-          "enum": [
-            "United Kingdom",
-            "European Union",
-            "Rest of world"
-          ]
+          "enum": [ "meta_i18n_enum:coronavirus_form.questions.business_details.company_location.options" ]
         },
         "company_postcode": {
           "$ref": "#/definitions/postcode"

--- a/config/form_response_meta_schema.json
+++ b/config/form_response_meta_schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "description": "This is a meta-schema.",
+  "description": "This meta-schema, it is used to generate the form response schema. refer to the readme for details",
   "type": "object",
   "required": [
     "medical_equipment",

--- a/lib/tasks/generate_schema.rake
+++ b/lib/tasks/generate_schema.rake
@@ -1,0 +1,38 @@
+require "fileutils"
+
+def replace_meta_enums json
+  json.each do |key, value|
+    if (key == "enum") && value.any? { |member| member.start_with?("meta_i18n_enum:") }
+      if value.size > 1
+        throw ArgumentError("A meta enum should have a length of one. Found: #{value}")
+      end
+      json["enum"] = I18n.t(value.first.split(":", 2).last).map { |_, option| option[:label] }
+    elsif value.class == Hash
+      replace_meta_enums value
+    elsif value.class == Array
+      value.each do |member|
+        handle_array member
+      end
+    end
+  end
+end
+
+def handle_array member
+  if member.class == FalseClass
+    replace_meta_enums member
+  elsif member.class == Array
+    member.each do |nested_member|
+      handle_array nested_member
+    end
+  end
+end
+
+desc "Generate json schema from locale and meta schema files"
+task "generate-schema" => :environment do
+  schema = replace_meta_enums JSON.parse(File.read(Rails.root.join("config/form_response_meta_schema.json")))
+  schema.delete("description")
+  FileUtils.mkdir_p "config/schemas"
+  File.open("config/schemas/form_response.json", "w") do |f|
+    f.write(JSON.pretty_generate(schema))
+  end
+end

--- a/lib/tasks/generate_schema.rake
+++ b/lib/tasks/generate_schema.rake
@@ -6,7 +6,15 @@ def replace_meta_enums json
       if value.size > 1
         throw ArgumentError("A meta enum should have a length of one. Found: #{value}")
       end
-      json["enum"] = I18n.t(value.first.split(":", 2).last).map { |_, option| option[:label] }
+      begin
+        enum_values = I18n.t(value.first.split(":", 2).last).map { |_, option| option[:label] }
+      rescue NoMethodError
+        throw "Could not map key '#{value.first}' to yml structure"
+      end
+      if enum_values.any? { |v| v.class != String }
+        throw "Expected all option labels to be strings, Obtained: '#{enum_values}' for #{value.first}"
+      end
+      json["enum"] = enum_values
     elsif value.class == Hash
       replace_meta_enums value
     elsif value.class == Array


### PR DESCRIPTION
## Summary of changes

The approach described here is different from what the ticket suggested under the **Considerations** section but it does meet the **Acceptance** **criteria** of the ticket. i.e one can (under this scheme) now change the content only once and regenerating the schema once.

In addition this approach avoids having to refactor the en.yml file, and the rest of the codebase de-risking this change. It also minimises the structural constraints placed on the locale file, and allows the schema to be specified in a file with a near identical syntax to that of a json-schema file, which allows for linting and validation using that toolchain.

Initially the approach taken did follow the approach outlined in the **Considerations** section 
of the ticket. That experiment reached a point where the structure of the questions in the yml file had been flattened. 

I've adopted a scheme whereby the form response schema is automatically generated from the meta-schema `config/form_response_metaschema.json` and the `en.yml` locale file whenever rake is invoked. i.e when the server is started, or the tests are ran. (Note that the following is replicated from additions to the README file in the branch)

The generated file appears at:
```
config/schemas/form_response.json
```

If you want to generate it manually you can run:
```
bundle exec rake generate-schema
```

If you want to edit the schema, edit the meta-schema file:
```
config/form_response_metaschema.json
```

This json file is almost identical to a json schema, the only difference is
that it goes through a processing step that replaces any enums with the prefix
`meta_i18n_enum:` with values found in `config/locales/en.yml`.

### Example

Specifying an enum like so:

```
"enum" [
    "meta_i18n_enum:department.options"
]
```

Will result in the processing step looking at `department.options` in `en.yml`
path, and adding each of the labels of the options to the enum. i.e When the
above enum is processed together with an `en.yml` file with the following
structure:

```
department:
    options:
      medical:
        label: "Medical"
      engineering:
        label: "Engineering"
```

The enum in the schema will look like the following:

```
"enum" [
    "Medical",
    "Engineering",
]
```

## How to review

One can run:

```
bundle exec rake generate-schema
```

(or any rake command)

and observe that the form response schema is generated at `/config/schemas/form_response.json`

Diffing that file against the one in master shows that nothing substantial has changed in the file (a few formatting changes, and a (now correctly) escaped backslash.

Similarly one can run the tests and see that the file is correctly loaded, and that the validation is ran.

## Links

https://trello.com/c/7Ymm07ol/387-spike-generating-the-json-schema-using-erb