### PR TITLE
Update query string redaction to redact all values

### DIFF
--- a/app/assets/javascripts/stripPII.js
+++ b/app/assets/javascripts/stripPII.js
@@ -6,11 +6,15 @@ var stripPII = function (url) {
     var redactedArray = []
 
     for (var i = 0; i < queryString.length; i++) {
-      if (queryString[i].startsWith('reference_number') || queryString[i].startsWith('product_id')) {
+      if (queryString[i] !== '') {
         var paramToRedact = queryString[i].split('=')
-        redactedArray.push(paramToRedact[0] + '=<' + paramToRedact[0].toUpperCase() + '>')
-      } else {
-        if (queryString[i] !== '') redactedArray.push(queryString[i])
+
+        redactedArray.push(
+          paramToRedact[0] +
+          '=<' +
+          paramToRedact[0].toUpperCase() +
+          '>'
+        )
       }
     }
 
@@ -18,7 +22,12 @@ var stripPII = function (url) {
   }
 
   try {
-    return url.protocol + '//' + url.host + url.pathname + _splitAndRedact(url) + url.hash
+    return url.protocol +
+      '//' +
+      url.host +
+      url.pathname +
+      _splitAndRedact(url) +
+      url.hash
   } catch (error) {
     console.error(error)
     return ''

--- a/spec/javascripts/stripPII_spec.js
+++ b/spec/javascripts/stripPII_spec.js
@@ -1,50 +1,39 @@
+/* eslint-env jasmine */
+/* global stripPII */
+
 describe('stripPII', function () {
-  it ('returns an empty string given an empty string', function () {
+  it('returns an empty string given an empty string', function () {
     expect(stripPII('')).toEqual('')
   })
 
-  it ('returns an empty string given a null', function () {
+  it('returns an empty string given a null', function () {
     expect(stripPII(null)).toEqual('')
   })
 
-  it ('replaces nothing if there is no query string', function () {
+  it("does nothing if there's no query string", function () {
     var givenURL = new URL('http://example.com/')
     var expectedURL = 'http://example.com/'
 
     expect(stripPII(givenURL)).toEqual(expectedURL)
   })
 
-  it ('replaces nothing if there are no redactable params', function () {
+  it('redacts a single parameter', function () {
     var givenURL = new URL('http://example.com/?test=blah')
-    var expectedURL = 'http://example.com/?test=blah'
+    var expectedURL = 'http://example.com/?test=<TEST>'
 
     expect(stripPII(givenURL)).toEqual(expectedURL)
   })
 
-  it ('replaces reference_number', function() {
-    var givenURL = new URL('http://example.com/?test=blah&reference_number=12345')
-    var expectedURL = 'http://example.com/?test=blah&reference_number=<REFERENCE_NUMBER>'
-
-    expect(stripPII(givenURL)).toEqual(expectedURL)
-  })
-
-  it ('replaces product_id', function() {
-    var givenURL = new URL('http://example.com/?test=blah&product_id=12345')
-    var expectedURL = 'http://example.com/?test=blah&product_id=<PRODUCT_ID>'
-
-    expect(stripPII(givenURL)).toEqual(expectedURL)
-  })
-
-  it ('replaces both reference_number and product_id', function() {
+  it('redacts all parameters', function () {
     var givenURL = new URL('http://example.com/?product_id=12345&test=blah&reference_number=12345')
-    var expectedURL = 'http://example.com/?product_id=<PRODUCT_ID>&test=blah&reference_number=<REFERENCE_NUMBER>'
+    var expectedURL = 'http://example.com/?product_id=<PRODUCT_ID>&test=<TEST>&reference_number=<REFERENCE_NUMBER>'
 
     expect(stripPII(givenURL)).toEqual(expectedURL)
   })
 
-  it ('replaces product_id with a page link', function() {
+  it('redacts parameters when a page link is present', function () {
     var givenURL = new URL('http://example.com/?test=blah&product_id=12345#page_link')
-    var expectedURL = 'http://example.com/?test=blah&product_id=<PRODUCT_ID>#page_link'
+    var expectedURL = 'http://example.com/?test=<TEST>&product_id=<PRODUCT_ID>#page_link'
 
     expect(stripPII(givenURL)).toEqual(expectedURL)
   })


### PR DESCRIPTION
What
----
All query string values are now redacted, regardless of what they are.

Previously, only two set keys were redacted. This would mean that any change in the keys - eg `product_id` to `productID` - would not be redacted and could cause a leak into Google Analytics. Redacting all the values will prevent this.

This brings this app to parity with alphagov/govuk-coronavirus-vulnerable-people-form/pull/410

## Why

Because PII in GA is bad and this will help prevent any PII from being reported.

How to review

Links

Trello

How to review
-------------

 - Using a GA debugger, check that any URL with query string correctly redacts the values.
 - The Google doc linked to the Trello card may also be useful for giving some more context
 - Check the Jasmine tests cover all bases

Links
-----
 Part of https://trello.com/c/JFMD3vzV

