### PR TITLE
Add prefix to product cost field

### DIFF
--- a/app/views/coronavirus_form/product_details.html.erb
+++ b/app/views/coronavirus_form/product_details.html.erb
@@ -59,6 +59,7 @@
     text: t("coronavirus_form.questions.product_details.product_cost.label"),
   },
   hint: t("coronavirus_form.questions.product_details.product_cost.hint"),
+  prefix: t("coronavirus_form.questions.product_details.product_cost.prefix"),
   id: "product_cost",
   name: "product_cost",
   inputmode: "decimal",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -231,6 +231,7 @@ en:
         product_cost:
           label: "Cost per item, in pounds"
           hint: "For example, 23.99. Enter 0 if you will donate it."
+          prefix: "£"
           custom_error: "Enter the cost per item in pounds, do not include words or symbols. If you are giving it for free, enter 0"
         certification_details:
           label: "Certification details"


### PR DESCRIPTION
What
----

Add a "£" prefix to product_cost fields in the UI.

Why
----

Cabinet Office told us they couldn't use these fields, since people are treating these fields as free text rather than numbers.

This will help people understand that they're expected to input an amount in pounds.



<img width="400" alt="Screenshot 2020-05-26 at 09 30 30" src="https://user-images.githubusercontent.com/41922771/82878601-9890db00-9f33-11ea-885d-a73c3831ee7b.png">

[Trello](https://trello.com/c/GCGNaCSH/367-add-prefix-to-input-fields-on-product-details-question)