### PR TITLE
Use older image tag in pipeline, to fix PaaS deploys

### DIFF
--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -3,7 +3,7 @@ image_resource:
   type: docker-image
   source:
     repository: governmentpaas/cf-cli
-    tag: latest
+    tag: 5b44bd954693937ddd07ee6c9e113923bc620aed
 inputs:
   - name: git-master
     path: src

--- a/concourse/tasks/export-form-responses.yml
+++ b/concourse/tasks/export-form-responses.yml
@@ -3,7 +3,7 @@ image_resource:
   type: docker-image
   source:
     repository: governmentpaas/cf-cli
-    tag: latest
+    tag: 5b44bd954693937ddd07ee6c9e113923bc620aed
 params:
   CF_API: https://api.cloud.service.gov.uk
   CF_USERNAME: ((paas-username))


### PR DESCRIPTION
- PaaS have updated the Docker image to use a new version of the CLI
- This commit tags a compatible version, to enable us to deploy with the current commands
- This is a quick fix, we'll make a Trello task for updating our commands so that we can go back to using the latest image on (https://hub.docker.com/r/governmentpaas/cf-cli/tags)