### PR TITLE
Use character count for descriptions

### DIFF
--- a/app/controllers/coronavirus_form/construction_services_controller.rb
+++ b/app/controllers/coronavirus_form/construction_services_controller.rb
@@ -10,13 +10,16 @@ class CoronavirusForm::ConstructionServicesController < ApplicationController
     }
     @form_responses[:construction_services_other] = strip_tags(params[:construction_services_other]).presence
 
-    invalid_fields = validate_field_response_length(controller_name, TEXT_FIELDS) +
-      validate_checkbox_field(
-        controller_name,
-        values: @form_responses[:construction_services],
-        allowed_values: I18n.t("coronavirus_form.questions.#{controller_name}.options").map { |_, item| item.dig(:label) },
-      ) +
-      validate_charge_field("construction_cost", @form_responses[:construction_cost])
+    invalid_fields =
+      [
+        validate_checkbox_field(
+          controller_name,
+          values: @form_responses[:construction_services],
+          allowed_values: I18n.t("coronavirus_form.questions.#{controller_name}.options").map { |_, item| item.dig(:label) },
+        ),
+        validate_field_response_length(controller_name, TEXT_FIELDS),
+        validate_charge_field("construction_cost", @form_responses[:construction_cost]),
+      ].flatten.compact
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields

--- a/app/controllers/coronavirus_form/it_services_controller.rb
+++ b/app/controllers/coronavirus_form/it_services_controller.rb
@@ -10,13 +10,16 @@ class CoronavirusForm::ItServicesController < ApplicationController
       it_cost: strip_tags(params[:it_cost]).presence,
     }
 
-    invalid_fields = validate_field_response_length(controller_name, TEXT_FIELDS) +
-      validate_checkbox_field(
-        controller_name,
-        values: @form_responses[:it_services],
-        allowed_values: I18n.t("coronavirus_form.questions.#{controller_name}.options").map { |_, item| item.dig(:label) },
-      ) +
-      validate_charge_field("it_cost", @form_responses[:it_cost])
+    invalid_fields =
+      [
+        validate_checkbox_field(
+          controller_name,
+          values: @form_responses[:it_services],
+          allowed_values: I18n.t("coronavirus_form.questions.#{controller_name}.options").map { |_, item| item.dig(:label) },
+        ),
+        validate_field_response_length(controller_name, TEXT_FIELDS),
+        validate_charge_field("it_cost", @form_responses[:it_cost]),
+      ].flatten.compact
 
     if invalid_fields.any?
       flash.now[:validation] = invalid_fields

--- a/app/controllers/coronavirus_form/offer_staff_type_controller.rb
+++ b/app/controllers/coronavirus_form/offer_staff_type_controller.rb
@@ -4,6 +4,7 @@ class CoronavirusForm::OfferStaffTypeController < ApplicationController
   OPTIONS = I18n.t("coronavirus_form.questions.#{controller_name}.offer_staff_type.options")
   ALLOWED_VALUES = OPTIONS.map { |_, item| item.dig(:label) }
   DESCRIPTION_FIELDS = OPTIONS.map { |_, item| item.dig(:description, :id) }.freeze
+  TEXT_FIELDS = %w[offer_staff_description].freeze
 
   def submit
     @form_responses = {
@@ -47,6 +48,7 @@ private
     [
       validate_checkbox_field("#{controller_name}.offer_staff_type", values: @form_responses[:offer_staff_type], allowed_values: ALLOWED_VALUES),
       validate_description_fields(@form_responses[:offer_staff_type]),
+      validate_field_response_length(controller_name, TEXT_FIELDS),
       validate_radio_field("#{controller_name}.offer_staff_charge", radio: @form_responses[:offer_staff_charge]),
     ].flatten.compact
   end

--- a/app/views/coronavirus_form/construction_services.html.erb
+++ b/app/views/coronavirus_form/construction_services.html.erb
@@ -28,13 +28,19 @@
       end
     } %>
 
