### PR TITLE
[Do not merge] Update pages to dissuade small offers of PPE

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,6 +8,7 @@
 @import 'govuk_publishing_components/components/button';
 @import 'govuk_publishing_components/components/checkboxes';
 @import 'govuk_publishing_components/components/cookie-banner';
+@import 'govuk_publishing_components/components/details';
 @import 'govuk_publishing_components/components/error-message';
 @import 'govuk_publishing_components/components/error-summary';
 @import 'govuk_publishing_components/components/fieldset';

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,6 +14,7 @@
 @import 'govuk_publishing_components/components/heading';
 @import 'govuk_publishing_components/components/hint';
 @import 'govuk_publishing_components/components/input';
+@import 'govuk_publishing_components/components/inset-text';
 @import 'govuk_publishing_components/components/label';
 @import 'govuk_publishing_components/components/layout-footer';
 @import 'govuk_publishing_components/components/layout-header';

--- a/app/controllers/coronavirus_form/check_answers_controller.rb
+++ b/app/controllers/coronavirus_form/check_answers_controller.rb
@@ -2,6 +2,7 @@
 
 class CoronavirusForm::CheckAnswersController < ApplicationController
   include SchemaHelper
+  include ProductHelper
 
   before_action :set_reference_number
 
@@ -24,9 +25,11 @@ class CoronavirusForm::CheckAnswersController < ApplicationController
     send_confirmation_email if session.dig(:contact_details, :email).present?
 
     ref_number = session[:reference_number]
+    enough_product_items = ppe_products_with_not_enough_items.empty?
+
     reset_session
 
-    redirect_to thank_you_url(reference_number: ref_number)
+    redirect_to thank_you_url(reference_number: ref_number, enough_items: enough_product_items)
   end
 
 private

--- a/app/controllers/coronavirus_form/coordination_centres_controller.rb
+++ b/app/controllers/coronavirus_form/coordination_centres_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CoronavirusForm::CoordinationCentresController < ApplicationController
+  skip_before_action :check_first_question_answered
+
+private
+
+  def previous_path
+    return first_question_path if session[:previous_path].blank?
+
+    path = URI(session[:previous_path]).path
+    path.presence || first_question_path
+  end
+end

--- a/app/controllers/coronavirus_form/thank_you_controller.rb
+++ b/app/controllers/coronavirus_form/thank_you_controller.rb
@@ -2,4 +2,9 @@
 
 class CoronavirusForm::ThankYouController < ApplicationController
   skip_before_action :check_first_question_answered
+
+  def show
+    @enough_items = params[:enough_items]
+    super
+  end
 end

--- a/app/helpers/product_helper.rb
+++ b/app/helpers/product_helper.rb
@@ -23,4 +23,15 @@ module ProductHelper
       prod[:product_id] == product_id
     end
   end
+
+  def ppe_products_with_not_enough_items
+    all_products = session.to_h.with_indifferent_access[:product_details]
+    return [] unless all_products
+
+    products = all_products.map do |product|
+      product if product[:product_quantity] && product[:product_quantity].to_i < MINIMUM_ACCEPTED_PRODUCT_QUANTITY
+    end
+
+    products.compact
+  end
 end

--- a/app/helpers/product_helper.rb
+++ b/app/helpers/product_helper.rb
@@ -1,4 +1,6 @@
 module ProductHelper
+  MINIMUM_ACCEPTED_PRODUCT_QUANTITY = 100_000
+
   def add_product_to_session(product)
     session[:product_details] ||= []
     products = products_except(product.with_indifferent_access[:product_id])

--- a/app/views/coronavirus_form/coordination_centres.html.erb
+++ b/app/views/coronavirus_form/coordination_centres.html.erb
@@ -1,0 +1,15 @@
+<% content_for :title, t("coordination_centres.title") %>
+<% content_for :meta_tags do %>
+  <meta name="description" content="<%= t("coordination_centres.title") %>" />
+<% end %>
+
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", { href: previous_path } %>
+<% end %>
+
+<%= render "govuk_publishing_components/components/title", {
+  title:t("coordination_centres.title"),
+  margin_top: 0
+} %>
+
+<%= sanitize(t("coordination_centres.body_text")) %>

--- a/app/views/coronavirus_form/medical_equipment_type.html.erb
+++ b/app/views/coronavirus_form/medical_equipment_type.html.erb
@@ -7,6 +7,12 @@
   <%= render "govuk_publishing_components/components/back_link", { href: previous_path } %>
 <% end %>
 
