### PR TITLE
Allow company number to be blank in schema (if company not UK registered)

### DIFF
--- a/config/schemas/form_response.json
+++ b/config/schemas/form_response.json
@@ -364,7 +364,7 @@
         },
         "company_number": {
           "type": "string",
-          "pattern": "^([0-9]{8}|[A-Za-z]{2}[0-9]{6})$"
+          "pattern": "^$|^([0-9]{8}|[A-Za-z]{2}[0-9]{6})$"
         },
         "company_size": {
           "type": "string",

--- a/spec/helpers/schema_helper_spec.rb
+++ b/spec/helpers/schema_helper_spec.rb
@@ -376,7 +376,7 @@ RSpec.describe SchemaHelper, type: :helper do
 
       it "allows company_number to be blank" do
         data = valid_data.tap do |valid_data|
-          valid_data[:business_details].delete(:company_number)
+          valid_data[:business_details][:company_number] = ""
         end
 
         expect(validate_against_form_response_schema(data)).to be_empty


### PR DESCRIPTION
What
----

Company number can be `""` - if company is not UK registered. This was failing validation and reporting error to sentry

How to review
-------------

:ship: Since this service is continuously deployed, all testing must be done
before the pull request is merged. :ship:

For developer locally:
For company select "No" for registered in UK
Debug session and ensure check_answers_controller#submit line 15 validation errors does not have any error for company number.

Links
-----

https://trello.com/c/RkmCEolp/632-error-is-sent-to-sentry-if-the-business-is-not-registered-in-the-uk
