### PR TITLE
Alert Slack when Concourse tasks fail

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -149,6 +149,17 @@ jobs:
         file: git-master/concourse/tasks/run-smoke-tests.yml
         params:
           TEST_URL: 'https://gds:((basic-auth-password))@govuk-coronavirus-business-volunteer-form-stg.cloudapps.digital'
+        on_failure:
+          put: govuk-coronavirus-services-tech-slack
+          params:
+            channel: '#govuk-corona-services-tech'
+            username: 'Concourse (Business Volunteering Service)'
+            icon_emoji: ':concourse:'
+            silent: true
+            text: |
+              :kaboom:
+              Staging smoke tests for the Business Volunteering service have failed
+              Failed build: http://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
 
   - name: deploy-to-prod
     serial: true
@@ -192,6 +203,17 @@ jobs:
         file: git-master/concourse/tasks/run-smoke-tests.yml
         params:
           TEST_URL: 'https://coronavirus-business-volunteers.service.gov.uk'
+        on_failure:
+          put: govuk-coronavirus-services-tech-slack
+          params:
+            channel: '#govuk-corona-services-tech'
+            username: 'Concourse (Business Volunteering Service)'
+            icon_emoji: ':concourse:'
+            silent: true
+            text: |
+              :kaboom:
+              Production smoke tests for the Business Volunteering service have failed
+              Failed build: http://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
 
   - name: export-form-responses-periodically
     plan:

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -130,6 +130,17 @@ jobs:
           AWS_ASSETS_BUCKET_NAME: govuk-coronavirus-business-volunteer-assets-staging
           GOVUK_NOTIFY_TEMPLATE_ID: b9661b65-805c-4290-9428-2495f3427964
           NOTIFY_API_KEY: ((notify-api-key-stg))
+        on_failure:
+          put: govuk-coronavirus-services-tech-slack
+          params:
+            channel: '#govuk-corona-services-tech'
+            username: 'Concourse (Business Volunteering Service)'
+            icon_emoji: ':concourse:'
+            silent: true
+            text: |
+              :kaboom:
+              Deploy to staging for the Business Volunteering service has failed
+              Failed build: http://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
 
   - name: smoke-test-staging
     plan:
@@ -184,6 +195,17 @@ jobs:
           AWS_ASSETS_BUCKET_NAME: govuk-coronavirus-business-volunteer-assets-prod
           GOVUK_NOTIFY_TEMPLATE_ID: 94e7f169-6c10-487f-b9d2-4d03fc162a1e
           NOTIFY_API_KEY: ((notify-api-key-prod))
+        on_failure:
+          put: govuk-coronavirus-services-tech-slack
+          params:
+            channel: '#govuk-corona-services-tech'
+            username: 'Concourse (Business Volunteering Service)'
+            icon_emoji: ':concourse:'
+            silent: true
+            text: |
+              :kaboom:
+              Deploy to production for the Business Volunteering service has failed
+              Failed build: http://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
 
   - name: smoke-test-prod
     plan:

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -5,6 +5,12 @@ resource_types:
     source:
       repository: nulldriver/cf-cli-resource
 
+  - name: slack-notification
+    type: docker-image
+    source:
+      repository: cfcommunity/slack-notification-resource
+      tag: latest
+
 resources:
   - name: git-master
     type: git
@@ -39,6 +45,11 @@ resources:
     source:
       repository: ((readonly_private_ecr_repo_url))
       tag: govuk-coronavirus-business-volunteer-tests-image
+
+  - name: govuk-coronavirus-services-tech-slack
+    type: slack-notification
+    source:
+      url: https://hooks.slack.com/((slack_webhook_url))
 
 jobs:
   - name: update-pipeline


### PR DESCRIPTION
What
----

Posts a message to #govuk-corona-services-tech on Slack when Concourse tasks fail.

Makes the same change as in https://github.com/alphagov/govuk-coronavirus-vulnerable-people-form/pull/364.

Example:
![Screenshot 2020-05-26 at 14 00 11](https://user-images.githubusercontent.com/6329861/82903694-3d71df00-9f59-11ea-8923-4feff1929758.png)

Links
-----

Trello card: https://trello.com/c/TSaLQkQp