+<% description_html = capture do %>
+  <%= render "govuk_publishing_components/components/inset_text" do %>
+     <%= sanitize(t("coronavirus_form.questions.medical_equipment_type.description")) %>
+  <% end %>
+<% end %>
+
 <%= form_tag({},
   "data-module": "track-coronavirus-form-business-medical-equipment-type",
   "data-question-key": "medical_equipment_type",
@@ -15,6 +21,7 @@
 ) do %>
 <%= render "govuk_publishing_components/components/radio", {
   heading: t("coronavirus_form.questions.medical_equipment_type.title"),
+  description: description_html,
   hint: t("coronavirus_form.questions.medical_equipment_type.hint"),
   is_page_heading: true,
   name: "medical_equipment_type",

--- a/app/views/coronavirus_form/product_details.html.erb
+++ b/app/views/coronavirus_form/product_details.html.erb
@@ -57,6 +57,13 @@
   error_message: error_items('product_quantity'),
   value: @product[:product_quantity],
 } %>
+
+<%= render "govuk_publishing_components/components/details", {
+  title: t("coronavirus_form.questions.product_details.ppe_amount_details.title"),
+} do %>
+  <%= sanitize(t("coronavirus_form.questions.product_details.ppe_amount_details.description")) %>
+<% end %>
+
 <%= render "govuk_publishing_components/components/input", {
   label: {
     text: t("coronavirus_form.questions.product_details.product_cost.label"),

--- a/app/views/coronavirus_form/product_details.html.erb
+++ b/app/views/coronavirus_form/product_details.html.erb
@@ -18,6 +18,9 @@
   "novalidate": "true"
 ) do %>
 <%= tag.input type: "hidden", name: "product_id", value: @product[:product_id] %>
+<%= render "govuk_publishing_components/components/inset_text" do %>
+  <%= sanitize(t("coronavirus_form.questions.product_details.ppe_tech_spec_callout")) %>
+<% end %>
 <%= render "govuk_publishing_components/components/input", {
   label: {
     text: t("coronavirus_form.questions.product_details.product_name.label")

--- a/app/views/coronavirus_form/thank_you.html.erb
+++ b/app/views/coronavirus_form/thank_you.html.erb
@@ -3,4 +3,8 @@
   title: t("coronavirus_form.thank_you.title")
 } %>
 
-<%= sanitize(t("coronavirus_form.thank_you.enough_items.description")) %>
+<% if @enough_items == "true" %>
+  <%= sanitize(t("coronavirus_form.thank_you.enough_items.description")) %>
+<% else %>
+  <%= sanitize(t("coronavirus_form.thank_you.too_few_items.description")) %>
+<% end %>

--- a/app/views/coronavirus_form/thank_you.html.erb
+++ b/app/views/coronavirus_form/thank_you.html.erb
@@ -3,4 +3,4 @@
   title: t("coronavirus_form.thank_you.title")
 } %>
 
-<%= sanitize(t("coronavirus_form.thank_you.description")) %>
+<%= sanitize(t("coronavirus_form.thank_you.enough_items.description")) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -219,6 +219,8 @@ en:
         custom_select_error: "Select if you have medical equipment to offer"
       medical_equipment_type:
         title: "What type of medical equipment can you offer?"
+        description: |
+          <p class="govuk-body">If you cannot offer more than 100,000 items of a personal protective equipment product, you should not use this form. <a class="govuk-link" href="/coordination-centres">Contact an NHS Regional Incident Coordination Centre to offer the product</a>.</p>
         hint: "Give details for one product at a time."
         options:
           number_ppe:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -701,7 +701,9 @@ en:
         custom_select_error: "Select if it would be a donation, a reduced price, or standard price"
     thank_you:
       title: "Thank you for offering support"
-      description: |
-        <p class="govuk-body">If your help is needed you’ll be contacted as soon as possible.</p>
-        <p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/coronavirus">Find all information on coronavirus (COVID-19)</a>.</p>
-        <p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/done/coronavirus-support-from-business">Give feedback on this service</a>.</p>
+      enough_items:
+        description: |
+          <p class="govuk-body">We have sent you a confirmation email.</p>
+          <h2 class="govuk-heading-m">What happens next</h2>
+          <p class="govuk-body">If your help is needed you’ll be contacted as soon as possible.</p>
+          <p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/done/coronavirus-support-from-business">What did you think of this service?</a> (takes 30 seconds)</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -249,6 +249,8 @@ en:
           title: If you cannot offer more than 100,000 items
           description: |
             <p class="govuk-body">If you cannot offer more than 100,000 items, you should not use this form. <a class="govuk-link" href="/coordination-centres">Contact an NHS Regional Incident Coordination Centre to offer the product</a>.</p>
+        ppe_amount_check_answers_callout: |
+          <p class="govuk-body">You cannot offer more than 100,000 items of this product. Contact an <a class="govuk-link" href="/coordination-centres">NHS Regional Incident Coordination Centre</a> to offer the product instead of using this form.</p>
         product_name:
           label: "Name of product"
           custom_error: "Enter the name of the product"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -156,6 +156,27 @@ en:
     heading: "Now send the form"
     confirmation: "By submitting this form you’re confirming that, to the best of your knowledge, the details you’re providing are correct."
     submit: "Accept and send"
+  coordination_centres:
+    title: Offer your products to an NHS Regional Coordination Centre
+    body_text: |
+      <p class="govuk-body">If you’re offering less than 100,000 items of a personal protective equipment product, you should offer them to an NHS Regional Coordination Centre</p>
+      <h2 class="govuk-heading-m">How to offer your products</h2>
+      <p class="govuk-body">Email the centre giving details of the prod you’re offering, including whether they <a class="govuk-link" href="https://www.gov.uk/government/publications/technical-specifications-for-personal-protective-equipment-ppe">meet the technical specifications</a>.</p>
+      <p class="govuk-body">You will be contacted as soon as possible if your products are needed.</p>
+      <h2 class="govuk-heading-m">East of England</h2>
+      <p class="govuk-body"><a href="mailto:england.eastofengland-covid19@nhs.net" class="govuk-link">england.eastofengland-covid19@nhs.net</a></p>
+      <h2 class="govuk-heading-m">London</h2>
+      <p class="govuk-body"><a href="mailto:england.london-covid19@nhs.net" class="govuk-link">england.london-covid19@nhs.net</a></p>
+      <h2 class="govuk-heading-m">Midlands</h2>
+      <p class="govuk-body"><a href="mailto:england.mids-incident@nhs.net" class="govuk-link">england.mids-incident@nhs.net</a></p>
+      <h2 class="govuk-heading-m">North East and Yorkshire</h2>
+      <p class="govuk-body"><a href="mailto:england.eprrney@nhs.net" class="govuk-link">england.eprrney@nhs.net</a></p>
+      <h2 class="govuk-heading-m">North West</h2>
+      <p class="govuk-body"><a href="mailto:england.eprrnw@nhs.net" class="govuk-link">england.eprrnw@nhs.net</a></p>
+      <h2 class="govuk-heading-m">South East</h2>
+      <p class="govuk-body"><a href="mailto:england.se-incident@nhs.net" class="govuk-link">england.se-incident@nhs.net</a></p>
+      <h2 class="govuk-heading-m">South West</h2>
+      <p class="govuk-body"><a href="mailto:england.sw-incident1@nhs.net" class="govuk-link">england.sw-incident1@nhs.net</a></p>
   session_expired:
     title: Your session has ended due to inactivity
     body_text: |

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -707,3 +707,11 @@ en:
           <h2 class="govuk-heading-m">What happens next</h2>
           <p class="govuk-body">If your help is needed you’ll be contacted as soon as possible.</p>
           <p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/done/coronavirus-support-from-business">What did you think of this service?</a> (takes 30 seconds)</p>
+      too_few_items:
+        description: |
+          <p class="govuk-body">We have sent you a confirmation email.</p>
+          <h2 class="govuk-heading-m">Offering less than 100,000 items of a product</h2>
+          <p class="govuk-body">Your offer of less than 100,000 items cannot be processed. Contact an <a class="govuk-link" href="/coordination-centres">NHS Regional Incident Coordination Centre to offer the product</a>.</p>
+          <h2 class="govuk-heading-m">What happens next</h2>
+          <p class="govuk-body">If your help is needed you’ll be contacted as soon as possible.</p>
+          <p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/done/coronavirus-support-from-business">What did you think of this service?</a> (takes 30 seconds)</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -245,6 +245,10 @@ en:
         title: "Tell us about the product you’re offering"
         ppe_tech_spec_callout: |
           <p class="govuk-body">The product must <a class="govuk-link" href="https://www.gov.uk/government/publications/technical-specifications-for-personal-protective-equipment-ppe">meet the technical specifications</a>, or your offer will not be accepted.</p>
+        ppe_amount_details:
+          title: If you cannot offer more than 100,000 items
+          description: |
+            <p class="govuk-body">If you cannot offer more than 100,000 items, you should not use this form. <a class="govuk-link" href="/coordination-centres">Contact an NHS Regional Incident Coordination Centre to offer the product</a>.</p>
         product_name:
           label: "Name of product"
           custom_error: "Enter the name of the product"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -243,6 +243,8 @@ en:
         custom_select_error: "Select the best way to describe your business"
       product_details:
         title: "Tell us about the product you’re offering"
+        ppe_tech_spec_callout: |
+          <p class="govuk-body">The product must <a class="govuk-link" href="https://www.gov.uk/government/publications/technical-specifications-for-personal-protective-equipment-ppe">meet the technical specifications</a>, or your offer will not be accepted.</p>
         product_name:
           label: "Name of product"
           custom_error: "Enter the name of the product"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -218,7 +218,7 @@ en:
             label: "No"
         custom_select_error: "Select if you have medical equipment to offer"
       medical_equipment_type:
-        title: "Tell us about the medical equipment you can offer"
+        title: "What type of medical equipment can you offer?"
         hint: "Give details for one product at a time."
         options:
           number_ppe:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -250,7 +250,7 @@ en:
           custom_error: "Enter the name of the product"
         product_quantity:
           label: "Quantity of this product"
-          hint: "Approximate amount, for example 10, 500, 10000."
+          hint: "Approximate amount. For example, 100,000"
           custom_error: "Enter the approximate total number of items, do not include words or symbols"
           suffix: "items"
         product_cost:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -122,5 +122,8 @@ Rails.application.routes.draw do
 
     # Other page - Session expired notice
     get "/session-expired", to: "session_expired#show"
+
+    # Other page - NHS Regional Coordination centres
+    get "/coordination-centres", to: "coordination_centres#show"
   end
 end

--- a/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/check_answers_controller_spec.rb
@@ -91,10 +91,23 @@ RSpec.describe CoronavirusForm::CheckAnswersController, type: :controller do
       expect(session.to_hash).to eq({})
     end
 
-    it "redirects to thank you if sucessfully creates record" do
+    it "redirects to thank you if it successfully creates record and there are enough product items" do
+      session.merge!(valid_data)
       post :submit
 
-      expect(response).to redirect_to(thank_you_path(reference_number: "abc"))
+      expect(response).to redirect_to(thank_you_path(reference_number: "abc", enough_items: "true"))
+    end
+
+    it "redirects to thank you if it successfully creates record and there are not enough product items" do
+      data = valid_data
+      data[:product_details].each do |product|
+        product[:product_quantity] = (ProductHelper::MINIMUM_ACCEPTED_PRODUCT_QUANTITY - 1).to_s if product[:product_quantity]
+      end
+
+      session.merge!(data)
+      post :submit
+
+      expect(response).to redirect_to(thank_you_path(reference_number: "abc", enough_items: "false"))
     end
 
     it "doesn't create a FormResponse if the user is the smoke tester" do

--- a/spec/controllers/coronavirus_form/coordination_centres_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/coordination_centres_controller_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe CoronavirusForm::CoordinationCentresController, type: :controller do
+  let(:current_template) { "coronavirus_form/coordination_centres" }
+
+  describe "GET show" do
+    it "renders the page" do
+      get :show
+      expect(response).to render_template(current_template)
+    end
+  end
+end

--- a/spec/helpers/product_helper_spec.rb
+++ b/spec/helpers/product_helper_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+RSpec.describe ProductHelper, type: :helper do
+  include FormResponseHelper
+
+  describe "#ppe_products_with_not_enough_items" do
+    it "returns nothing if all ppe products have enough items" do
+      session.merge!(valid_data)
+      expect(helper.ppe_products_with_not_enough_items).to be_empty
+    end
+
+    it "only returns products that don't have enough items" do
+      data = valid_data
+
+      data[:product_details].each do |product|
+        product[:product_quantity] = (ProductHelper::MINIMUM_ACCEPTED_PRODUCT_QUANTITY - 1).to_s if product[:product_quantity]
+      end
+
+      session.merge!(data)
+      expect(helper.ppe_products_with_not_enough_items.count).to eq(1)
+    end
+  end
+end

--- a/spec/support/form_response_helper.rb
+++ b/spec/support/form_response_helper.rb
@@ -1,4 +1,6 @@
 module FormResponseHelper
+  include ProductHelper
+
   def valid_data
     {
       medical_equipment: I18n.t("coronavirus_form.questions.medical_equipment.options").map { |_, item| item[:label] }.sample,
@@ -75,7 +77,7 @@ module FormResponseHelper
           equipment_type: I18n.t("coronavirus_form.questions.product_details.equipment_type.options").map { |_, item| item[:label] }.sample,
           product_location: I18n.t("coronavirus_form.questions.product_details.product_location.options").map { |_, item| item[:label] }.sample,
           product_postcode: "E1 8QS",
-          product_quantity: "10000",
+          product_quantity: MINIMUM_ACCEPTED_PRODUCT_QUANTITY.to_s,
           certification_details: "None",
           medical_equipment_type: I18n.t("coronavirus_form.questions.medical_equipment_type.options.number_ppe.label"),
         },


### PR DESCRIPTION
Trello: https://trello.com/c/FRMVxDpP
Preview app 👉 https://coronavirus-small-ppe-vyqaarwo.herokuapp.com/start

# What's changed?

- “What type of medical equipment can you offer?” page
  - Update the title text
  - add NHS regional coordination centre call-out
- “Tell us about the product you’re offering” (product details) page:
  - Add tech specs call-out at the top of the page (below the page title)
  - Update the hint text on the quantity field to be "Approximate amount. For example, 100,000"
  - Add details component below input field to highlight the 100,000 PPE threshold
- "Thank you" page 
  - update confirmation text
  - add NHS regional coordination centre call-out if they have continued to send the form with PPE below the 100,000 item threshold
- Create “Offer your products to an NHS Regional Coordination Centre” page (and link to it from all NHS regional coordination centre call-outs)

Still left to do:

- “Are you ready to send the form?” (check your answers) page 
  - add NHS regional coordination centre call-out adjacent to product title
This is blocked on: https://trello.com/c/eGsOEifg

# Why?

Cabinet Office is receiving too many offers that are too small (e.g. 500 masks) for them to deal with. They don't want to reject the offers out-right, so we are directing people to offering small quantities to the regional offices.

# Expected changes
## New Coordination Centres page
![screenshot-localhost_5000-2020 06 01-11_30_18](https://user-images.githubusercontent.com/5793815/83400762-510ac300-a3fb-11ea-841d-77fdf4ddb843.png)

## What type of medical equipment can you offer? page
|Before|After|
| ------|-----|
|<img width="1532" alt="Screenshot 2020-06-01 at 11 31 37" src="https://user-images.githubusercontent.com/5793815/83400863-844d5200-a3fb-11ea-84a9-917cb60420e4.png">|<img width="1532" alt="Screenshot 2020-06-01 at 11 24 07" src="https://user-images.githubusercontent.com/5793815/83400264-71864d80-a3fa-11ea-86c6-2211e09648ae.png">

## Tell us about the product you’re offering (product details) page
|Before|After|
| ------|-----|
|![screenshot-govuk-coronavirus-business-volunteer-form-stg cloudapps digital-2020 06 01-11_32_24](https://user-images.githubusercontent.com/5793815/83400939-aa72f200-a3fb-11ea-8fdb-06790a535806.png)| ![screenshot-localhost_5000-2020 06 01-11_24_49](https://user-images.githubusercontent.com/5793815/83400381-a2668280-a3fa-11ea-9f99-9e3476c8adab.png)|

## Thank you page

### Before
<img width="1532" alt="Screenshot 2020-06-01 at 11 35 03" src="https://user-images.githubusercontent.com/5793815/83401087-f4f46e80-a3fb-11ea-9608-52517d5e862c.png">

### After
|100,000 items or more| Less than 100,000 items|
| ----------------------|-------------------------|
|<img width="1532" alt="Screenshot 2020-06-01 at 11 29 38" src="https://user-images.githubusercontent.com/5793815/83400712-39cbd580-a3fb-11ea-86b5-3aa839bb783e.png">|<img width="1532" alt="Screenshot 2020-06-01 at 11 28 26" src="https://user-images.githubusercontent.com/5793815/83400595-08530a00-a3fb-11ea-8505-5afd2bb20a44.png">
