### PR TITLE
Update Dockerfile to fix broken quality-checks in pipeline

### DIFF
--- a/concourse/Dockerfile
+++ b/concourse/Dockerfile
@@ -10,15 +10,12 @@ FROM ruby:2.6.6-buster
 # Adds google chrome to software sources, install chrome, install postgres and redis
 # clear up lists behind ourselves
 RUN apt-get update --fix-missing && apt-get -y upgrade \
-    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-    && apt-get update \
+    && wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
     && apt-get install -y --no-install-recommends \
-      google-chrome-unstable \
+      ./google-chrome-stable_current_amd64.deb \
       postgresql-11 \
       redis-server \
-    && rm -rf /var/lib/apt/lists/* \
-    && rm -rf /src/*.deb
+    && rm ./google-chrome-stable_current_amd64.deb
 
 ENV CHROME_NO_SANDBOX=true
 


### PR DESCRIPTION
- Capybara requires headless chrome
- We encountered an issue in that the Chrome version we used in the Dockerfile stopped working, thus causing the tests to fail in the pipeline
- We are still investigating what happened, but think the problem has been caused due to using google-chrome-unstable
- We now install a stable version of chrome

We have tested this in a local Docker container.

Co-authored-by: Huw Diprose <huw.diprose@digital.cabinet-office.gov.uk>
Co-authored-by: Leena Gupte <leena.gupte@digital.cabinet-office.gov.uk>

