### PR TITLE
Fix flakey smoke test

### DIFF
--- a/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
+++ b/spec/features/filling_in_the_form/fill_in_the_form_spec.rb
@@ -50,24 +50,24 @@ RSpec.feature "fill in the business volunteer form" do
   scenario "ensure we can perform a healthcheck" do
     visit healthcheck_path
 
-    expect(page.body).to have_content("OK")
+    expect(page).to have_content("OK")
   end
 
   scenario "ensure the privacy notice page is visible" do
     visit privacy_path
 
-    expect(page.body).to have_content(I18n.t("privacy_page.title"))
+    expect(page).to have_content(I18n.t("privacy_page.title"))
   end
 
   scenario "ensure the accessibility statement page is visible" do
     visit accessibility_statement_path
 
-    expect(page.body).to have_content(I18n.t("accessibility_statement.title"))
+    expect(page).to have_content(I18n.t("accessibility_statement.title"))
   end
 
   scenario "ensure the session expired page is visible" do
     visit session_expired_path
 
-    expect(page.body).to have_content(I18n.t("session_expired.title"))
+    expect(page).to have_content(I18n.t("session_expired.title"))
   end
 end

--- a/spec/support/fill_in_the_form_steps.rb
+++ b/spec/support/fill_in_the_form_steps.rb
@@ -6,7 +6,7 @@ module FillInTheFormSteps
   end
 
   def that_can_offer_medical_equipment
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.medical_equipment.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.medical_equipment.title"))
     within find(".govuk-main-wrapper") do
       choose I18n.t("coronavirus_form.questions.medical_equipment.options.option_yes.label")
       click_on I18n.t("coronavirus_form.submit_and_next")
@@ -14,7 +14,7 @@ module FillInTheFormSteps
   end
 
   def and_is_a_manufacturer_a_distributor_and_agent
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.are_you_a_manufacturer.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.are_you_a_manufacturer.title"))
     within find(".govuk-main-wrapper") do
       check I18n.t("coronavirus_form.questions.are_you_a_manufacturer.options.manufacturer.label")
       check I18n.t("coronavirus_form.questions.are_you_a_manufacturer.options.distributor.label")
@@ -24,11 +24,11 @@ module FillInTheFormSteps
   end
 
   def and_has_personal_protection_equipment_available
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.medical_equipment_type.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.medical_equipment_type.title"))
     choose I18n.t("coronavirus_form.questions.medical_equipment_type.options.number_ppe.label")
     click_on I18n.t("coronavirus_form.submit_and_next")
 
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.product_details.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.product_details.title"))
     fill_in "product_name", with: "Testing"
     choose I18n.t("coronavirus_form.questions.product_details.equipment_type.options.iir_face_masks.label")
     fill_in "product_quantity", with: "500"
@@ -47,39 +47,39 @@ module FillInTheFormSteps
   end
 
   def and_has_no_more_testing_equipment_to_offer
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.additional_product.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.additional_product.title"))
     choose I18n.t("coronavirus_form.questions.additional_product.options.option_no.label")
     click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
   def then_they_see_the_external_testing_equipment_link
     link = I18n.t("coronavirus_form.testing_equipment.external_link")
-    expect(page.body).to have_content(I18n.t("coronavirus_form.testing_equipment.link.label"))
-    expect(page.body).to have_selector(:css, "a[href='#{link}']")
+    expect(page).to have_content(I18n.t("coronavirus_form.testing_equipment.link.label"))
+    expect(page).to have_selector(:css, "a[href='#{link}']")
   end
 
   def and_can_navigate_back_to_offer_another_product
     click_on I18n.t("coronavirus_form.testing_equipment.button.label")
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.additional_product.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.additional_product.title"))
   end
 
   def and_can_offer_accommodation
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.accommodation.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.accommodation.title"))
     choose I18n.t("coronavirus_form.questions.accommodation.options.yes_all_uses.label")
     click_on I18n.t("coronavirus_form.submit_and_next")
 
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.rooms_number.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.rooms_number.title"))
     fill_in "rooms_number", with: "500"
     choose I18n.t("coronavirus_form.how_much_charge.options.nothing.label")
     click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
   def and_can_offer_transport_or_logistics
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.offer_transport.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.offer_transport.title"))
     choose I18n.t("coronavirus_form.questions.offer_transport.options.option_yes.label")
     click_on I18n.t("coronavirus_form.submit_and_next")
 
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.transport_type.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.transport_type.title"))
     check I18n.t("coronavirus_form.questions.transport_type.options.moving_people.label")
     check I18n.t("coronavirus_form.questions.transport_type.options.moving_goods.label")
     check I18n.t("coronavirus_form.questions.transport_type.options.other.label")
@@ -89,13 +89,13 @@ module FillInTheFormSteps
   end
 
   def and_can_offer_space
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.offer_space.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.offer_space.title"))
     choose I18n.t("coronavirus_form.questions.offer_space.options.option_yes.label")
     click_button I18n.t("coronavirus_form.submit_and_next")
 
     sleep 0.5
 
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.offer_space_type.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.offer_space_type.title"))
     check I18n.t("coronavirus_form.questions.offer_space_type.options.warehouse_space.label")
     fill_in "warehouse_space_description", with: "1000"
     check I18n.t("coronavirus_form.questions.offer_space_type.options.office_space.label")
