### PR TITLE
Back links

### DIFF
--- a/app/controllers/coronavirus_form/accommodation_controller.rb
+++ b/app/controllers/coronavirus_form/accommodation_controller.rb
@@ -39,6 +39,6 @@ private
   end
 
   def previous_path
-    medical_equipment_url
+    session[:additional_product] ? additional_product_url : medical_equipment_url
   end
 end

--- a/app/controllers/coronavirus_form/expert_advice_type_controller.rb
+++ b/app/controllers/coronavirus_form/expert_advice_type_controller.rb
@@ -63,7 +63,7 @@ private
   end
 
   def previous_path
-    offer_staff_url
+    session[:offer_staff_charge] ? offer_staff_type_url : offer_staff_url
   end
 
   def next_page

--- a/app/controllers/coronavirus_form/offer_care_controller.rb
+++ b/app/controllers/coronavirus_form/offer_care_controller.rb
@@ -38,10 +38,10 @@ private
   end
 
   def previous_path
-    if session[:expert_advice_type]&.include?(I18n.t("coronavirus_form.questions.expert_advice_type.options.construction.label"))
-      construction_services_path
-    elsif session[:expert_advice_type]&.include?(I18n.t("coronavirus_form.questions.expert_advice_type.options.it.label"))
+    if session[:expert_advice_type]&.include?(I18n.t("coronavirus_form.questions.expert_advice_type.options.it.label"))
       it_services_path
+    elsif session[:expert_advice_type]&.include?(I18n.t("coronavirus_form.questions.expert_advice_type.options.construction.label"))
+      construction_services_path
     else
       expert_advice_type_path
     end

--- a/app/controllers/coronavirus_form/offer_other_support_controller.rb
+++ b/app/controllers/coronavirus_form/offer_other_support_controller.rb
@@ -30,6 +30,6 @@ private
   end
 
   def previous_path
-    offer_care_url
+    session[:care_cost] ? offer_care_qualifications_url : offer_care_url
   end
 end

--- a/app/controllers/coronavirus_form/offer_space_controller.rb
+++ b/app/controllers/coronavirus_form/offer_space_controller.rb
@@ -35,6 +35,6 @@ private
   end
 
   def previous_path
-    offer_transport_url
+    session[:transport_type] ? transport_type_url : offer_transport_url
   end
 end

--- a/app/controllers/coronavirus_form/offer_staff_controller.rb
+++ b/app/controllers/coronavirus_form/offer_staff_controller.rb
@@ -31,6 +31,6 @@ private
   end
 
   def previous_path
-    offer_space_url
+    session[:space_cost] ? offer_space_type_url : offer_space_url
   end
 end

--- a/app/controllers/coronavirus_form/offer_transport_controller.rb
+++ b/app/controllers/coronavirus_form/offer_transport_controller.rb
@@ -38,6 +38,6 @@ private
   end
 
   def previous_path
-    accommodation_url
+    session[:rooms_number] ? rooms_number_url : accommodation_url
   end
 end


### PR DESCRIPTION
This fixes all the back links for this service. A number of them weren't working properly if a user had said that they could offer support. 

Trello - https://trello.com/c/Efx2SrSn/510-back-button-should-take-users-back-to-the-page-they-were-on-directly-before

