### PR TITLE
Redact IDs from urls for cross domain tracking

### DIFF
--- a/app/assets/javascripts/analytics.js.erb
+++ b/app/assets/javascripts/analytics.js.erb
@@ -1,6 +1,20 @@
 // Start cookie banner (display settings controlled internally by cookies)
 var element = document.querySelector('[data-module="cookie-banner"]')
+var PRODUCT_ID_PATTERN = /\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b/
+var REFERENCE_NUMBER_PATTERN = /\d{8}-\d{6}-.{6}/
+
 new GOVUK.Modules.CookieBanner().start($(element))
+
+var stripPII = function(url) {
+  url = url.replace(REFERENCE_NUMBER_PATTERN, 'reference_number')
+  url = url.replace(PRODUCT_ID_PATTERN, 'product_id')
+
+  if(url.includes('reference_number' || 'product_id')) {
+    return url
+  } else {
+    return location.protocol + '//' + location.host + location.pathname
+  }
+}
 
 var analyticsInit = function() {
   <% if Rails.application.config.analytics_tracking_id.present? %>
@@ -19,6 +33,7 @@ var analyticsInit = function() {
       ga('create', trackingId, 'auto')
       ga('set', 'allowAdFeatures', false);
       ga('set', 'anonymizeIp', true);
+      ga('set', 'location', stripPII(window.location.href));
       ga('send', 'pageview');
 
       // Cross Government Domain Google Analytics
@@ -27,6 +42,7 @@ var analyticsInit = function() {
       ga('govuk_shared.set', 'anonymizeIp', true);
       ga('govuk_shared.set', 'allowAdFeatures', false);
       ga('govuk_shared.linker:autoLink', ['www.gov.uk']);
+      ga('govuk_shared.set', 'location', stripPII(window.location.href));
       ga('govuk_shared.send', 'pageview');
     }
   <% end %>


### PR DESCRIPTION
What
----

Redact the `product_id` and `reference_number` params for Google Analytics X domain tracking.

Technically this isn't personally identifiable information (PII) on its own, but it could be along with the backend data.

How to review
-------------

:ship: Since this service is continuously deployed, all testing must be done
before the pull request is merged. :ship:

Describe the steps required to review and test the changes.

- I'm not hugely familiar with JS so any tips on refactoring the logic could be good. I am thinking it may be good to move the functions out into a separate file?

for the regexs:
- the `product_id` is created using `SecureRandom.uuid`.
- the `reference_number` is created using a timestamp and random number [see here](https://github.com/alphagov/govuk-coronavirus-business-volunteer-form/blob/master/app/controllers/coronavirus_form/check_answers_controller.rb#L64).
- The Google doc linked to the Trello card may also be useful for giving some more context.

Links
-----

[Trello](https://trello.com/c/JFMD3vzV/501-dont-send-google-analytics-user-transaction-id-query-parameters)

