### PR TITLE
Fixes double pageview when cookies are accepted

### DIFF
--- a/app/assets/javascripts/analytics.js.erb
+++ b/app/assets/javascripts/analytics.js.erb
@@ -1,8 +1,3 @@
-// Start cookie banner (display settings controlled internally by cookies)
-var element = document.querySelector('[data-module="cookie-banner"]')
-
-new GOVUK.Modules.CookieBanner().start($(element))
-
 var analyticsInit = function() {
   <% if Rails.application.config.analytics_tracking_id.present? %>
     var trackingId = "<%= Rails.application.config.analytics_tracking_id %>"


### PR DESCRIPTION



What & why
----
Two pageviews were being fired when a user accepted cookies using the cookie banner. This is not a good thing, as it artificially inflates views on any page where a user accepts cookies.

The cookie banner was being initalised twice, with two sets of listeners set up to fire pageviews attached to the banner. This pull request removes one of those, so the pageviews now only fire once when a user has accepted cookies.

How to review
-------------

1. Clear all cookies 
1. Check that no tracking blocking plugin is running
1. Check that a GA debugger is running
1. Visit the site
1. Accept cookies

Expected - only one page view is fired once cookies have been accepted.

Links
-----

Trello card: https://trello.com/c/qcLLrnqK

