### PR TITLE
Remove cf routing from concourse job

### DIFF
--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -59,15 +59,3 @@ run:
       cf set-env govuk-coronavirus-business-volunteer-form PAAS_ENV "$CF_SPACE"
       cf v3-zdt-push govuk-coronavirus-business-volunteer-form --wait-for-deploy-complete --no-route
       cf map-route govuk-coronavirus-business-volunteer-form cloudapps.digital --hostname "$HOSTNAME"
-
-      if [[ "${CF_SPACE:-}" = "staging" ]]; then
-        cf map-route govuk-coronavirus-business-volunteer-form cloudapps.digital --hostname govuk-coronavirus-business-volunteer-form-stg --path metrics
-        cf bind-route-service cloudapps.digital re-ip-whitelist-service --hostname govuk-coronavirus-business-volunteer-form-stg --path metrics
-      fi
-
-      if [[ "${CF_SPACE:-}" = "production" ]]; then
-        cf map-route govuk-coronavirus-business-volunteer-form coronavirus-business-volunteers.service.gov.uk --path metrics
-        cf map-route govuk-coronavirus-business-volunteer-form cloudapps.digital --hostname govuk-coronavirus-business-volunteer-form-prod --path metrics
-        cf bind-route-service coronavirus-business-volunteers.service.gov.uk re-ip-whitelist-service --path metrics
-        cf bind-route-service cloudapps.digital re-ip-whitelist-service --hostname govuk-coronavirus-business-volunteer-form-prod --path metrics
-      fi


### PR DESCRIPTION
Doing a 'cf bind-route-service' multiple times leads to duplicate bindings...

So we could keep the map-route calls in here, but they don't make sense without the context of the bind-route, which will have to be done manually.