### PR TITLE
; Add semicolon back

### DIFF
--- a/app/assets/javascripts/analytics.js.erb
+++ b/app/assets/javascripts/analytics.js.erb
@@ -6,7 +6,7 @@ var analyticsInit = function() {
     // Start analytics only if we have user consent
     var consentCookie = window.GOVUK.getConsentCookie()
     if (consentCookie && consentCookie["usage"]) {
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=ri[r]=i[r]||function(){
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
                               m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
       })(window,document,'script','https://www.google-analytics.com/analytics.js','ga')


### PR DESCRIPTION
What
----
A semicolon was erroneously removed from the Google Analytics tracking snippet - which then broke it.

This pull request adds that semicolon back in.

How to review
-------------

Open browser tools, go to console
Accept cookies
Check that it doesn't break.

Links
-----

https://trello.com/c/RSNi0Hq8

