### PR TITLE
Make company number mandatory

### DIFF
--- a/app/helpers/check_answers_helper.rb
+++ b/app/helpers/check_answers_helper.rb
@@ -185,7 +185,8 @@ module CheckAnswersHelper
       joiner = "<br>"
     elsif question.eql?("business_details")
       concatenated_answer << "Company name: #{answer[:company_name]}" if answer[:company_name]
-      concatenated_answer << "Company number: #{answer[:company_number]}" if answer[:company_number]
+      concatenated_answer << "Company registered in the UK: #{answer[:company_is_uk_registered]}"
+      concatenated_answer << "Company number: #{answer[:company_number]}" if answer[:company_number].present?
       concatenated_answer << "Company size number: #{answer[:company_size]}" if answer[:company_size]
       concatenated_answer << "Company location: #{answer[:company_location]}" if answer[:company_location]
       concatenated_answer << "Company postcode: #{answer[:company_postcode]}" if answer[:company_postcode]

--- a/app/helpers/field_validation_helper.rb
+++ b/app/helpers/field_validation_helper.rb
@@ -102,6 +102,14 @@ module FieldValidationHelper
     end
   end
 
+  def validate_company_number(field, company_number)
+    if company_number =~ /^([0-9]{8}|[A-Za-z]{2}[0-9]{6})$/
+      []
+    else
+      [{ field: field.to_s.sub(".", "_"), text: t("coronavirus_form.errors.company_number") }]
+    end
+  end
+
   def validate_charge_field(field, value)
     if value.blank?
       return [{

--- a/app/views/coronavirus_form/business_details.html.erb
+++ b/app/views/coronavirus_form/business_details.html.erb
@@ -22,6 +22,7 @@
 <%= render "govuk_publishing_components/components/input", {
   id: "company_name",
   name: "company_name",
+  heading_size: "s",
   label: {
     text: t("coronavirus_form.questions.business_details.company_name.label"),
   },

--- a/app/views/coronavirus_form/business_details.html.erb
+++ b/app/views/coronavirus_form/business_details.html.erb
@@ -29,13 +29,35 @@
   value: @form_responses.dig(:business_details, :company_name),
 } %>
 
-<%= render "govuk_publishing_components/components/input", {
-  name: "company_number",
-  label: {
-    text: t("coronavirus_form.questions.business_details.company_number.label"),
-  },
-  error_message: error_items('company_number'),
-  value: @form_responses.dig(:business_details, :company_number),
+<%= render "govuk_publishing_components/components/radio", {
+  heading: t("coronavirus_form.questions.business_details.company_is_uk_registered.label"),
+  heading_size: "s",
+  name: "company_is_uk_registered",
+  error_message: error_items('company_is_uk_registered'),
+  items: [
+    {
+      id: "company_is_uk_registered",
+      value: t("coronavirus_form.questions.business_details.company_is_uk_registered.options.united_kingdom.label"),
+      text: t("coronavirus_form.questions.business_details.company_is_uk_registered.options.united_kingdom.label"),
+      checked: @form_responses.dig(:business_details, :company_is_uk_registered) == t("coronavirus_form.questions.business_details.company_is_uk_registered.options.united_kingdom.label"),
+      conditional: render("govuk_publishing_components/components/input", {
+        label: {
+          text: t("coronavirus_form.questions.business_details.company_is_uk_registered.options.united_kingdom.company_number.label"),
+        },
+        id: "company_number",
+        name: "company_number",
+        hint: t("coronavirus_form.questions.business_details.company_is_uk_registered.options.united_kingdom.company_number.hint"),
+        error_message: error_items('company_number'),
+        value: @form_responses.dig(:business_details, :company_number),
+        width: 10
+      })
+    },
+    {
+      value: t("coronavirus_form.questions.business_details.company_is_uk_registered.options.not_united_kingdom.label"),
+      text: t("coronavirus_form.questions.business_details.company_is_uk_registered.options.not_united_kingdom.label"),
+      checked: @form_responses.dig(:business_details, :company_is_uk_registered) == t("coronavirus_form.questions.business_details.company_is_uk_registered.options.not_united_kingdom.label"),
+    },
+  ]
 } %>
 
 <%= render "govuk_publishing_components/components/radio", {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,11 +82,11 @@ en:
       subject: You offered coronavirus support from your business
       body_text: |
         You told us that your business might be able to help with the response to coronavirus (COVID-19). Thank you.
-        
-        If you’ve offered personal protective equipment (PPE) your offer has been sent to the Department of Health and Social Care. If you’ve offered other types of support your offer has been sent to the Crown Commercial Service. 
+
+        If you’ve offered personal protective equipment (PPE) your offer has been sent to the Department of Health and Social Care. If you’ve offered other types of support your offer has been sent to the Crown Commercial Service.
 
         You’ll be contacted if your support is needed. This can take a few weeks. You do not need to do anything else.
-        
+
         Because we’re receiving a lot of offers, you might not hear back if your support is not needed.
 
         If you want to offer more products or services, answer the questions again with details of the new products or services:
@@ -183,6 +183,7 @@ en:
       invalid_date: "Enter a real %{field}"
       date_order: "The end date must be after the start date"
       email_format: "Enter an email address in the correct format, like name@example.com"
+      company_number: "Enter a Companies House registration number"
       postcode_format: "Enter a real postcode"
       page_title_prefix: 'Error: '
     testing_equipment:
@@ -675,7 +676,7 @@ en:
       custom_select_error: "Select if it would be a donation, a reduced price, or standard price"
     thank_you:
       title: "Thank you for offering support"
-      description: 
+      description:
         <p class="govuk-body">We’ve sent you a confirmation email.</p>
         <p class="govuk-body">If you’ve offered personal protective equipment (PPE) your offer has been sent to the Department of Health and Social Care. If you’ve offered other types of support your offer has been sent to the Crown Commercial Service.</p>
         <p class="govuk-body">You’ll be contacted if your support is needed. This can take a few weeks.</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -183,7 +183,7 @@ en:
       invalid_date: "Enter a real %{field}"
       date_order: "The end date must be after the start date"
       email_format: "Enter an email address in the correct format, like name@example.com"
-      company_number: "Enter a Companies House registration number"
+      company_number: "Enter a valid Companies House registration number"
       postcode_format: "Enter a real postcode"
       page_title_prefix: 'Error: '
     testing_equipment:
@@ -626,8 +626,18 @@ en:
         company_name:
           label: "Company name"
           custom_error: "Enter the name of your company"
-        company_number:
-          label: "Company number (optional)"
+        company_is_uk_registered:
+          label: "Is your company registered in the UK?"
+          custom_error: "Select if your company is registered in the UK"
+          options:
+            united_kingdom:
+              label: "Yes"
+              company_number:
+                label: "Company number"
+                hint: "This is the Companies House registration number"
+                custom_error: "Enter a company number"
+            not_united_kingdom:
+              label: "No"
         company_size:
           label: "Company size"
           options:

--- a/config/schemas/form_response.json
+++ b/config/schemas/form_response.json
@@ -349,7 +349,8 @@
           "type": "string"
         },
         "company_number": {
-          "type": ["string", "null"]
+          "type": ["string", "null"],
+          "pattern": "^([0-9]{8}|[A-Za-z]{2}[0-9]{6})$"
         },
         "company_size": {
           "type": "string",

--- a/config/schemas/form_response.json
+++ b/config/schemas/form_response.json
@@ -340,6 +340,7 @@
       "type": "object",
       "required": [
         "company_name",
+        "company_is_uk_registered",
         "company_size",
         "company_location"
       ],
@@ -348,8 +349,11 @@
         "company_name": {
           "type": "string"
         },
+        "company_is_uk_registered": {
+          "$ref": "#/definitions/yes_no"
+        },
         "company_number": {
-          "type": ["string", "null"],
+          "type": "string",
           "pattern": "^([0-9]{8}|[A-Za-z]{2}[0-9]{6})$"
         },
         "company_size": {

--- a/lib/upload_error_pages.rb
+++ b/lib/upload_error_pages.rb
@@ -8,7 +8,6 @@ class UploadErrorPages
   def upload
     error_pages.map do |error_page|
       path = Rails.root.join("public", error_page)
-      puts "Writing #{path} to S3 bucket #{bucket_name}"
       s3_client.put_object(
         acl: "public-read",
         body: File.open(path).read,

--- a/spec/controllers/coronavirus_form/business_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/business_details_controller_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe CoronavirusForm::BusinessDetailsController, type: :controller do
     let(:params) do
       {
         company_name: "My Company Ltd",
+        company_is_uk_registered: "Yes",
         company_number: "AA123456",
         company_size: "under_50_people",
         company_location: "united_kingdom",
@@ -59,6 +60,57 @@ RSpec.describe CoronavirusForm::BusinessDetailsController, type: :controller do
 
     it "validates company name is entered" do
       post :submit, params: params.merge(company_name: "")
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to render_template(current_template)
+    end
+
+    it "validates company registration option is chosen" do
+      post :submit, params: params.merge(company_is_uk_registered: "")
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to render_template(current_template)
+    end
+
+    it "does not require a company number if the company registration is not UK" do
+      post :submit,
+           params: params.merge(
+             company_is_uk_registered: I18n.t("coronavirus_form.questions.business_details.company_is_uk_registered.options.not_united_kingdom.label"),
+           ).except(:company_number)
+
+      expect(response).to redirect_to(contact_details_path)
+    end
+
+    it "validates a company number is provided if company registration is UK" do
+      post :submit,
+           params: params.merge(
+             company_is_uk_registered: I18n.t("coronavirus_form.questions.business_details.company_is_uk_registered.options.united_kingdom.label"),
+           ).except(:company_number)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to render_template(current_template)
+    end
+
+    it "redirects to next step when a valid company number is provided" do
+      valid_company_numbers = %w[12345678 AA123456]
+
+      valid_company_numbers.each do |company_number|
+        post :submit,
+             params: params.merge(
+               company_is_uk_registered: I18n.t("coronavirus_form.questions.business_details.company_is_uk_registered.options.united_kingdom.label"),
+               company_number: company_number,
+             )
+
+        expect(response).to redirect_to(contact_details_path)
+      end
+    end
+
+    it "does not redirect to next step when the company number is invalid" do
+      post :submit,
+           params: params.merge(
+             company_is_uk_registered: I18n.t("coronavirus_form.questions.business_details.company_is_uk_registered.options.united_kingdom.label"),
+             company_number: "AAA12345",
+           )
 
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response).to render_template(current_template)

--- a/spec/controllers/coronavirus_form/business_details_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/business_details_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe CoronavirusForm::BusinessDetailsController, type: :controller do
     let(:params) do
       {
         company_name: "My Company Ltd",
-        company_number: "1234",
+        company_number: "AA123456",
         company_size: "under_50_people",
         company_location: "united_kingdom",
         company_postcode: "AB11AA",

--- a/spec/helpers/check_answers_helper_spec.rb
+++ b/spec/helpers/check_answers_helper_spec.rb
@@ -234,7 +234,7 @@ RSpec.describe CheckAnswersHelper, type: :helper do
       it "concatenates business_details with a line break" do
         answer = {
           company_name: "Snow White Inc",
-          company_number: rand(10),
+          company_number: "AB123456",
           company_size: 1000,
           company_location: "UK",
           company_postcode: "E1 8QS",

--- a/spec/helpers/check_answers_helper_spec.rb
+++ b/spec/helpers/check_answers_helper_spec.rb
@@ -234,6 +234,7 @@ RSpec.describe CheckAnswersHelper, type: :helper do
       it "concatenates business_details with a line break" do
         answer = {
           company_name: "Snow White Inc",
+          company_is_uk_registered: "Yes",
           company_number: "AB123456",
           company_size: 1000,
           company_location: "UK",
@@ -242,6 +243,7 @@ RSpec.describe CheckAnswersHelper, type: :helper do
 
         expected_answer =
           "Company name: #{answer[:company_name]}<br>" \
+            "Company registered in the UK: #{answer[:company_is_uk_registered]}<br>" \
             "Company number: #{answer[:company_number]}<br>" \
             "Company size number: #{answer[:company_size]}<br>" \
             "Company location: #{answer[:company_location]}<br>" \
@@ -250,19 +252,25 @@ RSpec.describe CheckAnswersHelper, type: :helper do
         expect(helper.concat_answer(answer, question)).to eq(expected_answer)
       end
 
-      it "returns nothing if the business details are empty" do
-        answer = {}
+      context "company_is_uk_registered" do
+        it "returns only company_is_uk_registered if all other business detail fields have no value" do
+          answer = {
+            company_is_uk_registered: "No",
+          }
 
-        expect(helper.concat_answer(answer, question)).to be_empty
-      end
+          expected_answer = "Company registered in the UK: No"
+          expect(helper.concat_answer(answer, question)).to eq(expected_answer)
+        end
 
-      it "only concatenates the fields that have a value" do
-        answer = {
-          company_name: "Snow White Inc",
-        }
+        it "only concatenates the other business detail fields that have a value" do
+          answer = {
+            company_name: "Snow White Inc",
+            company_is_uk_registered: "No",
+          }
 
-        expected_answer = "Company name: #{answer[:company_name]}"
-        expect(helper.concat_answer(answer, question)).to eq(expected_answer)
+          expected_answer = "Company name: #{answer[:company_name]}<br>Company registered in the UK: No"
+          expect(helper.concat_answer(answer, question)).to eq(expected_answer)
+        end
       end
     end
 

--- a/spec/helpers/field_validation_helper_spec.rb
+++ b/spec/helpers/field_validation_helper_spec.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+
+RSpec.describe FieldValidationHelper, type: :helper do
+  describe "#validate_company_number" do
+    let(:field) { "company_number" }
+    let(:error) { [{ field: field, text: t("coronavirus_form.errors.company_number") }] }
+
+    it "can be 8 digits" do
+      expect(validate_company_number(field, "12345678")).to eq []
+    end
+
+    it "can be 2 alpha characters plus 6 digits" do
+      expect(validate_company_number(field, "AB123456")).to eq []
+    end
+
+    it "cannot be less than 8 digits long" do
+      expect(validate_company_number(field, "1234567")).to eq error
+    end
+
+    it "cannot be more than 8 digits long" do
+      expect(validate_company_number(field, "123456789")).to eq error
+    end
+
+    it "cannot have 1 alpha character" do
+      expect(validate_company_number(field, "A1234567")).to eq error
+    end
+
+    it "cannot have 3 alpha characters" do
+      expect(validate_company_number(field, "ABC12345")).to eq error
+    end
+  end
+end

--- a/spec/helpers/schema_helper_spec.rb
+++ b/spec/helpers/schema_helper_spec.rb
@@ -358,6 +358,22 @@ RSpec.describe SchemaHelper, type: :helper do
         expect(validate_against_form_response_schema(data).first).to include("company_name")
       end
 
+      it "returns a list of errors when company_is_uk_registered is missing" do
+        data = valid_data.tap do |valid_data|
+          valid_data[:business_details].delete(:company_is_uk_registered)
+        end
+
+        expect(validate_against_form_response_schema(data).first).to include("company_is_uk_registered")
+      end
+
+      it "returns a list of errors when company_is_uk_registered has an unexpected value" do
+        data = valid_data.tap do |valid_data|
+          valid_data[:business_details][:company_is_uk_registered] = "Foo"
+        end
+
+        expect(validate_against_form_response_schema(data).first).to include("company_is_uk_registered")
+      end
+
       it "allows company_number to be blank" do
         data = valid_data.tap do |valid_data|
           valid_data[:business_details].delete(:company_number)

--- a/spec/helpers/schema_helper_spec.rb
+++ b/spec/helpers/schema_helper_spec.rb
@@ -366,6 +366,14 @@ RSpec.describe SchemaHelper, type: :helper do
         expect(validate_against_form_response_schema(data)).to be_empty
       end
 
+      it "returns a list of errors when company_number has an invalid value" do
+        data = valid_data.tap do |valid_data|
+          valid_data[:business_details][:company_number] = "Foo"
+        end
+
+        expect(validate_against_form_response_schema(data).first).to include("company_number")
+      end
+
       it "returns a list of errors when company_size is missing" do
         data = valid_data.tap do |valid_data|
           valid_data[:business_details].delete(:company_size)

--- a/spec/support/fill_in_the_form_steps.rb
+++ b/spec/support/fill_in_the_form_steps.rb
@@ -197,6 +197,7 @@ module FillInTheFormSteps
   def and_has_given_their_business_details
     expect(page).to have_content(I18n.t("coronavirus_form.questions.business_details.title"))
     fill_in "company_name", with: "Government Digital Service"
+    choose I18n.t("coronavirus_form.questions.business_details.company_is_uk_registered.options.united_kingdom.label")
     fill_in "company_number", with: "AB123456"
     choose I18n.t("coronavirus_form.questions.business_details.company_size.options.under_50_people.label")
     choose I18n.t("coronavirus_form.questions.business_details.company_location.options.united_kingdom.label")

--- a/spec/support/fill_in_the_form_steps.rb
+++ b/spec/support/fill_in_the_form_steps.rb
@@ -197,7 +197,7 @@ module FillInTheFormSteps
   def and_has_given_their_business_details
     expect(page).to have_content(I18n.t("coronavirus_form.questions.business_details.title"))
     fill_in "company_name", with: "Government Digital Service"
-    fill_in "company_number", with: "020 3451 9000"
+    fill_in "company_number", with: "AB123456"
     choose I18n.t("coronavirus_form.questions.business_details.company_size.options.under_50_people.label")
     choose I18n.t("coronavirus_form.questions.business_details.company_location.options.united_kingdom.label")
     fill_in "company_postcode", with: "E1 8QS"

--- a/spec/support/form_response_helper.rb
+++ b/spec/support/form_response_helper.rb
@@ -46,6 +46,7 @@ module FormResponseHelper
       offer_other_support: "All the support, all the time!",
       business_details: {
         company_name: "Mandalore Inc.",
+        company_is_uk_registered: I18n.t("coronavirus_form.questions.business_details.company_is_uk_registered.options.united_kingdom.label"),
         company_number: "12345678",
         company_size: I18n.t("coronavirus_form.questions.business_details.company_size.options.under_50_people.label"),
         company_location: I18n.t("coronavirus_form.questions.business_details.company_location.options.united_kingdom.label"),


### PR DESCRIPTION
Why
----

CCS can only process offers from UK companies who have a company number, so we don't want UK companies who don't have a UK Company Registration Number (CRN) completing the form.

Non-UK companies can still complete the form without a company number.

What
----

This change replaces company number (optional) with a radio option that asks the user if their company is registered in the UK. If 'yes' is selected, it asks the user to enter their company number as a mandatory field. If 'no' is selected, it does not ask the user for their company
number.

Show suitable error messages and update the check your answers screen to include the new field and company number (if appropriate).

Links
-----

[Trello card](https://trello.com/c/JT4SfRoQ/576-make-company-number-mandatory)


Screenshots
-----

**New business details page**

![business-details-001-implemented](https://user-images.githubusercontent.com/44037625/84668162-2d776a80-af1b-11ea-811c-8afa681c9c74.png)

**New business details page with nothing entered**

![screencapture-localhost-5000-business-details-2020-06-16-08_46_24](https://user-images.githubusercontent.com/44037625/84748867-1aaf7500-afb1-11ea-8f74-fdd752c3aed8.png)

**New business details page with UK registered and UK location selected**

![screencapture-localhost-5000-business-details-2020-06-16-08_47_10](https://user-images.githubusercontent.com/44037625/84748894-269b3700-afb1-11ea-9c48-333ffde2b4d4.png)

**New check your details page showing UK registered and company number**

![check-your-answers-001-implemented](https://user-images.githubusercontent.com/44037625/84668214-4122d100-af1b-11ea-84e5-a6e525942e54.png)

**New check your details page showing not-UK registered and no company number**

![check-your-answers-002-implemented](https://user-images.githubusercontent.com/44037625/84668226-46801b80-af1b-11ea-970d-28bc8d335586.png)
