### PR TITLE
Fix error summary links

### DIFF
--- a/app/views/coronavirus_form/_how_much_charge.html.erb
+++ b/app/views/coronavirus_form/_how_much_charge.html.erb
@@ -1,6 +1,7 @@
 <%= render "govuk_publishing_components/components/radio", {
   heading: t('coronavirus_form.how_much_charge.title'),
   name: cost_field,
+  id: cost_field,
   error_message: error_items(cost_field),
   items: t('coronavirus_form.how_much_charge.options').map do |_, item|
     {


### PR DESCRIPTION
What
----

Adding an `id` to the charge question to fix broken error summary links in all 7 pages using the partial.

How to review
-------------

:ship: Since this service is continuously deployed, all testing must be done
before the pull request is merged. :ship:

Submit a page without filling in the form and check the error summary links point to the appropriate field.

Links
-----

[Trello card](https://trello.com/c/ShFaMw6j/545-review-error-messages)
