### PR TITLE
GA cross government domain tracking with test ID

### DIFF
--- a/app/assets/javascripts/analytics.js.erb
+++ b/app/assets/javascripts/analytics.js.erb
@@ -5,6 +5,7 @@ new GOVUK.Modules.CookieBanner().start($(element))
 var analyticsInit = function() {
   <% if Rails.application.config.analytics_tracking_id.present? %>
     var trackingId = "<%= Rails.application.config.analytics_tracking_id %>"
+    var crossDomainTrackingId = "<%= Rails.application.config.analytics_cross_domain_id %>"
 
     // Start analytics only if we have user consent
     var consentCookie = window.GOVUK.getConsentCookie();
@@ -14,10 +15,19 @@ var analyticsInit = function() {
                               m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
       })(window,document,'script','https://www.google-analytics.com/analytics.js','ga')
 
+      // govuk-coronavirus-business-volunteer-form Google Analytics
       ga('create', trackingId, 'auto')
       ga('set', 'allowAdFeatures', false);
       ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
+
+      // Cross Government Domain Google Analytics
+      ga('create', crossDomainTrackingId, 'auto', 'govuk_shared', {'allowLinker': true});
+      ga('govuk_shared.require', 'linker');
+      ga('govuk_shared.set', 'anonymizeIp', true);
+      ga('govuk_shared.set', 'allowAdFeatures', false);
+      ga('govuk_shared.linker:autoLink', ['www.gov.uk']);
+      ga('govuk_shared.send', 'pageview');
     }
   <% end %>
 }

--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -21,6 +21,8 @@ params:
   WORKER_INSTANCES:
   BASIC_AUTH_PASSWORD:
   GA_VIEW_ID: UA-43115970-1
+  GA_CROSS_DOMAIN_ID: UA-145652997-7
+
   AWS_ACCESS_KEY_ID:
   AWS_SECRET_ACCESS_KEY:
   GOVUK_NOTIFY_TEMPLATE_ID:
@@ -51,6 +53,7 @@ run:
       cf set-env govuk-coronavirus-business-volunteer-form SENTRY_DSN "$SENTRY_DSN"
       cf set-env govuk-coronavirus-business-volunteer-form SENTRY_CURRENT_ENV "$CF_SPACE"
       cf set-env govuk-coronavirus-business-volunteer-form GA_VIEW_ID "$GA_VIEW_ID"
+      cf set-env govuk-coronavirus-business-volunteer-form GA_CROSS_DOMAIN_ID "$GA_CROSS_DOMAIN_ID"
       cf set-env govuk-coronavirus-business-volunteer-form AWS_ACCESS_KEY_ID "$AWS_ACCESS_KEY_ID"
       cf set-env govuk-coronavirus-business-volunteer-form AWS_SECRET_ACCESS_KEY "$AWS_SECRET_ACCESS_KEY"
       cf set-env govuk-coronavirus-business-volunteer-form SECRET_KEY_BASE "$SECRET_KEY_BASE"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -56,6 +56,8 @@ Rails.application.configure do
   config.assets.quiet = true
 
   config.analytics_tracking_id = "12345"
+
+  config.analytics_cross_domain_id = "54321"
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -117,6 +117,8 @@ Rails.application.configure do
 
   config.analytics_tracking_id = ENV["GA_VIEW_ID"]
 
+  config.analytics_cross_domain_id = ENV["GA_CROSS_DOMAIN_ID"]
+
   # Inserts middleware to perform automatic connection switching.
   # The `database_selector` hash is used to pass options to the DatabaseSelector
   # middleware. The `delay` is used to determine how long to wait after a write

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -40,6 +40,8 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
   config.analytics_tracking_id = "12345"
 
+  config.analytics_cross_domain_id = "54321"
+
   config.cache_store = :redis_cache_store
   config.session_store :cache_store, expire_after: 4.hours, key: "_sessions_store"
 


### PR DESCRIPTION
What
----

Describe what you have changed and why.

- Adds Google Analytics cross domain tracking.
- Currently uses a test ID. This will need to be updated in a future PR once testing with a business analyst is complete.

Why
----
We want to have as rich an understanding of cross-domain user journeys during coronavirus as possible.

How to review
-------------

Instructions for adding X-domain GA tracking are linked to the [Trello card](https://trello.com/c/q10D4CcH/499-add-cross-domain-tracking-to-business-volunteering-spike-the-complexity-1-day). This also gives information as to the process of testing with an analyst. 

- When sending analytics, we redact personally identifiable information. For this form, no personally identifiable information needed to be redacted, as none is stored in places such as titles or URL query params. Further information about this can also be found on the doc linked to the Trello card.

:ship: Since this service is continuously deployed, all testing must be done
before the pull request is merged. :ship:

This work is a spike. My hope is to merge this with the test ID and test with an analyst today. Then everything will be in place for using a real ID when we want to start x-domain tracking. 

Links
-----
 [Trello card](https://trello.com/c/q10D4CcH/499-add-cross-domain-tracking-to-business-volunteering-spike-the-complexity-1-day)