-    <%= render "govuk_publishing_components/components/textarea", {
-      label: {
-        text: t("coronavirus_form.questions.construction_services_other.title"),
-        bold: true
+    <%= render "govuk_publishing_components/components/character_count", {
+      textarea: {
+        label: {
+          text: t("coronavirus_form.questions.construction_services.construction_services_other.label"),
+          heading_size: "m",
+        },
+        name: "construction_services_other",
+        hint: t("coronavirus_form.questions.construction_services.construction_services_other.hint"),
+        error_message: error_items("construction_services_other"),
+        value: @form_responses[:construction_services_other]
       },
-      name: "construction_services_other",
-      value: @form_responses[:construction_services_other]
+      id: "construction_services_other",
+      maxlength: 1000,
     } %>
 
     <%= render partial: "coronavirus_form/how_much_charge", locals: { cost_field: "construction_cost" } %>

--- a/app/views/coronavirus_form/it_services.html.erb
+++ b/app/views/coronavirus_form/it_services.html.erb
@@ -28,13 +28,19 @@
       end
     } %>
 
-    <%= render "govuk_publishing_components/components/textarea", {
-      label: {
-        text: t("coronavirus_form.questions.it_services_other.title"),
-        bold: true
+    <%= render "govuk_publishing_components/components/character_count", {
+      textarea: {
+        label: {
+          text: t("coronavirus_form.questions.it_services.it_services_other.label"),
+          heading_size: "m",
+        },
+        name: "it_services_other",
+        hint: t("coronavirus_form.questions.it_services.it_services_other.hint"),
+        error_message: error_items("it_services_other"),
+        value: @form_responses[:it_services_other],
       },
-      name: "it_services_other",
-      value: @form_responses[:it_services_other]
+      id: "it_services_other",
+      maxlength: 1000,
     } %>
 
     <%= render partial: "coronavirus_form/how_much_charge", locals: { cost_field: "it_cost" } %>

--- a/app/views/coronavirus_form/offer_staff_type.erb
+++ b/app/views/coronavirus_form/offer_staff_type.erb
@@ -40,16 +40,19 @@
     end
   } %>
 
-  <%= render "govuk_publishing_components/components/textarea", {
-    label: {
-      text: t("coronavirus_form.questions.offer_staff_type.offer_staff_description.label"),
-      heading_size: "m",
+  <%= render "govuk_publishing_components/components/character_count", {
+    textarea: {
+      label: {
+        text: t("coronavirus_form.questions.offer_staff_type.offer_staff_description.label"),
+        heading_size: "m",
+      },
+      name: "offer_staff_description",
+      hint: t("coronavirus_form.questions.offer_staff_type.offer_staff_description.hint"),
+      error_message: error_items("offer_staff_description"),
+      value: @form_responses[:offer_staff_description]
     },
-    name: "offer_staff_description",
-    hint: t("coronavirus_form.questions.offer_staff_type.offer_staff_description.hint"),
-    id: "offer_staff_type_offer_staff_description",
-    error_message: error_items("offer_staff_type_offer_staff_description"),
-    value: @form_responses[:offer_staff_description]
+    id: "offer_staff_description",
+    maxlength: 1000,
   } %>
 
   <%= render partial: "coronavirus_form/how_much_charge", locals: { cost_field: "offer_staff_charge" } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -514,13 +514,12 @@ en:
             label: "Construction work"
           other:
             label: "Other"
-      construction_services_other:
-        title: "Give a description of the type of construction services (optional)"
-        hint: "For example, the amount of work you can do."
         construction_services_other:
+          label: "Give a description of the type of construction services (optional)"
+          hint: "For example, the amount of work you can do."
           custom_length_error: "Description of your qualification must be 1000 characters or fewer"
-      construction_cost:
-        title: "How much would you charge for the construction services?"
+        construction_cost:
+          title: "How much would you charge for the construction services?"
       it_services:
         title: What kind of IT services can you offer?
         hint: "Select the types of services you can offer."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -537,13 +537,12 @@ en:
             label: "Virtual office tools"
           other:
             label: "Other"
-      it_services_other:
-        title: "Give a description of the type of IT services (optional)"
-        hint: "For example, the amount of services you can offer."
         it_services_other:
+          label: "Give a description of the type of IT services (optional)"
+          hint: "For example, the amount of services you can offer."
           custom_length_error: "Description of your qualification must be 1000 characters or fewer"
-      it_cost:
-        title: "How much would you charge for the IT services?"
+        it_cost:
+          title: "How much would you charge for the IT services?"
       offer_care:
         title: "Can you offer social care or childcare?"
         hint: "For example, nursing or assistance to other people."

--- a/spec/controllers/coronavirus_form/offer_staff_type_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/offer_staff_type_controller_spec.rb
@@ -142,5 +142,15 @@ RSpec.describe CoronavirusForm::OfferStaffTypeController, type: :controller do
 
       expect(response).to redirect_to(check_your_answers_path)
     end
+
+    described_class::TEXT_FIELDS.each do |field|
+      it "validates that #{field} is 1000 or fewer characters" do
+        params[field] = SecureRandom.hex(1001)
+        post :submit, params: params
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to render_template(current_template)
+      end
+    end
   end
 end


### PR DESCRIPTION
What
----

Use the character count component for description fields on the following pages:
- What kind of staff can you offer?
- What kind of construction services can you offer
- What kind of IT services can you offer

How to review
-------------

:ship: Since this service is continuously deployed, all testing must be done
before the pull request is merged. :ship:

Check the component in the mentioned pages using the [preview app](https://coronavirus-use-charact-k5kujd.herokuapp.com/medical-equipment).

Example below on 'What kind of staff can you offer?' page

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

![localhost_5000_offer-staff-type](https://user-images.githubusercontent.com/788096/83667681-ad6e0e00-a5c6-11ea-8274-7eadace4b787.png)


</td><td valign="top">

![localhost_5000_offer-staff-type-after](https://user-images.githubusercontent.com/788096/83667686-afd06800-a5c6-11ea-82e1-36435bb71d32.png)


</td></tr>
<tr><td valign="top">

![localhost_5000_offer-staff-type (1)](https://user-images.githubusercontent.com/788096/83667693-b232c200-a5c6-11ea-8a2b-6c19ebbb18a9.png)


</td><td valign="top">

![localhost_5000_offer-staff-type (1)-after](https://user-images.githubusercontent.com/788096/83667702-b52db280-a5c6-11ea-89d6-5a88a71966b5.png)


</td></tr>
</table>


Links
-----

[Trello card](https://trello.com/c/IQJXuhtn)