@@ -108,11 +108,11 @@ module FillInTheFormSteps
   end
 
   def and_can_offer_staff
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.offer_staff.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.offer_staff.title"))
     choose I18n.t("coronavirus_form.questions.offer_staff.options.option_yes.label")
     click_on I18n.t("coronavirus_form.submit_and_next")
 
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.offer_staff_type.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.offer_staff_type.title"))
     check I18n.t("coronavirus_form.questions.offer_staff_type.offer_staff_type.options.cleaners.label")
     fill_in "cleaners_number", with: "1000"
     fill_in "offer_staff_description", with: "Testing"
@@ -121,7 +121,7 @@ module FillInTheFormSteps
   end
 
   def and_can_offer_all_types_of_expertise
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.expert_advice_type.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.expert_advice_type.title"))
     check I18n.t("coronavirus_form.questions.expert_advice_type.options.medical.label")
     check I18n.t("coronavirus_form.questions.expert_advice_type.options.engineering.label")
     check I18n.t("coronavirus_form.questions.expert_advice_type.options.construction.label")
@@ -134,7 +134,7 @@ module FillInTheFormSteps
   end
 
   def and_can_offer_construction_services
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.construction_services.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.construction_services.title"))
     check I18n.t("coronavirus_form.questions.construction_services.options.building_materials.label")
     check I18n.t("coronavirus_form.questions.construction_services.options.building_maintenance.label")
     check I18n.t("coronavirus_form.questions.construction_services.options.temporary_buildings.label")
@@ -146,7 +146,7 @@ module FillInTheFormSteps
   end
 
   def and_can_offer_it_services
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.it_services.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.it_services.title"))
     check I18n.t("coronavirus_form.questions.it_services.options.broadband.label")
     check I18n.t("coronavirus_form.questions.it_services.options.equipment.label")
     check I18n.t("coronavirus_form.questions.it_services.options.mobile_phones.label")
@@ -159,11 +159,11 @@ module FillInTheFormSteps
   end
 
   def and_can_offer_all_kinds_of_social_and_child_care
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.offer_care.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.offer_care.title"))
     choose I18n.t("coronavirus_form.questions.offer_care.options.option_yes.label")
     click_on I18n.t("coronavirus_form.submit_and_next")
 
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.offer_care_qualifications.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.offer_care_qualifications.title"))
     check I18n.t("coronavirus_form.questions.offer_care_qualifications.offer_care_type.options.adult_care.label")
     check I18n.t("coronavirus_form.questions.offer_care_qualifications.offer_care_type.options.child_care.label")
     check I18n.t("coronavirus_form.questions.offer_care_qualifications.care_qualifications.options.dbs_check.label")
@@ -172,13 +172,13 @@ module FillInTheFormSteps
     choose I18n.t("coronavirus_form.how_much_charge.options.nothing.label")
     click_on I18n.t("coronavirus_form.submit_and_next")
 
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.offer_other_support.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.offer_other_support.title"))
     fill_in "offer_other_support", with: "Testing"
     click_on I18n.t("coronavirus_form.submit_and_next")
   end
 
   def and_offers_these_across_the_uk
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.location.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.location.title"))
     check I18n.t("coronavirus_form.questions.location.options.east_of_england.label")
     check I18n.t("coronavirus_form.questions.location.options.east_midlands.label")
     check I18n.t("coronavirus_form.questions.location.options.west_midland.label")
@@ -195,7 +195,7 @@ module FillInTheFormSteps
   end
 
   def and_has_given_their_business_details
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.business_details.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.business_details.title"))
     fill_in "company_name", with: "Government Digital Service"
     fill_in "company_number", with: "020 3451 9000"
     choose I18n.t("coronavirus_form.questions.business_details.company_size.options.under_50_people.label")
@@ -205,7 +205,7 @@ module FillInTheFormSteps
   end
 
   def and_has_supplied_a_contact
-    expect(page.body).to have_content(I18n.t("coronavirus_form.questions.contact_details.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.questions.contact_details.title"))
     fill_in "contact_name", with: "Test Please Ignore"
     fill_in "role", with: "Test Please Ignore"
     fill_in "phone_number", with: "07000000000"
@@ -214,11 +214,11 @@ module FillInTheFormSteps
   end
 
   def and_has_accepted_the_terms_and_conditions
-    expect(page.body).to have_content(I18n.t("check_your_answers.title"))
+    expect(page).to have_content(I18n.t("check_your_answers.title"))
     click_on I18n.t("check_your_answers.submit")
   end
 
   def then_they_are_thanked
-    expect(page.body).to have_content(I18n.t("coronavirus_form.thank_you.title"))
+    expect(page).to have_content(I18n.t("coronavirus_form.thank_you.title"))
   end
 end


### PR DESCRIPTION

What
----
Following up from the change made in this commit
https://github.com/alphagov/govuk-coronavirus-find-support/pull/286/commits/276f12b1698015442cf39511bb65597475f54820
we are changing all instances of page.body to just be
page in order to avoid smoke test flakiness

Links
-----

[Trello](https://trello.com/c/LcjmW7vI/587-remove-uses-of-pagebody-from-all-feature-tests)


