### PR TITLE
Remove unrequired fields

### DIFF
--- a/app/controllers/coronavirus_form/check_answers_controller.rb
+++ b/app/controllers/coronavirus_form/check_answers_controller.rb
@@ -11,7 +11,7 @@ class CoronavirusForm::CheckAnswersController < ApplicationController
   end
 
   def submit
-    validation_errors = validate_against_form_response_schema(session.to_h)
+    validation_errors = validate_against_form_response_schema(parsed_session)
     if validation_errors.any?
       GovukError.notify(
         FormResponseInvalidError.new,
@@ -19,7 +19,7 @@ class CoronavirusForm::CheckAnswersController < ApplicationController
       )
     end
 
-    FormResponse.create(form_response: session) unless smoke_tester?
+    FormResponse.create(form_response: parsed_session) unless smoke_tester?
 
     send_confirmation_email if session.dig(:contact_details, :email).present?
 
@@ -30,6 +30,10 @@ class CoronavirusForm::CheckAnswersController < ApplicationController
   end
 
 private
+
+  def parsed_session
+    session.to_h.with_indifferent_access.except(:session_id, :_csrf_token, :current_path, :previous_path, :check_answers_seen)
+  end
 
   def set_reference_number
     session[:reference_number] ||= reference_number

--- a/config/schemas/form_response.json
+++ b/config/schemas/form_response.json
@@ -399,18 +399,6 @@
     "reference_number": {
       "type": "string"
     },
-    "check_answers_seen": {
-      "type": "boolean"
-    },
-    "_csrf_token": {
-      "type": "string"
-    },
-    "current_path": {
-      "type": "string"
-    },
-    "previous_path": {
-      "type": "string"
-    },
     "additional_product": {
       "$ref": "#/definitions/yes_no"
     }

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -3,7 +3,7 @@ require "aws-sdk-s3"
 namespace :export do
   desc "Exports all form responses for a specific date in JSON format"
   task :form_responses, [:date] => [:environment] do |_, args|
-    args.with_defaults(date: Date.yesterday.to_s)
+    args.with_defaults(date: Time.zone.today.to_s)
 
     responses = FormResponse.where(created_at: Date.parse(args.date).all_day)
     puts responses.to_json

--- a/spec/helpers/schema_helper_spec.rb
+++ b/spec/helpers/schema_helper_spec.rb
@@ -585,29 +585,24 @@ RSpec.describe SchemaHelper, type: :helper do
         expect(validate_against_form_response_schema(data)).to be_empty
       end
 
-      it "allows check_answers_seen to be stored" do
+      it "does not allow check_answers_seen to be stored" do
         data = valid_data.merge(check_answers_seen: true)
-        expect(validate_against_form_response_schema(data)).to be_empty
-      end
-
-      it "returns a list of errors when check_answers_seen has an invalid value" do
-        data = valid_data.merge(check_answers_seen: "Foo")
         expect(validate_against_form_response_schema(data).first).to include("check_answers_seen")
       end
 
-      it "allows a _csrf_token to be stored" do
+      it "does not allow a _csrf_token to be stored" do
         data = valid_data.merge(_csrf_token: "abc")
-        expect(validate_against_form_response_schema(data)).to be_empty
+        expect(validate_against_form_response_schema(data).first).to include("_csrf_token")
       end
 
-      it "allows the current_path to be stored" do
+      it "does not allow the current_path to be stored" do
         data = valid_data.merge(current_path: "/foo")
-        expect(validate_against_form_response_schema(data)).to be_empty
+        expect(validate_against_form_response_schema(data).first).to include("current_path")
       end
 
-      it "allows the previous_path to be stored" do
+      it "does not allow the previous_path to be stored" do
         data = valid_data.merge(previous_path: "/foo")
-        expect(validate_against_form_response_schema(data)).to be_empty
+        expect(validate_against_form_response_schema(data).first).to include("previous_path")
       end
     end
   end

--- a/spec/support/form_response_helper.rb
+++ b/spec/support/form_response_helper.rb
@@ -82,7 +82,6 @@ module FormResponseHelper
       ],
       are_you_a_manufacturer: I18n.t("coronavirus_form.questions.are_you_a_manufacturer.options").map { |_, item| item[:label] },
       additional_product: I18n.t("coronavirus_form.questions.additional_product.options").map { |_, item| item[:label] }.sample,
-      check_answers_seen: true,
       location: I18n.t("coronavirus_form.questions.location.options").map { |_, item| item[:label] },
     }
   end


### PR DESCRIPTION
What
----

Similar to https://github.com/alphagov/govuk-coronavirus-vulnerable-people-form/pull/356, this removes some unnecessary fields from new `FormResponse` records.

It also changes the structure of the data we save in `form_response` from an array to a hash/json. Since we control how we export the data from the DB, we are able to do this without changing the data export format for our data team downstream.

Links
-----

https://trello.com/c/zzS6yMZG/493-remove-unnecessary-fields-from-formresponse