### PR TITLE
Add jasmine testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,9 @@ group :development, :test do
   gem "brakeman", "~> 4.8"
   gem "byebug", "~> 11"
   gem "foreman", "~> 0.87.1"
+  gem "govuk_test", "~> 1.0"
+  gem "jasmine"
+  gem "jasmine_selenium_runner", require: false
   gem "pry", "~> 0.13.1"
   gem "pry-rails", "~> 0.3.9"
   gem "rails-controller-testing", "~> 1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,12 +160,27 @@ GEM
       rake
       rouge
       sprockets (< 4)
+    govuk_test (1.0.3)
+      brakeman (~> 4.6)
+      capybara
+      puma
+      selenium-webdriver (>= 3.142)
+      webdrivers (>= 4)
     http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (1.8.3)
       concurrent-ruby (~> 1.0)
     ipaddress (0.8.3)
+    jasmine (3.5.1)
+      jasmine-core (~> 3.5.0)
+      phantomjs
+      rack (>= 1.2.1)
+      rake
+    jasmine-core (3.5.0)
+    jasmine_selenium_runner (3.0.0)
+      jasmine (~> 3.0)
+      selenium-webdriver (~> 3.8)
     jmespath (1.4.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
@@ -219,6 +234,7 @@ GEM
     parser (2.7.1.3)
       ast (~> 2.4.0)
     pg (1.2.3)
+    phantomjs (2.1.1.0)
     plek (3.0.0)
     prometheus-client (2.0.0)
     pry (0.13.1)
@@ -408,6 +424,9 @@ DEPENDENCIES
   foreman (~> 0.87.1)
   govuk_app_config (~> 2.2.0)
   govuk_publishing_components (~> 21.56.0)
+  govuk_test (~> 1.0)
+  jasmine
+  jasmine_selenium_runner
   json-schema
   listen (~> 3)
   lograge

--- a/Rakefile
+++ b/Rakefile
@@ -8,4 +8,4 @@ require_relative "config/application"
 
 Rails.application.load_tasks
 
-task default: %i[spec lint brakeman]
+task default: %i[spec jasmine:ci lint brakeman]

--- a/app/assets/javascripts/analytics.js.erb
+++ b/app/assets/javascripts/analytics.js.erb
@@ -1,20 +1,7 @@
 // Start cookie banner (display settings controlled internally by cookies)
 var element = document.querySelector('[data-module="cookie-banner"]')
-var PRODUCT_ID_PATTERN = /\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b/
-var REFERENCE_NUMBER_PATTERN = /\d{8}-\d{6}-.{6}/
 
 new GOVUK.Modules.CookieBanner().start($(element))
-
-var stripPII = function(url) {
-  url = url.replace(REFERENCE_NUMBER_PATTERN, 'reference_number')
-  url = url.replace(PRODUCT_ID_PATTERN, 'product_id')
-
-  if(url.includes('reference_number' || 'product_id')) {
-    return url
-  } else {
-    return location.protocol + '//' + location.host + location.pathname
-  }
-}
 
 var analyticsInit = function() {
   <% if Rails.application.config.analytics_tracking_id.present? %>
@@ -33,7 +20,7 @@ var analyticsInit = function() {
       ga('create', trackingId, 'auto')
       ga('set', 'allowAdFeatures', false);
       ga('set', 'anonymizeIp', true);
-      ga('set', 'location', stripPII(window.location.href));
+      ga('set', 'location', window.GOVUK.stripPII(window.location));
       ga('send', 'pageview');
 
       // Cross Government Domain Google Analytics
@@ -42,7 +29,7 @@ var analyticsInit = function() {
       ga('govuk_shared.set', 'anonymizeIp', true);
       ga('govuk_shared.set', 'allowAdFeatures', false);
       ga('govuk_shared.linker:autoLink', ['www.gov.uk']);
-      ga('govuk_shared.set', 'location', stripPII(window.location.href));
+      ga('govuk_shared.set', 'location', window.GOVUK.stripPII(window.location));
       ga('govuk_shared.send', 'pageview');
     }
   <% end %>

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -7,6 +7,7 @@
 //= require govuk_publishing_components/components/cookie-banner
 //= require govuk_publishing_components/components/error-summary
 //= require govuk_publishing_components/components/radio
+//= require stripPII
 //= require analytics
 //= require cookies
 window.CookieSettings.start()

--- a/app/assets/javascripts/stripPII.js
+++ b/app/assets/javascripts/stripPII.js
@@ -1,0 +1,28 @@
+window.GOVUK = window.GOVUK || {}
+
+var stripPII = function (url) {
+  var _splitAndRedact = function (url) {
+    var queryString = url.search.replace(/^\?/,'').split('&')
+    var redactedArray = []
+
+    for (var i = 0; i < queryString.length; i++) {
+      if (queryString[i].startsWith('reference_number') || queryString[i].startsWith('product_id')) {
+        var paramToRedact = queryString[i].split('=')
+        redactedArray.push(paramToRedact[0] + '=<' + paramToRedact[0].toUpperCase() + '>')
+      } else {
+        if (queryString[i] !== "") redactedArray.push(queryString[i])
+      }
+    }
+
+    return redactedArray.length > 0 ? '?' + redactedArray.join('&') : ''
+  }
+
+  try {
+    return url.protocol + '//' + url.host + url.pathname + _splitAndRedact(url) + url.hash
+  } catch (error) {
+    console.error(error)
+    return ''
+  }
+}
+
+window.GOVUK.stripPII = stripPII

--- a/spec/javascripts/stripPII_spec.js
+++ b/spec/javascripts/stripPII_spec.js
@@ -1,0 +1,51 @@
+describe('stripPII', function () {
+  it ('returns an empty string given an empty string', function () {
+    expect(stripPII('')).toEqual('')
+  })
+
+  it ('returns an empty string given a null', function () {
+    expect(stripPII(null)).toEqual('')
+  })
+
+  it ('replaces nothing if there is no query string', function () {
+    var givenURL = new URL('http://example.com/')
+    var expectedURL = 'http://example.com/'
+
+    expect(stripPII(givenURL)).toEqual(expectedURL)
+  })
+
+  it ('replaces nothing if there are no redactable params', function () {
+    var givenURL = new URL('http://example.com/?test=blah')
+    var expectedURL = 'http://example.com/?test=blah'
+
+    expect(stripPII(givenURL)).toEqual(expectedURL)
+  })
+
+  it ('replaces reference_number', function() {
+    var givenURL = new URL('http://example.com/?test=blah&reference_number=12345')
+    var expectedURL = 'http://example.com/?test=blah&reference_number=<REFERENCE_NUMBER>'
+
+    expect(stripPII(givenURL)).toEqual(expectedURL)
+  })
+
+  it ('replaces product_id', function() {
+    var givenURL = new URL('http://example.com/?test=blah&product_id=12345')
+    var expectedURL = 'http://example.com/?test=blah&product_id=<PRODUCT_ID>'
+
+    expect(stripPII(givenURL)).toEqual(expectedURL)
+  })
+
+  it ('replaces both reference_number and product_id', function() {
+    var givenURL = new URL('http://example.com/?product_id=12345&test=blah&reference_number=12345')
+    var expectedURL = 'http://example.com/?product_id=<PRODUCT_ID>&test=blah&reference_number=<REFERENCE_NUMBER>'
+
+    expect(stripPII(givenURL)).toEqual(expectedURL)
+  })
+
+  it ('replaces product_id with a page link', function() {
+    var givenURL = new URL('http://example.com/?test=blah&product_id=12345#page_link')
+    var expectedURL = 'http://example.com/?test=blah&product_id=<PRODUCT_ID>#page_link'
+
+    expect(stripPII(givenURL)).toEqual(expectedURL)
+  })
+})

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -1,0 +1,7 @@
+src_files:
+  - 'app/assets/javascripts/stripPII.js'
+
+spec_files:
+  - '**/*_spec.js'
+
+spec_helper: spec/javascripts/support/jasmine_helper.rb

--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -1,0 +1,15 @@
+require "jasmine/runners/selenium"
+require "webdrivers/chromedriver"
+
+Jasmine.configure do |config|
+  config.prevent_phantom_js_auto_install = true
+
+  config.runner = lambda { |formatter, jasmine_server_url|
+    options = Selenium::WebDriver::Chrome::Options.new
+    options.headless!
+    options.add_argument("--no-sandbox")
+
+    webdriver = Selenium::WebDriver.for(:chrome, options: options)
+    Jasmine::Runners::Selenium.new(formatter, jasmine_server_url, webdriver, 50)
+  }
+end


### PR DESCRIPTION
What
----

We need to test that the `product_id` and `reference_number` are redacted and sent in the correct format. 

Currently, if the parameter names changed or the code used to generate the IDs changed, then there would be no test in place to test that redacting the params for GA had broken as a result. 

If the `product_id` and `reference_number` patterns are not matched and redacted, then the params are dropped, so we don't risk sending PII data. The reason that we kept redacted data at all, is that the PAs advise that it is better to have [redacted-number] because it shows that there is missing data and what the redacted data is.

This change adds testing.

Co-authored-by: Ian James <ian.james@digital.cabinet-office.gov.uk>

Links
-----

[Trello cards](https://trello.com/c/M7GUZRpa/585-add-jasmine-testing-to-business-volunteers-form-to-test-redacting-ga-params)
