### PR TITLE
Prefix page title with 'Error: '

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template">
   <head>
     <meta charset="utf-8" />
-    <title><%= yield :title %> - GOV.UK</title>
+    <title><%= t('coronavirus_form.errors.page_title_prefix') if flash[:validation]&.any? %><%= yield :title %> - GOV.UK</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="robots" content="noindex nofollow">
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -180,6 +180,7 @@ en:
       date_order: "The end date must be after the start date"
       email_format: "Enter an email address in the correct format, like name@example.com"
       postcode_format: "Enter a real postcode"
+      page_title_prefix: 'Error: '
     testing_equipment:
       title: "Testing equipment"
       button:


### PR DESCRIPTION
What
----

Add 'Error: ' to the beginning of the page <title> so screen readers read it out as soon as possible.

How to review
-------------

:ship: Since this service is continuously deployed, all testing must be done
before the pull request is merged. :ship:

Submit an empty form and you should see the 'Error: ' at the beginning of the page title.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

<img width="500" alt="Screenshot 2020-06-03 at 11 49 48" src="https://user-images.githubusercontent.com/788096/83628690-cfe53480-a590-11ea-8abd-045f636fe0bb.png">


</td><td valign="top">

<img width="500" alt="Screenshot 2020-06-03 at 11 43 23" src="https://user-images.githubusercontent.com/788096/83628701-d1aef800-a590-11ea-9a5c-c64363776d16.png">


</td></tr>
</table>


Links
-----
[Trello card](https://trello.com/c/yfXnkV5x)