### PR TITLE
Codecov GitHub action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,7 @@ jobs:
         DB_USERNAME: postgres
         REDIS_HOST: redis
         REDIS_PORT: ${{ job.services.redis.ports[6379] }}
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1.0.7
+      with:
+        file: ./coverage/coverage.xml

--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ group :test do
   gem "mini_racer", "~> 0.2"
   gem "selenium-webdriver"
   gem "simplecov", "~> 0.16"
+  gem "simplecov-cobertura"
   gem "webdrivers"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -349,6 +349,8 @@ GEM
     simplecov (0.18.5)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
+    simplecov-cobertura (1.3.1)
+      simplecov (~> 0.8)
     simplecov-html (0.12.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
@@ -421,6 +423,7 @@ DEPENDENCIES
   sentry-raven (~> 3.0)
   sidekiq (~> 6.0)
   simplecov (~> 0.16)
+  simplecov-cobertura
   uglifier (~> 4.2)
   webdrivers
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require "byebug"
 require "simplecov"
+require "simplecov-cobertura"
 require "capybara/rspec"
 require "capybara/apparition"
 
@@ -11,6 +12,7 @@ require "rspec/rails"
 
 Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
 SimpleCov.start
+SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
 
 Capybara.javascript_driver = :apparition
 


### PR DESCRIPTION
What
----

- Codecov is a code coverage reporting tool. It checks that your tests still test the same (or more) of your code when you add new code. This is an example report from the docs: https://codecov.io/gh/codecov/example-ruby.

- Codecov is free for public repos.

- This will enable us to identify any gaps in our test coverage.

- There is a Github Marketplace app (https://github.com/marketplace/codecov) for Codecov which has already been configured for all public AlphaGov repositories.

- There is also a Github Marketplace Actions app (https://github.com/marketplace/actions/codecov) for Codecov.

- Reports need to be in XML format to be uploaded to Codecov, so there is a commit to generate the coverage report as XML.

- Uploading the report to Codecov as a Github Action is configured within this PR.

How to review
-------------

:ship: Since this service is continuously deployed, all testing must be done
before the pull request is merged. :ship:

- Have a look at https://github.com/marketplace/actions/codecov and see if you think this looks ok in comparison. 

- Its hard to test if it has worked until it runs... once it has then:

1. Go to: https://codecov.io 
2. Sign in with Github
3. Choose the govuk-coronavirus-vulnerable-people-form repo from the menu
4. You should see some metrics
5. A bot also posts comments in Github

Links
-----

[Trello](https://trello.com/c/iKWfHb9n/437-add-codecov-to-our-ci-pipelines)

