### PR TITLE
Bugfix: additional product back link

### DIFF
--- a/app/controllers/coronavirus_form/additional_product_controller.rb
+++ b/app/controllers/coronavirus_form/additional_product_controller.rb
@@ -35,7 +35,7 @@ private
 
   def previous_path
     session["product_details"] ||= []
-    latest_product_id = (session["product_details"].last || {}).dig("product_id")
+    latest_product_id = session["product_details"].last&.with_indifferent_access&.dig("product_id")
     product_details_url(product_id: latest_product_id)
   end
 end

--- a/spec/controllers/coronavirus_form/additional_product_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/additional_product_controller_spec.rb
@@ -20,6 +20,21 @@ RSpec.describe CoronavirusForm::AdditionalProductController, type: :controller d
     end
   end
 
+  describe "#previous_path" do
+    context "products have been added" do
+      it "includes a query parameter for the last added product" do
+        session["product_details"] = [{ product_id: "first" }, { product_id: "last" }]
+        expect(URI.parse(@controller.send(:previous_path)).request_uri).to eq("/product-details?product_id=last")
+      end
+    end
+
+    context "products have not been added" do
+      it "returns a link to the previous page" do
+        expect(URI.parse(@controller.send(:previous_path)).request_uri).to eq("/product-details")
+      end
+    end
+  end
+
   describe "POST submit" do
     it "redirects to next step for yes response" do
       post :submit, params: { additional_product: I18n.t("coronavirus_form.questions.additional_product.options.option_yes.label") }


### PR DESCRIPTION
This fixes an issue with the back link on the additional product page: this was changed from a String to a Symbol which introduced a bug.

I've added a test to catch this for next time.

https://trello.com/c/6fdlmZlR/509-prefill-previous-answers-on-medical-equipment-page
