### PR TITLE
Task/change check your answers layout

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -21,6 +21,7 @@
 @import 'govuk_publishing_components/components/radio';
 @import 'govuk_publishing_components/components/skip-link';
 @import 'govuk_publishing_components/components/summary-list';
+@import 'govuk_publishing_components/components/inset-text';
 @import 'govuk_publishing_components/components/table';
 @import 'govuk_publishing_components/components/textarea';
 @import 'govuk_publishing_components/components/title';

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -48,6 +48,10 @@ $color-red: #d4351c;
   }
 }
 
+.gem-c-summary-list {
+  border: None;
+}
+
 .govuk-summary-list__nested__value {
   list-style-position: inside;
   padding-left: 0;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -45,3 +45,8 @@
     width: 25%;
   }
 }
+
+.govuk-summary-list__nested__value {
+  list-style-position: inside;
+  padding-left: 0;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,6 +28,8 @@
 @import 'cookie-settings';
 
 // Application
+$color-red: #d4351c;
+
 .app-body--right {
   @include govuk-media-query($from: tablet) {
     text-align: right;
@@ -49,4 +51,8 @@
 .govuk-summary-list__nested__value {
   list-style-position: inside;
   padding-left: 0;
+}
+
+.delete-link:link {
+  color: $color-red;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -50,6 +50,7 @@ $color-red: #d4351c;
 
 .gem-c-summary-list {
   border: None;
+  margin-bottom: 50px;
 }
 
 .govuk-summary-list__nested__value {

--- a/app/helpers/check_answers_helper.rb
+++ b/app/helpers/check_answers_helper.rb
@@ -1,86 +1,49 @@
 module CheckAnswersHelper
-  SKIPPABLE_QUESTIONS = %w[
-    are_you_a_manufacturer
-    product_details
-    rooms_number
-    accommodation_cost
-    transport_type
-    transport_cost
-    offer_space_type
-    space_cost
-    offer_care_qualifications
-    care_cost
-    offer_staff_type
-    offer_staff_charge
-    construction_services
-    construction_services_other
-    construction_cost
-    it_services
-    it_services_other
-    it_cost
-  ].freeze
+  def summary_entry(session_path_or_key, description, edit, delete)
+    value = session.to_h.dig(*session_path_or_key.is_a?(Array) ? session_path_or_key : [session_path_or_key])
 
-  def items
-    items = questions.map do |question|
-      # We have answers as strings and hashes. The hashes need a little more
-      # work to make them readable.
-
-      next if skip_question?(question)
-
-      next product_details if question.eql?("product_details")
-      next transport_type if question.eql?("transport_type")
-      next offer_care_qualifications if question.eql?("offer_care_qualifications")
-      next offer_staff_type if question.eql?("offer_staff_type")
-      next link_to_parent_page(question, "offer_staff_type") if question.eql?("offer_staff_charge")
-      next link_to_parent_page(question, "construction_services") if question.eql?("construction_services_other")
-      next link_to_parent_page(question, "construction_services") if question.eql?("construction_cost")
-      next link_to_parent_page(question, "it_services") if question.eql?("it_services_other")
-      next link_to_parent_page(question, "it_services") if question.eql?("it_cost")
-      next link_to_parent_page(question, "transport_type") if question.eql?("transport_cost")
-      next link_to_parent_page(question, "offer_care_qualifications") if question.eql?("care_cost")
-      next link_to_parent_page(question, "rooms_number") if question.eql?("accommodation_cost")
-      next link_to_parent_page(question, "offer_space_type") if question.eql?("space_cost")
-
-      value = concat_answer(session[question], question)
-
-      [{
-        field: t("coronavirus_form.questions.#{question}.title"),
-        value: sanitize(value),
-        edit: {
-          href: "#{question.dasherize}?change-answer",
-        },
-      }]
+    entry = {
+      field: description,
+      value: value.is_a?(Array) ? value.map { |v| sanitize(v) } : sanitize(value),
+    }
+    question = session_path_or_key.is_a?(Array) ? session_path_or_key.first : session_path_or_key
+    if edit == true
+      entry[:edit] = {
+        href: "#{question.dasherize}?change-answer",
+      }
     end
-
-    items.compact.flatten
+    if delete == true
+      entry[:delete] = {
+        href: "#{question.dasherize}?change-answer",
+      }
+    end
+    entry
   end
 
-  def skip_question?(question)
-    return true if question.eql?("medical_equipment_type")
-
-    question.in?(SKIPPABLE_QUESTIONS) && session[question].blank?
+  def medical_equipment_section
+    {
+      title: t("check_your_answers.sections.medical_equipment.title"),
+      title_size: "l",
+      items: medical_equipment_items,
+    }
   end
 
-  def additional_product_index
-    items.index { |item| item[:field] == t("coronavirus_form.questions.additional_product.title") }
-  end
-
-  def items_part_1
-    items.select.with_index { |_, index| index < additional_product_index }
-  end
-
-  def items_part_2
-    items.select.with_index { |_, index| index > additional_product_index }
+  def medical_equipment_items
+    [
+      summary_entry("medical_equipment", t("coronavirus_form.questions.medical_equipment.title"), true, false),
+      summary_entry("are_you_a_manufacturer", t("coronavirus_form.questions.are_you_a_manufacturer.title"), true, false),
+    ].select { |x| item_has_value(x) }
   end
 
   def product_details
     products = session["product_details"]
-    return unless products && products.any?
+    return [] unless products && products.any?
 
-    products.map do |product|
+    products.map.with_index do |product, index|
       {
-        field: "Details for product #{product[:product_name]}",
-        value: sanitize(product_info(product)),
+        title: "Product #{index + 1}",
+        title_size: "m",
+        items: product_info(product),
         edit: {
           href: product_details_url(product_id: product[:product_id]),
         },
@@ -92,113 +55,215 @@ module CheckAnswersHelper
   end
 
   def product_info(product)
-    prod = []
-    prod << "Type: #{product[:medical_equipment_type]}"
-    prod << "Product: #{product[:product_name]}" if product[:product_name]
-    prod << "Equipment type: #{product[:equipment_type]}" if product[:equipment_type]
-    prod << "Quantity: #{product[:product_quantity]}" if product[:product_quantity]
-    prod << "Cost: #{product[:product_cost]}" if product[:product_cost]
-    prod << "Certification details: #{product[:certification_details]}" if product[:certification_details]
-    prod << "Location: #{product[:product_location]}" if product[:product_location]
-    prod << "Postcode: #{product[:product_postcode]}" if product[:product_postcode]
-    prod << "URL: #{product[:product_url]}" if product[:product_url]
-    prod << "Lead time: #{product[:lead_time]}" if product[:lead_time]
-
-    prod.join("<br>")
+    %w[
+      product_name
+      equipment_type
+      product_quantity
+      product_cost
+      certification_details
+      product_location
+      product_url
+      lead_time
+    ]
+      .select { |product_sym| product[product_sym.to_sym] }
+      .map do |product_sym|
+      summary_data = {
+        field: t("coronavirus_form.questions.product_details.#{product_sym}.label"),
+        value: sanitize(product[product_sym.to_sym]),
+      }
+      if product_sym == "product_location" && summary_data[:value] == t("coronavirus_form.questions.product_details.product_location.options.option_uk.label")
+        summary_data[:value] = "#{summary_data[:value]} (#{product[:product_postcode]})"
+      end
+      summary_data
+    end
   end
 
-  def transport_type
-    [{
-      field: t("coronavirus_form.questions.transport_type.title"),
-      value: sanitize(transport_type_info),
+  def accommodation_section
+    yes_no_section "accommodation", "accommodation"
+  end
+
+  def accommodation_details_section
+    details_section "accommodation", "rooms_number", %w[rooms_number accommodation_description accommodation_cost]
+  end
+
+  def transport_section
+    yes_no_section "transport", "offer_transport"
+  end
+
+  def transport_details_section
+    details_section "offer_transport", "transport_type", %w[transport_type transport_description transport_cost]
+  end
+
+  def staff_section
+    yes_no_section "staff", "offer_staff"
+  end
+
+  def staff_details_section
+    section_data = details_section "offer_staff", "offer_staff_type", %w[offer_staff_type offer_staff_description offer_staff_charge]
+    return section_data unless section_data
+
+    label_to_cost_key = t("coronavirus_form.questions.offer_staff_type.offer_staff_type.options").map { |_key, value| [value[:label], value.dig(:description, :id).to_sym] }.to_h
+    section_data[:items][0][:value] = section_data[:items][0][:value].map do |item|
+      "#{item} (#{session['offer_staff_number'][label_to_cost_key[item]]} people)"
+    end
+    section_data
+  end
+
+  def space_section
+    yes_no_section "space", "offer_space"
+  end
+
+  def space_details_section
+    section_data = details_section "offer_space", "offer_space_type", %w[offer_space_type offer_space_type_other space_cost]
+    return section_data unless section_data
+
+    label_to_space_description = t(
+      "coronavirus_form.questions.offer_space_type.options",
+    ).map { |_key, value| [value[:label], value.dig(:description, :id)] }.to_h
+    section_data[:items][0][:value] = section_data[:items][0][:value].map do |item|
+      "#{item} (#{session[label_to_space_description[item]]})"
+    end
+    section_data
+  end
+
+  def care_section
+    yes_no_section "care", "offer_care"
+  end
+
+  def care_details_section
+    details_section "offer_care", "offer_care_qualifications", %w[offer_care_type offer_care_qualifications offer_care_qualifications_type care_cost]
+  end
+
+  def location_section
+    {
+      title: t("check_your_answers.sections.location.title"),
+      title_size: "l",
+      items: [summary_entry("location", t("check_your_answers.fields.location.title"), true, false)],
+    }
+  end
+
+  def expertise_section
+    {
+      title: t("check_your_answers.sections.expertise.title"),
+      title_size: "l",
+      items: [summary_entry("expert_advice_type", t("check_your_answers.fields.expert_advice_type.title"), true, false)],
+    }
+  end
+
+  def construction_expertise_section
+    expertise_details_section "construction"
+  end
+
+  def it_expertise_section
+    expertise_details_section "it"
+  end
+
+  def business_details_section
+    section_data = {
+      title: t("check_your_answers.sections.business_details.title"),
+      title_size: "l",
       edit: {
-        href: "transport-type?change-answer",
+        href: "business-details?change-answer",
       },
-    }]
+      items: [
+        summary_entry(["business_details", :company_name], t("check_your_answers.fields.company_name.title"), false, false),
+        summary_entry(["business_details", :company_number], t("check_your_answers.fields.company_number.title"), false, false),
+        summary_entry(["business_details", :company_size], t("check_your_answers.fields.company_size.title"), false, false),
+        # TODO: special case postcode
+        summary_entry(["business_details", :company_location], t("check_your_answers.fields.company_location.title"), false, false),
+      ],
+    }
+    country = section_data[:items].last[:value]
+    if country == t("coronavirus_form.questions.business_details.company_location.options.united_kingdom.label")
+      section_data[:items].last[:value] = "#{country} (#{session['business_details'][:company_postcode]})"
+    end
+    section_data
   end
 
-  def transport_type_info
-    answer = []
-    answer << Array(session[:transport_type]).flatten.to_sentence
-    answer << session[:transport_description]
-
-    answer.join("<br>")
-  end
-
-  def offer_care_qualifications
-    [{
-      field: t("coronavirus_form.questions.offer_care_qualifications.offer_care_type.title"),
-      value: sanitize(Array(session[:offer_care_type]).flatten.to_sentence),
+  def contact_details_section
+    {
+      title: t("check_your_answers.sections.contact_details.title"),
+      title_size: "l",
       edit: {
-        href: "offer-care-qualifications?change-answer",
+        href: "contact-details?change-answer",
       },
-    },
-     {
-       field: t("coronavirus_form.questions.offer_care_qualifications.care_qualifications.title"),
-       value: sanitize(Array(session[:offer_care_qualifications]).flatten.to_sentence),
-       edit: {
-         href: "offer-care-qualifications?change-answer",
-       },
-     }]
+      items: [
+        summary_entry(["contact_details", :contact_name], t("check_your_answers.fields.contact_name.title"), false, false),
+        summary_entry(["contact_details", :role], t("check_your_answers.fields.role.title"), false, false),
+        summary_entry(["contact_details", :phone_number], t("check_your_answers.fields.phone.title"), false, false),
+        # TODO: special case postcode
+        summary_entry(["contact_details", :email], t("check_your_answers.fields.email.title"), false, false),
+      ],
+    }
   end
 
-  def link_to_parent_page(question, parent_question)
-    [{
-      field: t("coronavirus_form.questions.#{question}.title"),
-      value: sanitize(concat_answer(session[question.to_sym], question)),
+  def other_support_section
+    section_data = {
+      title: t("check_your_answers.sections.offer_other_support.title"),
+      title_size: "l",
+      items: [summary_entry("offer_other_support", t("check_your_answers.fields.offer_other_support.title"), true, false)],
+    }
+    unless item_has_value(section_data[:items][0])
+      section_data[:items][0][:value] = "I cannot offer any other kind of support"
+    end
+    section_data
+  end
+
+private
+
+  def item_has_value(item)
+    ["", nil].exclude?(item[:value])
+  end
+
+  def yes_no_section(section_key, session_key)
+    {
+      title: t("check_your_answers.sections.#{section_key}.title"),
+      title_size: "l",
       edit: {
-        href: "#{parent_question.dasherize}?change-answer",
+        href: "#{session_key.dasherize}?change-answer",
       },
-    }]
+      items: [
+        summary_entry(session_key, t("coronavirus_form.questions.#{session_key}.title"), false, false),
+      ],
+    }
   end
 
-  def offer_staff_type
-    [{
-      field: t("coronavirus_form.questions.offer_staff_type.title"),
-      value: sanitize(Array(session[:offer_staff_type]).flatten.to_sentence),
-      edit: {
-        href: "offer-staff-type?change-answer",
-      },
-    },
-     {
-       field: t("coronavirus_form.questions.offer_staff_type.offer_staff_description.label"),
-       value: sanitize(session[:offer_staff_description]),
-       edit: {
-         href: "offer-staff-type?change-answer",
-       },
-     }]
-  end
-
-  def concat_answer(answer, question)
-    return unless answer
-    return answer if answer.is_a?(String)
-    return answer.flatten.to_sentence if answer.is_a?(Array)
-
-    concatenated_answer = []
-    joiner = " "
-
-    if question.eql?("contact_details")
-      concatenated_answer << "Name: #{answer[:contact_name]}" if answer[:contact_name]
-      concatenated_answer << "Role: #{answer[:role]}" if answer[:role]
-      concatenated_answer << "Phone number: #{answer[:phone_number]}" if answer[:phone_number]
-      concatenated_answer << "Email: #{answer[:email]}" if answer[:email]
-      joiner = "<br>"
-    elsif question.eql?("business_details")
-      concatenated_answer << "Company name: #{answer[:company_name]}" if answer[:company_name]
-      concatenated_answer << "Company number: #{answer[:company_number]}" if answer[:company_number]
-      concatenated_answer << "Company size number: #{answer[:company_size]}" if answer[:company_size]
-      concatenated_answer << "Company location: #{answer[:company_location]}" if answer[:company_location]
-      concatenated_answer << "Company postcode: #{answer[:company_postcode]}" if answer[:company_postcode]
-      joiner = "<br>"
-    else
-      concatenated_answer = answer.values.compact
+  def details_section(key, edit_link_key, item_keys)
+    # Annoyingly their are two possible paths in the YAML.
+    if [t("coronavirus_form.questions.#{key}.options.no_option.label"), t("coronavirus_form.questions.#{key}.options.option_no.label")].include?(session.to_h[key])
+      return nil
     end
 
-    concatenated_answer.join(joiner)
+    items = item_keys.map do |item_key|
+      summary_entry(item_key, t("check_your_answers.fields.#{item_key}.title"), false, false)
+    end
+    items = items.select { |x| item_has_value(x) }
+    return nil if items.empty?
+
+    {
+      title: t("check_your_answers.sections.details_subsection.title"),
+      title_size: "m",
+      edit: {
+        href: "#{edit_link_key.dasherize}?change-answer",
+      },
+      items: items,
+    }
   end
 
-  def questions
-    questions ||= YAML.load_file(Rails.root.join("config/locales/en.yml"))
-    questions["en"]["coronavirus_form"]["questions"].keys
+  def expertise_details_section(base_key)
+    return unless session["expert_advice_type"].include?(t("coronavirus_form.questions.expert_advice_type.options.#{base_key}.label"))
+
+    services_key = "#{base_key}_services"
+    other_key = "#{base_key}_services_other"
+    cost_key = "#{base_key}_cost"
+    {
+      title: t("check_your_answers.sections.#{base_key}.title"),
+      title_size: "m",
+      items: [
+        summary_entry(services_key, t("check_your_answers.fields.#{services_key}.title"), true, false),
+        summary_entry(other_key, t("check_your_answers.fields.#{other_key}.title"), true, false),
+        summary_entry(cost_key, t("check_your_answers.fields.#{cost_key}.title"), true, false),
+      ],
+    }
   end
 end

--- a/app/views/coronavirus_form/_summary_list.erb
+++ b/app/views/coronavirus_form/_summary_list.erb
@@ -1,0 +1,97 @@
+<%
+  id ||= nil
+  title ||= nil
+  borderless ||= false
+  edit ||= {}
+  delete ||= {}
+  items ||= []
+  block ||= yield
+  title_size ||= "m"
+%>
+<% if title || items.any? %>
+  <%= tag.div class: "gem-c-summary-list #{"govuk-summary-list--no-border" if borderless}", id: id do %>
+    <% if title %>
+      <%= tag.h3 title, class: "govuk-heading-#{title_size}" %>
+      <% if edit.any? || delete.any? %>
+        <%= tag.ul class: "govuk-summary-list__actions-list govuk-summary-list__actions-list__actions" do %>
+          <%= tag.div class: "gem-c-summary-list__edit-section-link" do %>
+          <% if edit.any? %>
+            <%= tag.li class: "govuk-summary-list__actions-list-item" do %>
+              <% edit_link_text = edit[:link_text] || "Change" %>
+              <%= link_to edit.fetch(:href),
+                          class: "govuk-link",
+                          title: "#{edit_link_text} #{title.downcase}",
+                          data: edit.fetch(:data_attributes, {}) do %>
+                <%= edit_link_text %><%= tag.span title, class: "govuk-visually-hidden" %>
+              <% end %>
+            <% end %>
+          <% end %>
+          <% if delete.any? %>
+            <%= tag.li class: "govuk-summary-list__actions-list-item" do %>
+              <% delete_link_text = delete[:link_text] || "Delete" %>
+              <%= link_to delete.fetch(:href),
+                          class: "govuk-link",
+                          title: "#{delete_link_text} #{title.downcase}",
+                          data: delete.fetch(:data_attributes, {}) do %>
+                <%= delete_link_text %><%= tag.span title, class: "govuk-visually-hidden" %>
+              <% end %>
+            <% end %>
+          <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <% if items.any? %>
+      <%= tag.dl class: "govuk-summary-list" do %>
+        <% items.each do |item| %>
+          <%= tag.div class: "govuk-summary-list__row" do %>
+
+            <%= tag.dt item[:field], class: "govuk-summary-list__key" %>
+            <%= tag.dd class: "govuk-summary-list__value" do %>
+              <% if item[:value].is_a?(Array) %>
+                <%= tag.ul do %>
+                  <% item[:value].each do |value_item| %>
+                    <%= tag.li value_item %>
+                  <% end %>
+                <% end %>
+              <% else %>
+                <%= item[:value] %>
+              <% end %>
+            <% end %>
+
+            <% if item.fetch(:edit, {}).any? || item.fetch(:delete, {}).any? %>
+              <%= tag.dd class: "govuk-summary-list__actions" do %>
+                <%= tag.ul class: "govuk-summary-list__actions-list" do %>
+                  <% if item.fetch(:edit, {}).any? %>
+                    <%= tag.li class: "govuk-summary-list__actions-list-item" do %>
+                      <% edit_link_text = item[:edit][:link_text] || "Change" %>
+                      <%= link_to item[:edit].fetch(:href),
+                                  class: "govuk-link",
+                                  title: "#{edit_link_text} #{item[:field].downcase}",
+                                  data: item[:edit].fetch(:data_attributes, {}) do %>
+                        <%= edit_link_text %><%= tag.span " #{item[:field]}", class: "govuk-visually-hidden" %><% end %>
+                    <% end %>
+                  <% end %>
+                  <% if item.fetch(:delete, {}).any? %>
+                    <%= tag.li class: "govuk-summary-list__actions-list-item" do %>
+                      <% delete_link_text = item[:delete][:link_text] || "Delete" %>
+                      <%= link_to item[:delete].fetch(:href),
+                                  class: "govuk-link",
+                                  title: "#{delete_link_text} #{item[:field].downcase}",
+                                  data: item[:delete].fetch(:data_attributes, {}) do %>
+                        <%= delete_link_text %><%= tag.span " #{item[:field]}", class: "govuk-visually-hidden" %>
+                      <% end %>
+                    <% end %>
+                  <% end %>
+                <% end %>
+              <% end %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <%= tag.div block, class: "gem-c-summary__block" if block %>
+  <% end %>
+<% end %>

--- a/app/views/coronavirus_form/_summary_list.erb
+++ b/app/views/coronavirus_form/_summary_list.erb
@@ -30,7 +30,7 @@
             <%= tag.li class: "govuk-summary-list__actions-list-item" do %>
               <% delete_link_text = delete[:link_text] || "Delete" %>
               <%= link_to delete.fetch(:href),
-                          class: "govuk-link",
+                          class: "delete-link govuk-link",
                           title: "#{delete_link_text} #{title.downcase}",
                           data: delete.fetch(:data_attributes, {}) do %>
                 <%= delete_link_text %><%= tag.span title, class: "govuk-visually-hidden" %>
@@ -77,7 +77,7 @@
                     <%= tag.li class: "govuk-summary-list__actions-list-item" do %>
                       <% delete_link_text = item[:delete][:link_text] || "Delete" %>
                       <%= link_to item[:delete].fetch(:href),
-                                  class: "govuk-link",
+                                  class: "delete-link govuk-link",
                                   title: "#{delete_link_text} #{item[:field].downcase}",
                                   data: item[:delete].fetch(:data_attributes, {}) do %>
                         <%= delete_link_text %><%= tag.span " #{item[:field]}", class: "govuk-visually-hidden" %>

--- a/app/views/coronavirus_form/_summary_list.erb
+++ b/app/views/coronavirus_form/_summary_list.erb
@@ -50,7 +50,7 @@
             <%= tag.dt item[:field], class: "govuk-summary-list__key" %>
             <%= tag.dd class: "govuk-summary-list__value" do %>
               <% if item[:value].is_a?(Array) %>
-                <%= tag.ul do %>
+                <%= tag.ul class: "govuk-summary-list__nested__value" do %>
                   <% item[:value].each do |value_item| %>
                     <%= tag.li value_item %>
                   <% end %>

--- a/app/views/coronavirus_form/check_answers.html.erb
+++ b/app/views/coronavirus_form/check_answers.html.erb
@@ -10,32 +10,39 @@
 <%= render "govuk_publishing_components/components/title", {
   title: t("check_your_answers.title"),
   margin_top: 0,
-  margin_bottom: 3,
+  margin_bottom: 9,
 } %>
 
-<%= tag.p t("check_your_answers.description"), class: "govuk-body" %>
+<%= render "coronavirus_form/summary_list", medical_equipment_section %>
+<% product_details.each.with_index do |product| %>
+  <%= render "coronavirus_form/summary_list", product %>
+<% end %>
+<%= tag.div sanitize( tag.p(
+              link_to("Add another product",
+                      "/medical-equipment-type",
+                      class: "govuk-link"
+              ),
+            class: "govuk-body app-body--left")
+           ), class: "gem-c-summary__block" %>
 
-<%= render "govuk_publishing_components/components/summary_list", {
-  items: items_part_1,
-  block: sanitize(
-          tag.p(
-            link_to("Add an additional product",
-                    "/medical-equipment-type",
-                    class: "govuk-link"
-            ),
-          class: "govuk-body app-body--right")
-         )
-} %>
 
-<%= render "govuk_publishing_components/components/summary_list", {
-  items: items_part_2,
-} %>
-
-<%= render "govuk_publishing_components/components/heading", {
-  text: t("check_your_answers.heading"),
-  heading_level: 2,
-  margin_bottom: 3,
-} %>
+<%= render "coronavirus_form/summary_list", accommodation_section %>
+<%= render "coronavirus_form/summary_list", accommodation_details_section %>
+<%= render "coronavirus_form/summary_list", transport_section %>
+<%= render "coronavirus_form/summary_list", transport_details_section %>
+<%= render "coronavirus_form/summary_list", space_section %>
+<%= render "coronavirus_form/summary_list", space_details_section %>
+<%= render "coronavirus_form/summary_list", staff_section %>
+<%= render "coronavirus_form/summary_list", staff_details_section %>
+<%= render "coronavirus_form/summary_list", care_section %>
+<%= render "coronavirus_form/summary_list", care_details_section %>
+<%= render "coronavirus_form/summary_list", expertise_section %>
+<%= render "coronavirus_form/summary_list", construction_expertise_section %>
+<%= render "coronavirus_form/summary_list", it_expertise_section %>
+<%= render "coronavirus_form/summary_list", other_support_section %>
+<%= render "coronavirus_form/summary_list", location_section %>
+<%= render "coronavirus_form/summary_list", business_details_section %>
+<%= render "coronavirus_form/summary_list", contact_details_section %>
 
 <%= tag.p t("check_your_answers.confirmation"), class: "govuk-body" %>
 

--- a/app/views/coronavirus_form/check_answers.html.erb
+++ b/app/views/coronavirus_form/check_answers.html.erb
@@ -44,7 +44,7 @@
 <%= render "coronavirus_form/summary_list", business_details_section %>
 <%= render "coronavirus_form/summary_list", contact_details_section %>
 
-<%= tag.p t("check_your_answers.confirmation"), class: "govuk-body" %>
+<%= tag.p t("check_your_answers.confirmation"), class: "govuk-inset-text" %>
 
 <%= form_tag({},
   "data-module": "track-coronavirus-form-business-check-your-answers",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -157,9 +157,105 @@ en:
   check_your_answers:
     title: "Are you ready to send the form?"
     description: "Check your answers, then send the form."
-    heading: "Now send the form"
     confirmation: "By submitting this form you’re confirming that, to the best of your knowledge, the details you’re providing are correct."
     submit: "Accept and send"
+    sections:
+      details_subsection:
+        title: "Details of your offer"
+      location:
+        title: "Location"
+      expertise:
+        title: "Services or expertise"
+      medical_equipment:
+        title: "Medical equipment"
+        product_details_title_prefix: "Product"
+      accommodation:
+        title: "Accommodation"
+      transport:
+        title: "Transport"
+      space:
+        title: "Space"
+      care:
+        title: "Social care or childcare"
+      staff:
+        title: "Staff"
+      construction:
+        title: "Construction"
+      it:
+        title: "IT Services"
+      offer_other_support:
+        title: "Other support"
+      contact_details:
+        title: "Contact Details"
+      business_details:
+        title: "Business Details"
+    fields:
+      rooms_number:
+        title: "Number of rooms you can offer"
+      accommodation_description:
+        title: "Description of the type of rooms"
+      accommodation_cost:
+        title: "How much will you charge"
+      transport_type:
+        title: "Kind of transport or logistics services you can offer"
+      transport_description:
+        title: "Description of your transport or logistics services"
+      transport_cost:
+        title: "How much will you charge"
+      offer_space_type:
+        title: "Kind of space you can offer"
+      offer_space_type_other:
+        title: "Description of your space"
+      space_cost:
+        title: "How much will you charge"
+      offer_staff_type:
+        title: "What kind of staff can you can offer"
+      offer_staff_description:
+        title: "Description of the type of staff"
+      offer_staff_charge:
+        title: "How much will you charge"
+      offer_care_type:
+        title: "Kind of care you can offer"
+      care_cost:
+        title: "How much will you charge"
+      offer_care_qualifications:
+        title: "Qualifications or certificates you have"
+      offer_care_qualifications_type:
+        title: "Type of nursing or healthcare qualification"
+      offer_other_support:
+        title: "Details of other support you can offer"
+      location:
+        title: "Details of where you can offer your services"
+      company_name:
+        title: "Company name"
+      company_number:
+        title: "Company number"
+      company_size:
+        title: "Company size"
+      company_location:
+        title: "Company location"
+      contact_name:
+        title: "Company location"
+      role:
+        title: "Role of main contact"
+      phone:
+        title: "Phone number of main contact"
+      email:
+        title: "Email address of main contact"
+      expert_advice_type:
+        title: "Kind of expertise you offer"
+      construction_services:
+        title: "Kind of construction services you can offer"
+      construction_services_other:
+        title: "Description of your construction services"
+      construction_cost:
+        title: "How much will you charge"
+      it_services:
+        title: "Kind of IT services you can offer"
+      it_services_other:
+        title: "Description of your IT services"
+      it_cost:
+        title: "How much will you charge"
   session_expired:
     title: Your session has ended due to inactivity
     body_text: |

--- a/spec/helpers/check_answers_helper_spec.rb
+++ b/spec/helpers/check_answers_helper_spec.rb
@@ -32,56 +32,99 @@ RSpec.describe CheckAnswersHelper, type: :helper do
 
   let(:products) do
     {
-      product_details: [{
-        medical_equipment_type: I18n.t(
-          "coronavirus_form.questions.medical_equipment_type.options.number_ppe.label",
-        ),
-        product_name: "Product name",
-      }],
+      product_details: [
+        {
+          equipment_type: I18n.t(
+            "coronavirus_form.questions.medical_equipment_type.options.number_ppe.label",
+          ),
+          product_name: "Product name 1",
+        },
+        {
+          equipment_type: I18n.t(
+            "coronavirus_form.questions.medical_equipment_type.options.number_ppe.label",
+          ),
+          product_name: "Product name 2",
+        },
+        {
+          product_location: I18n.t(
+            "coronavirus_form.questions.product_details.product_location.options.option_uk.label",
+          ),
+          equipment_type: I18n.t(
+            "coronavirus_form.questions.medical_equipment_type.options.number_ppe.label",
+          ),
+          product_postcode: "RG1 2NU",
+          product_name: "Product name 3",
+        },
+      ],
     }
   end
 
-  describe "#items" do
-    it "adds a link to edit each item" do
-      helper.items.each do |item|
-        expect(item[:edit][:href]).to include("?change-answer")
-      end
+  describe "#summary_entry" do
+    context "edit permutations"
+    it "returns non-editable field data if session_key is valid" do
+      session.merge!({ "non_empty_string": "woah here's a string" })
+      expect(
+        helper.summary_entry("non_empty_string", "example description", false, false),
+      ).to eq(
+        { field: "example description", value: "woah here's a string" },
+      )
     end
 
-    it "has an entry for each regular question" do
-      session.merge!(answers_to_skippable_questions)
-
-      questions.each do |question|
-        unless question.in? %w[medical_equipment_type product_details]
-          expect(helper.items.pluck(:field)).to include(I18n.t("coronavirus_form.questions.#{question}.title"))
-        end
-      end
+    it "returns change link values if asked for them" do
+      session.merge!({ "non_empty_string": "woah here's a string" })
+      expect(
+        helper.summary_entry("non_empty_string", "example description", true, false),
+      ).to eq({
+        edit: { href: "non-empty-string?change-answer" },
+        field: "example description",
+        value: "woah here's a string",
+      })
     end
 
-    it "includes an entry for product_details" do
-      session.merge!(products)
-
-      questions.each do |question|
-        if question == "product_details"
-          expect(helper.items.pluck(:field)).to include(a_string_matching(/#{session["product_details"].first["product_name"]}/))
-        end
-      end
+    it "returns delete link values if asked" do
+      session.merge!({ "non_empty_string": "woah here's a string" })
+      expect(
+        helper.summary_entry("non_empty_string", "example description", false, true),
+      ).to eq({
+        delete: { href: "non-empty-string?change-answer" },
+        field: "example description",
+        value: "woah here's a string",
+      })
     end
 
-    it "doesn't include questions that the user has skipped" do
-      questions.each do |question|
-        if question.in? CheckAnswersHelper::SKIPPABLE_QUESTIONS
-          expect(helper.items.pluck(:field)).to_not include(I18n.t("coronavirus_form.questions.#{question}.title"))
-        end
-      end
+    it "returns change & delete link values if asked" do
+      session.merge!({ "non_empty_string": "woah here's a string" })
+      expect(
+        helper.summary_entry("non_empty_string", "example description", true, true),
+      ).to eq({
+        delete: { href: "non-empty-string?change-answer" },
+        edit: { href: "non-empty-string?change-answer" },
+        field: "example description",
+        value: "woah here's a string",
+      })
     end
-  end
-
-  describe "#additional_product_index" do
-    it "finds the index of the additional_product question" do
-      session.merge!(answers_to_skippable_questions)
-
-      expect(helper.additional_product_index).to eq(2)
+    it "returns an array if passed an array" do
+      session.merge!({ "non_empty_string": ["woah here's a string", "and a second", "and a third"] })
+      expect(
+        helper.summary_entry("non_empty_string", "example description", false, false),
+      ).to eq({
+        field: "example description",
+        value: ["woah here's a string", "and a second", "and a third"],
+      })
+    end
+    it "digs into nested structure if passed an array for a session key" do
+      session.merge!({ "non_empty_string": { key_1: { key_2: "woah here's a string" } } })
+      expect(
+        helper.summary_entry(
+          ["non_empty_string", :key_1, :key_2],
+          "example description", true, true
+        ),
+      ).to eq({
+        delete: { href: "non-empty-string?change-answer" },
+        edit: { href: "non-empty-string?change-answer" },
+        field: "example description",
+        value: "woah here's a string",
+      })
     end
   end
 
@@ -90,203 +133,520 @@ RSpec.describe CheckAnswersHelper, type: :helper do
       session.merge!(products)
     end
 
+    subject { helper.product_details }
+
     it "adds a link to edit each item" do
-      helper.product_details.each do |product|
+      subject.each do |product|
         expect(product[:edit][:href]).to include(product_details_url(product_id: product["product_id"]))
       end
     end
 
     it "adds a link to delete each item" do
-      helper.product_details.each do |product|
+      subject.each do |product|
         expect(product[:delete][:href]).to include("/product-details/#{product[:product_id]}/delete")
       end
     end
-  end
 
-  describe "#product_info" do
-    it "concatenates product information with a line break" do
-      product = {
-        medical_equipment_type: I18n.t(
-          "coronavirus_form.questions.medical_equipment_type.options.number_ppe.label",
-        ),
-        product_name: "Product name",
-        equipment_type: "Equipment type",
-        product_quantity: 100,
-        product_cost: 5,
-        certification_details: "Certification",
-        product_location: "UK",
-        product_postcode: "E1 8QS",
-        product_url: "https://www.example.com",
-        lead_time: 5,
-      }
-
-      expected_answer = "Type: #{product[:medical_equipment_type]}<br>" \
-                          "Product: #{product[:product_name]}<br>" \
-                          "Equipment type: #{product[:equipment_type]}<br>" \
-                          "Quantity: #{product[:product_quantity]}<br>" \
-                          "Cost: #{product[:product_cost]}<br>" \
-                          "Certification details: #{product[:certification_details]}<br>" \
-                          "Location: #{product[:product_location]}<br>" \
-                          "Postcode: #{product[:product_postcode]}<br>" \
-                          "URL: #{product[:product_url]}<br>" \
-                          "Lead time: #{product[:lead_time]}"
-
-      expect(helper.product_info(product)).to eq(expected_answer)
+    it "adds a numbered title to each item" do
+      subject.each.with_index do |product, index|
+        expect(product[:title]).to eq("Product #{index + 1}")
+      end
     end
 
-    it "only concatenates the fields that have a value" do
-      product = {
-        medical_equipment_type: I18n.t(
-          "coronavirus_form.questions.medical_equipment_type.options.number_ppe.label",
-        ),
-        product_name: "Product name",
-      }
+    it "sets title size to m" do
+      subject.each.with_index do |product, _index|
+        expect(product[:title_size]).to eq("m")
+      end
+    end
 
-      expected_answer = "Type: #{product[:medical_equipment_type]}<br>Product: #{product[:product_name]}"
-      expect(helper.product_info(product)).to eq(expected_answer)
+    it "retrieves value from products hash and maps it to data structure" do
+      subject.each.with_index do |product, index|
+        expect(product.dig(:items, 0, :value)).to eq(products[:product_details][index][:product_name])
+        expect(product.dig(:items, 1, :value)).to eq(products[:product_details][index][:equipment_type])
+      end
+    end
+
+    it "adds in the translation for the product_key value" do
+      subject.each.with_index do |product, _index|
+        expect(product.dig(:items, 0, :field)).to eq(t("coronavirus_form.questions.product_details.product_name.label"))
+        expect(product.dig(:items, 1, :field)).to eq(t("coronavirus_form.questions.product_details.equipment_type.label"))
+      end
+    end
+    it "handles the postcode special case correctly" do
+      product3 = subject[2]
+      expect(product3.dig(:items, 2, :field)).to eq(t("coronavirus_form.questions.product_details.product_location.label"))
+      expect(product3.dig(:items, 2, :value)).to eq("United Kingdom (RG1 2NU)")
     end
   end
 
-  describe "#transport_type" do
-    it "adds a query string to the link for each item" do
-      helper.transport_type.each do |item|
-        expect(item[:edit][:href]).to include("?change-answer")
+  describe "methods presenting offer sections (those preceding details sections that have yes no answers)" do
+    context "offer is yes" do
+      before do
+        session.merge!({
+          "accommodation": "Yes",
+          "rooms_number": "500",
+          "accommodation_description": "Very nice",
+          "accommodation_cost": t("coronavirus_form.how_much_charge.options.nothing.label"),
+
+          "offer_transport": "Yes",
+          "transport_type": "Yes",
+          "transport_description": "Yes",
+          "transport_cost": t("coronavirus_form.how_much_charge.options.nothing.label"),
+
+          "offer_staff": "Yes",
+          "offer_staff_type": [
+            t("coronavirus_form.questions.offer_staff_type.offer_staff_type.options.cleaners.label"),
+            t("coronavirus_form.questions.offer_staff_type.offer_staff_type.options.developers.label"),
+            t("coronavirus_form.questions.offer_staff_type.offer_staff_type.options.medical_staff.label"),
+          ],
+          "offer_staff_number": {
+            cleaners_number: 12,
+            developers_number: 39,
+            medical_staff_number: 9,
+          },
+          "offer_staff_description": "They're well qualified.",
+          "offer_staff_charge": t("coronavirus_form.how_much_charge.options.reduced.label"),
+
+          "offer_space": "Yes",
+          "offer_space_type": [t("coronavirus_form.questions.offer_space_type.options.warehouse_space.label").to_s],
+          "offer_space_type_other": "Description of space",
+          "space_cost": t("coronavirus_form.how_much_charge.options.nothing.label"),
+          "warehouse_space_description": "123 feet",
+
+          "offer_care": "Yes",
+          "offer_care_type": [t("coronavirus_form.questions.offer_care_qualifications.offer_care_type.options.adult_care.label")],
+          "offer_care_qualifications": [t("coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.dbs_check.label")],
+          "offer_care_qualifications_type": "Very good qualifications. This is a description field, really.",
+          "care_cost": t("coronavirus_form.how_much_charge.options.nothing.label"),
+        })
+      end
+
+      [
+        # Sections which report the result of offer questions
+        [
+          "accommodation_section",
+          { title: "Accommodation",
+            title_size: "l",
+            edit: { href: "accommodation?change-answer" },
+            items: [{ field: "Can you offer accommodation?", value: "Yes" }] },
+        ],
+        [
+          "transport_section",
+          { title: "Transport",
+            title_size: "l",
+            edit: { href: "offer-transport?change-answer" },
+            items: [{ field: "Can you offer transport or logistics?", value: "Yes" }] },
+        ],
+        [
+          "staff_section",
+          { title: "Staff",
+            title_size: "l",
+            edit: { href: "offer-staff?change-answer" },
+            items: [{ field: "Can you offer staff?", value: "Yes" }] },
+        ],
+        [
+          "space_section",
+          { title: "Space",
+            title_size: "l",
+            edit: { href: "offer-space?change-answer" },
+            items: [{ field: "Can you offer space?", value: "Yes" }] },
+        ],
+        [
+          "care_section",
+          { title: "Social care or childcare",
+            title_size: "l",
+            edit: { href: "offer-care?change-answer" },
+            items: [{ field: "Can you offer social care or childcare?", value: "Yes" }] },
+        ],
+        [
+          "accommodation_details_section",
+          { title: "Details of your offer",
+            title_size: "m",
+            edit: { href: "rooms-number?change-answer" },
+            items: [{ field: "Number of rooms you can offer", value: "500" },
+                    { field: "Description of the type of rooms", value: "Very nice" },
+                    { field: "How much will you charge",
+                      value: "Nothing, it would be a donation" }] },
+        ],
+        [
+          "transport_details_section",
+          { title: "Details of your offer",
+            title_size: "m",
+            edit: { href: "transport-type?change-answer" },
+            items: [{ field: "Kind of transport or logistics services you can offer",
+                      value: "Yes" },
+                    { field: "Description of your transport or logistics services",
+                      value: "Yes" },
+                    { field: "How much will you charge",
+                      value: "Nothing, it would be a donation" }] },
+        ],
+        [
+          "staff_details_section",
+          { title: "Details of your offer",
+            title_size: "m",
+            edit: { href: "offer-staff-type?change-answer" },
+            items: [{ field: "What kind of staff can you can offer",
+                      value: ["Cleaners (12 people)",
+                              "Developers (39 people)",
+                              "Medical staff (9 people)"] },
+                    { field: "Description of the type of staff",
+                      value: "They're well qualified." },
+                    { field: "How much will you charge", value: "A reduced price" }] },
+        ],
+        [
+          "space_details_section",
+          { title: "Details of your offer",
+            title_size: "m",
+            edit: { href: "offer-space-type?change-answer" },
+            items: [{ field: "Kind of space you can offer", value: ["Warehouse space (123 feet)"] },
+                    { field: "Description of your space", value: "Description of space" },
+                    { field: "How much will you charge",
+                      value: "Nothing, it would be a donation" }] },
+        ],
+        [
+          "care_details_section",
+          {
+            title: "Details of your offer",
+            title_size: "m",
+            edit: { href: "offer-care-qualifications?change-answer" },
+            items: [{ field: "Kind of care you can offer", value: ["Care for adults"] },
+                    { field: "Qualifications or certificates you have", value: ["DBS check"] },
+                    { field: "Type of nursing or healthcare qualification",
+                      value: "Very good qualifications. This is a description field, really." },
+                    { field: "How much will you charge",
+                      value: "Nothing, it would be a donation" }],
+          },
+        ],
+      ].each.with_index do |test, _index|
+        section_method_name, expected = test
+        it "correct data returned for sections #{section_method_name}" do
+          expect(helper.send(section_method_name)).to eq(expected)
+        end
+      end
+    end
+
+    context "no to offer" do
+      before do
+        session.merge!({
+          "accommodation": "No",
+          "rooms_number": "500",
+          "accommodation_description": "Very nice",
+          "accommodation_cost": t("coronavirus_form.how_much_charge.options.nothing.label"),
+
+          "offer_transport": "No",
+          "transport_type": "No",
+          "transport_description": "No",
+          "transport_cost": t("coronavirus_form.how_much_charge.options.nothing.label"),
+
+          "offer_staff": "No",
+          "offer_staff_type": [
+            t("coronavirus_form.questions.offer_staff_type.offer_staff_type.options.cleaners.label"),
+            t("coronavirus_form.questions.offer_staff_type.offer_staff_type.options.developers.label"),
+            t("coronavirus_form.questions.offer_staff_type.offer_staff_type.options.medical_staff.label"),
+          ],
+          "offer_staff_number": {
+            cleaners_number: 12,
+            developers_number: 39,
+            medical_staff_number: 9,
+          },
+          "offer_staff_description": "They're well qualified.",
+          "offer_staff_charge": t("coronavirus_form.how_much_charge.options.reduced.label"),
+
+          "offer_space": "No",
+          "offer_space_type": t("coronavirus_form.questions.offer_space_type.options.warehouse_space.label").to_s,
+          "offer_space_type_other": "Description of space",
+          "space_cost": t("coronavirus_form.how_much_charge.options.nothing.label"),
+
+          "offer_care": "No",
+          "offer_care_type": [t("coronavirus_form.questions.offer_care_qualifications.offer_care_type.options.adult_care.label")],
+          "offer_care_qualifications": [t("coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.dbs_check.label")],
+          "offer_care_qualifications_type": "Very good qualifications. This is a description field, really.",
+          "care_cost": t("coronavirus_form.how_much_charge.options.nothing.label"),
+        })
+      end
+
+      [
+        # Sections which report the result of offer questions
+        [
+          "accommodation_section",
+          { title: "Accommodation",
+            title_size: "l",
+            edit: { href: "accommodation?change-answer" },
+            items: [{ field: "Can you offer accommodation?", value: "No" }] },
+        ],
+        [
+          "transport_section",
+          { title: "Transport",
+            title_size: "l",
+            edit: { href: "offer-transport?change-answer" },
+            items: [{ field: "Can you offer transport or logistics?", value: "No" }] },
+        ],
+        [
+          "staff_section",
+          { title: "Staff",
+            title_size: "l",
+            edit: { href: "offer-staff?change-answer" },
+            items: [{ field: "Can you offer staff?", value: "No" }] },
+        ],
+        [
+          "space_section",
+          { title: "Space",
+            title_size: "l",
+            edit: { href: "offer-space?change-answer" },
+            items: [{ field: "Can you offer space?", value: "No" }] },
+        ],
+        [
+          "care_section",
+          { title: "Social care or childcare",
+            title_size: "l",
+            edit: { href: "offer-care?change-answer" },
+            items: [{ field: "Can you offer social care or childcare?", value: "No" }] },
+        ],
+        ["accommodation_details_section", nil],
+        ["transport_details_section", nil],
+        ["care_details_section", nil],
+        ["space_details_section", nil],
+      ].each.with_index do |test, _index|
+        section_method_name, expected = test
+        it "correct data returned for sections #section_method_name" do
+          expect(helper.send(section_method_name)).to eq(expected)
+        end
       end
     end
   end
 
-  describe "#transport_type_info" do
-    it "concates transport type and description" do
-      session["transport_type"] = [
-        I18n.t("coronavirus_form.questions.transport_type.options.moving_people.label"),
-        I18n.t("coronavirus_form.questions.transport_type.options.moving_goods.label"),
-        I18n.t("coronavirus_form.questions.transport_type.options.other.label"),
-      ]
-
-      session["transport_description"] = "Transport description"
-
-      expected_answer = "#{I18n.t('coronavirus_form.questions.transport_type.options.moving_people.label')}, " \
-                          "#{I18n.t('coronavirus_form.questions.transport_type.options.moving_goods.label')}, and " \
-                          "#{I18n.t('coronavirus_form.questions.transport_type.options.other.label')}<br>" \
-                          "#{session['transport_description']}"
-
-      expect(helper.transport_type_info).to eq(expected_answer)
+  describe "#other_support_section" do
+    it "shows other support text if it's in the session" do
+      session.merge!({ "offer_other_support": "I can offer support in textiles" })
+      expect(helper.other_support_section).to eq(
+        {
+          items: [
+            { edit: { href: "offer-other-support?change-answer" },
+              field: "Details of other support you can offer",
+              value: "I can offer support in textiles" },
+          ],
+          title: "Other support",
+          title_size: "l",
+        },
+      )
     end
 
-    it "only concatenates the fields that have a value" do
-      session["transport_type"] = [
-        I18n.t("coronavirus_form.questions.transport_type.options.moving_people.label"),
-      ]
-
-      expected_answer = "#{I18n.t('coronavirus_form.questions.transport_type.options.moving_people.label')}<br>"
-      expect(helper.transport_type_info).to eq(expected_answer)
-    end
-  end
-
-  describe "#offer_care_qualifications" do
-    it "adds a query string to the link for each item" do
-      helper.offer_care_qualifications.each do |item|
-        expect(item[:edit][:href]).to include("?change-answer")
-      end
-    end
-  end
-
-  describe "#concat_answer" do
-    context "contact_details" do
-      let(:question) { "contact_details" }
-
-      it "concatenates contact_details with a line break" do
-        answer = {
-          contact_name: "Snow White",
-          role: "COO",
-          phone_number: "012101234567",
-          email: "me@example.com",
-        }
-
-        expected_answer =
-          "Name: #{answer[:contact_name]}<br>" \
-            "Role: #{answer[:role]}<br>" \
-            "Phone number: #{answer[:phone_number]}<br>" \
-            "Email: #{answer[:email]}"
-
-        expect(helper.concat_answer(answer, question)).to eq(expected_answer)
-      end
-
-      it "returns nothing if the contact details are empty" do
-        answer = {}
-
-        expect(helper.concat_answer(answer, question)).to be_empty
-      end
-
-      it "only concatenates the fields that have a value" do
-        answer = {
-          email: "me@example.com",
-        }
-
-        expected_answer = "Email: #{answer[:email]}"
-        expect(helper.concat_answer(answer, question)).to eq(expected_answer)
-      end
+    it "shows a special string if it's not in the session" do
+      expect(helper.other_support_section).to eq(
+        {
+          items: [
+            { edit: { href: "offer-other-support?change-answer" },
+              field: "Details of other support you can offer",
+              value: "I cannot offer any other kind of support" },
+          ],
+          title: "Other support",
+          title_size: "l",
+        },
+      )
     end
 
-    context "business_details" do
-      let(:question) { "business_details" }
-
-      it "concatenates business_details with a line break" do
-        answer = {
-          company_name: "Snow White Inc",
-          company_number: rand(10),
-          company_size: 1000,
-          company_location: "UK",
-          company_postcode: "E1 8QS",
-        }
-
-        expected_answer =
-          "Company name: #{answer[:company_name]}<br>" \
-            "Company number: #{answer[:company_number]}<br>" \
-            "Company size number: #{answer[:company_size]}<br>" \
-            "Company location: #{answer[:company_location]}<br>" \
-            "Company postcode: #{answer[:company_postcode]}"
-
-        expect(helper.concat_answer(answer, question)).to eq(expected_answer)
-      end
-
-      it "returns nothing if the business details are empty" do
-        answer = {}
-
-        expect(helper.concat_answer(answer, question)).to be_empty
-      end
-
-      it "only concatenates the fields that have a value" do
-        answer = {
-          company_name: "Snow White Inc",
-        }
-
-        expected_answer = "Company name: #{answer[:company_name]}"
-        expect(helper.concat_answer(answer, question)).to eq(expected_answer)
-      end
-    end
-
-    context "general multipart questions" do
-      let(:question) { "question" }
-
-      it "concates other hash questions" do
-        answer = {
-          one: "One",
-          two: "Two",
-          three: "Three",
-        }
-
-        expected_answer = "One Two Three"
-        expect(helper.concat_answer(answer, question)).to eq(expected_answer)
-      end
+    it "shows a special string if an empty string is stored" do
+      session.merge!({ "offer_other_support": "" })
+      expect(helper.other_support_section).to eq(
+        {
+          items: [
+            { edit: { href: "offer-other-support?change-answer" },
+              field: "Details of other support you can offer",
+              value: "I cannot offer any other kind of support" },
+          ],
+          title: "Other support",
+          title_size: "l",
+        },
+      )
     end
   end
 
-  describe "#link_to_parent_page" do
-    it "links the user back to the page the question appeared on" do
-      helper.link_to_parent_page("question", "parent_question") do |item|
-        expect(item[:edit][:href]).to include("parent-question?change-answer")
-      end
+  describe "#expertise_section" do
+    it "returns correct data" do
+      session.merge!({ "expert_advice_type" => [
+        t("coronavirus_form.questions.expert_advice_type.options.construction.label"),
+        t("coronavirus_form.questions.expert_advice_type.options.it.label"),
+      ] })
+
+      expect(helper.expertise_section).to eq(
+        { title: "Services or expertise",
+          title_size: "l",
+          items: [{ field: "Kind of expertise you offer",
+                    value: ["Construction", "IT services"],
+                    edit: { href: "expert-advice-type?change-answer" } }] },
+      )
+    end
+  end
+
+  describe "#construction_expertise_section" do
+    it "returns correct data when it expertise selected" do
+      session.merge!({
+        "expert_advice_type" => [
+          t("coronavirus_form.questions.expert_advice_type.options.construction.label"),
+        ],
+        "construction_services" => [
+          t("coronavirus_form.questions.construction_services.options.temporary_buildings.label"),
+          t("coronavirus_form.questions.construction_services.options.construction_work.label"),
+        ],
+        "construction_services_other" => "Bricks and that",
+        "construction_cost" => t("coronavirus_form.how_much_charge.options.standard.label"),
+      })
+      expect(helper.construction_expertise_section).to eq({
+        title: t("check_your_answers.sections.construction.title"),
+        title_size: "m",
+        items: [
+          { field: t("check_your_answers.fields.construction_services.title"),
+            value: [
+              t("coronavirus_form.questions.construction_services.options.temporary_buildings.label"),
+              t("coronavirus_form.questions.construction_services.options.construction_work.label"),
+            ],
+            edit: { href: "construction-services?change-answer" } },
+          { field: t("check_your_answers.fields.construction_services_other.title"),
+            value: "Bricks and that",
+            edit: { href: "construction-services-other?change-answer" } },
+          { field: t("check_your_answers.fields.construction_cost.title"),
+            value: t("coronavirus_form.how_much_charge.options.standard.label"),
+            edit: { href: "construction-cost?change-answer" } },
+        ],
+      })
+    end
+
+    it "returns nil when it expertise is not selected but it data present" do
+      session.merge!({
+        "expert_advice_type" => [],
+        "construction_services" => [
+          t("coronavirus_form.questions.construction_services.options.temporary_buildings.label"),
+          t("coronavirus_form.questions.construction_services.options.construction_work.label"),
+        ],
+        "construction_services_other" => "Bricks and that",
+        "it_cost" => t("coronavirus_form.how_much_charge.options.standard.label"),
+      })
+      expect(helper.it_expertise_section).to eq(
+        nil,
+      )
+    end
+  end
+
+  describe "#it_expertise_section" do
+    it "returns correct data when it expertise selected" do
+      session.merge!({
+        "expert_advice_type" => [
+          t("coronavirus_form.questions.expert_advice_type.options.it.label"),
+        ],
+        "it_services" => [
+          t("coronavirus_form.questions.it_services.options.broadband.label"),
+          t("coronavirus_form.questions.it_services.options.mobile_phones.label"),
+          t("coronavirus_form.questions.it_services.options.video_conferencing.label"),
+        ],
+        "it_services_other" => "Computers and that",
+        "it_cost" => t("coronavirus_form.how_much_charge.options.reduced.label"),
+      })
+      expect(helper.it_expertise_section).to eq(
+        { title: "IT Services",
+          title_size: "m",
+          items: [
+            { field: t("check_your_answers.fields.it_services.title"),
+              value: [
+                t("coronavirus_form.questions.it_services.options.broadband.label"),
+                t("coronavirus_form.questions.it_services.options.mobile_phones.label"),
+                t("coronavirus_form.questions.it_services.options.video_conferencing.label"),
+              ],
+              edit: { href: "it-services?change-answer" } },
+            { field: t("check_your_answers.fields.it_services_other.title"),
+              value: "Computers and that",
+              edit: { href: "it-services-other?change-answer" } },
+            { field: t("check_your_answers.fields.it_cost.title"),
+              value: t("coronavirus_form.how_much_charge.options.reduced.label"),
+              edit: { href: "it-cost?change-answer" } },
+          ] },
+      )
+    end
+
+    it "returns nil when it expertise is not selected but it data present" do
+      session.merge!({
+        "expert_advice_type" => [],
+        "it_services" => [
+          t("coronavirus_form.questions.it_services.options.broadband.label"),
+          t("coronavirus_form.questions.it_services.options.mobile_phones.label"),
+          t("coronavirus_form.questions.it_services.options.video_conferencing.label"),
+        ],
+        "it_services_other" => "Really good ones",
+        "it_cost" => t("coronavirus_form.how_much_charge.options.reduced.label"),
+      })
+      expect(helper.it_expertise_section).to eq(
+        nil,
+      )
+    end
+  end
+
+  describe "#business_details_section" do
+    it "generates correct data structure" do
+      session.merge!({
+        "business_details" =>
+          { company_name: "ACME",
+            company_number: "12345",
+            company_size: t("coronavirus_form.questions.business_details.company_size.options.under_50_people.label"),
+            company_location: t("coronavirus_form.questions.business_details.company_location.options.european_union.label"),
+            company_postcode: nil },
+      })
+      expect(helper.business_details_section).to eq(
+        { title: "Business Details",
+          title_size: "l",
+          edit: { href: "business-details?change-answer" },
+          items: [{ field: "Company name", value: "ACME" },
+                  { field: "Company number", value: "12345" },
+                  { field: "Company size", value: t("coronavirus_form.questions.business_details.company_size.options.under_50_people.label") },
+                  { field: "Company location", value: t("coronavirus_form.questions.business_details.company_location.options.european_union.label") }] },
+      )
+    end
+
+    it "does not include postcode data for non UK company" do
+      session.merge!({
+        "business_details" =>
+          { company_name: "ACME",
+            company_number: "12345",
+            company_size: t("coronavirus_form.questions.business_details.company_size.options.under_50_people.label"),
+            company_location: t("coronavirus_form.questions.business_details.company_location.options.european_union.label"),
+            company_postcode: "RG1 2NU" },
+      })
+      expect(helper.business_details_section[:items]).to include(
+        { field: "Company location", value: t("coronavirus_form.questions.business_details.company_location.options.european_union.label") },
+      )
+    end
+
+    it "includes postcode data for UK company" do
+      session.merge!({
+        "business_details" =>
+          { company_name: "ACME",
+            company_number: "12345",
+            company_size: t("coronavirus_form.questions.business_details.company_size.options.under_50_people.label"),
+            company_location: t("coronavirus_form.questions.business_details.company_location.options.united_kingdom.label"),
+            company_postcode: "RG1 2NU" },
+      })
+      expect(helper.business_details_section[:items]).to include(
+        { field: "Company location", value: "United Kingdom (RG1 2NU)" },
+      )
+    end
+  end
+
+  describe "#contact_details_section" do
+    it "generates correct data structure" do
+      session.merge!({
+        "contact_details" =>
+          { contact_name: "Bob Business",
+            role: nil,
+            phone_number: "123456",
+            email: "bob@business.com" },
+      })
+      expect(helper.contact_details_section).to eq(
+        { title: "Contact Details",
+          title_size: "l",
+          edit: { href: "contact-details?change-answer" },
+          items: [{ field: "Company location", value: "Bob Business" },
+                  { field: "Role of main contact", value: nil },
+                  { field: "Phone number of main contact", value: "123456" },
+                  { field: "Email address of main contact", value: "bob@business.com" }] },
+      )
     end
   end
 end


### PR DESCRIPTION
## Summary of changes

Rewrote the check your answers helper (`check_your_answers_helper.rb`, the check your answers ERB file (`check_your_answers.html.erb`) and the check your answers helper test file (`check_your_answers_helper_spec.rb`), so that the check your answers page would match the new design illustrated in the ticket.

The summary list implementation provided by `govuk_publishing_components` was found to be lacking features and as a result a modified version was included for use (`_summary_list.html.erb`). In addition to the functionality of the original implementation it renders arrays as unordered lists, and allows for the list as a whole to have a delete button as well as an edit button.

It may be best to fold some of these features in upstream, however the implementation is a good fit for the needs of this project, and is probably a bit ungainly in library form, so additional work may be required.

## How to review

One can run just the modified tests using the following command: 

```
rspec spec/helpers/check_answers_helper_spec.rb
```

Or the whole test suite via:

```
bundle exec rake
```

Many of the changes are visual, so it is probably best, in addition to the above, to fill in the form and view the check your answers page, comparing the final visualisation to the page.

It is worth changing answers, and including/excluding certain answer sets (i.e the medical products) and ensuring that the check your answers page renders as you would expect.

## Links

https://trello.com/c/eGsOEifg/488-update-check-your-answers-page


