### PR TITLE
Bug fix - data not being cleared when going from a 'Yes' option to a 'No' option

### DIFF
--- a/app/controllers/coronavirus_form/accommodation_controller.rb
+++ b/app/controllers/coronavirus_form/accommodation_controller.rb
@@ -36,6 +36,8 @@ private
     session[:accommodation] = @form_responses[:accommodation]
 
     if @form_responses[:accommodation] == I18n.t("coronavirus_form.questions.#{controller_name}.options.no_option.label")
+      session[:rooms_number] = nil
+      session[:accommodation_description] = nil
       session[:accommodation_cost] = nil
     end
   end

--- a/app/controllers/coronavirus_form/offer_care_controller.rb
+++ b/app/controllers/coronavirus_form/offer_care_controller.rb
@@ -33,6 +33,9 @@ private
     session[:offer_care] = @form_responses[:offer_care]
 
     if @form_responses[:offer_care] == I18n.t("coronavirus_form.questions.#{controller_name}.options.option_no.label")
+      session[:offer_care_type] = nil
+      session[:offer_care_qualifications] = nil
+      session[:offer_care_qualifications_type] = nil
       session[:care_cost] = nil
     end
   end

--- a/app/controllers/coronavirus_form/offer_space_controller.rb
+++ b/app/controllers/coronavirus_form/offer_space_controller.rb
@@ -30,7 +30,12 @@ private
     session[:offer_space] = @form_responses[:offer_space]
 
     if @form_responses[:offer_space] == I18n.t("coronavirus_form.questions.#{controller_name}.options.option_no.label")
+      session[:offer_space_type] = nil
+      session[:general_space_description] = nil
       session[:space_cost] = nil
+      session[:offer_space_type_other] = nil
+      session[:warehouse_space_description] = nil
+      session[:office_space_description] = nil
     end
   end
 

--- a/app/controllers/coronavirus_form/offer_staff_controller.rb
+++ b/app/controllers/coronavirus_form/offer_staff_controller.rb
@@ -28,6 +28,13 @@ private
 
   def update_session_store
     session[:offer_staff] = @form_responses[:offer_staff]
+
+    if @form_responses[:offer_staff] == I18n.t("coronavirus_form.questions.#{controller_name}.options.option_no.label")
+      session[:offer_staff_type] = nil
+      session[:offer_staff_description] = nil
+      session[:offer_staff_charge] = nil
+      session[:offer_staff_number] = nil
+    end
   end
 
   def previous_path

--- a/app/controllers/coronavirus_form/offer_transport_controller.rb
+++ b/app/controllers/coronavirus_form/offer_transport_controller.rb
@@ -33,6 +33,8 @@ private
     session[:offer_transport] = @form_responses[:offer_transport]
 
     if @form_responses[:offer_transport] == I18n.t("coronavirus_form.questions.#{controller_name}.options.option_no.label")
+      session[:transport_type] = nil
+      session[:transport_description] = nil
       session[:transport_cost] = nil
     end
   end

--- a/spec/controllers/coronavirus_form/accommodation_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/accommodation_controller_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe CoronavirusForm::AccommodationController, type: :controller do
     let(:permitted_values) do
       I18n.t("coronavirus_form.questions.accommodation.options").map { |_, item| item[:label] }
     end
+    let(:selected_no) { I18n.t("coronavirus_form.questions.accommodation.options.no_option.label") }
 
     it "sets session variables" do
       post :submit, params: { accommodation: selected }
@@ -37,21 +38,25 @@ RSpec.describe CoronavirusForm::AccommodationController, type: :controller do
     end
 
     it "redirects to transport for a no response" do
-      post :submit, params: { accommodation: I18n.t("coronavirus_form.questions.accommodation.options.no_option.label") }
+      post :submit, params: { accommodation: selected_no }
       expect(response).to redirect_to(offer_transport_path)
     end
 
-    it "clears previously entered care cost for a 'No' response" do
+    it "clears previously entered answers given a 'No' response" do
+      session[:rooms_number] = 1000
+      session[:accommodation_description] = "Gludwch destun ar hap yma."
       session[:accommodation_cost] = I18n.t("coronavirus_form.how_much_charge.options").map { |_, item| item[:label] }.sample
 
-      post :submit, params: { accommodation: I18n.t("coronavirus_form.questions.accommodation.options.no_option.label") }
+      post :submit, params: { accommodation: selected_no }
 
+      expect(session[:rooms_number]).to be nil
+      expect(session[:accommodation_description]).to be nil
       expect(session[:accommodation_cost]).to be nil
     end
 
     it "redirects to check your answers if check your answers previously seen and answer is no" do
       session[:check_answers_seen] = true
-      post :submit, params: { accommodation: I18n.t("coronavirus_form.questions.accommodation.options.no_option.label") }
+      post :submit, params: { accommodation: selected_no }
 
       expect(response).to redirect_to(check_your_answers_path)
     end

--- a/spec/controllers/coronavirus_form/offer_care_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/offer_care_controller_spec.rb
@@ -55,11 +55,17 @@ RSpec.describe CoronavirusForm::OfferCareController, type: :controller do
       expect(response).to redirect_to(offer_other_support_path)
     end
 
-    it "clears previously entered care cost for a 'No' response" do
+    it "clears previously entered answers given a 'No' response" do
+      session[:offer_care_type] = I18n.t("coronavirus_form.questions.offer_care_qualifications.offer_care_type.options").map { |_, item| item[:label] }.sample
+      session[:offer_care_qualifications] = "Gludwch destun ar hap yma."
+      session[:offer_care_qualifications_type] = I18n.t("coronavirus_form.questions.offer_care_qualifications.care_qualifications.options").map { |_, item| item[:label] }.sample
       session[:care_cost] = I18n.t("coronavirus_form.how_much_charge.options").map { |_, item| item[:label] }.sample
 
       post :submit, params: { offer_care: selected_no }
 
+      expect(session[:offer_care_type]).to be nil
+      expect(session[:offer_care_qualifications]).to be nil
+      expect(session[:offer_care_qualifications_type]).to be nil
       expect(session[:care_cost]).to be nil
     end
 

--- a/spec/controllers/coronavirus_form/offer_space_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/offer_space_controller_spec.rb
@@ -27,6 +27,8 @@ RSpec.describe CoronavirusForm::OfferSpaceController, type: :controller do
     let(:permitted_values) do
       I18n.t("coronavirus_form.questions.offer_space.options").map { |_, item| item[:label] }
     end
+    let(:selected_yes) { I18n.t("coronavirus_form.questions.offer_space.options.option_yes.label") }
+    let(:selected_no) { I18n.t("coronavirus_form.questions.offer_space.options.option_no.label") }
 
     it "sets session variables" do
       post :submit, params: { offer_space: selected }
@@ -34,33 +36,43 @@ RSpec.describe CoronavirusForm::OfferSpaceController, type: :controller do
     end
 
     it "redirects to next step for a 'No' response" do
-      post :submit, params: { offer_space: I18n.t("coronavirus_form.questions.offer_space.options.option_no.label") }
+      post :submit, params: { offer_space: selected_no }
       expect(response).to redirect_to(offer_staff_path)
     end
 
-    it "clears previously entered space cost for a 'No' response" do
+    it "clears previously entered answers given a 'No' response" do
+      session[:offer_space_type] = permitted_values
+      session[:general_space_description] = "Gludwch destun ar hap yma."
       session[:space_cost] = I18n.t("coronavirus_form.how_much_charge.options").map { |_, item| item[:label] }.sample
+      session[:offer_space_type_other] = "Gludwch destun ar hap yma."
+      session[:warehouse_space_description] = "Gludwch destun ar hap yma."
+      session[:office_space_description] = "Gludwch destun ar hap yma."
 
-      post :submit, params: { offer_space: I18n.t("coronavirus_form.questions.offer_space.options.option_no.label") }
+      post :submit, params: { offer_space: selected_no }
 
+      expect(session[:offer_space_type]).to be nil
+      expect(session[:general_space_description]).to be nil
       expect(session[:space_cost]).to be nil
+      expect(session[:offer_space_type_other]).to be nil
+      expect(session[:warehouse_space_description]).to be nil
+      expect(session[:office_space_description]).to be nil
     end
 
     it "redirects to next step for a 'Yes' response" do
-      post :submit, params: { offer_space: I18n.t("coronavirus_form.questions.offer_space.options.option_yes.label") }
+      post :submit, params: { offer_space: selected_yes }
       expect(response).to redirect_to(offer_space_type_path)
     end
 
     it "redirects to check your answers if check your answers previously seen" do
       session[:check_answers_seen] = true
-      post :submit, params: { offer_space: I18n.t("coronavirus_form.questions.offer_space.options.option_no.label") }
+      post :submit, params: { offer_space: selected_no }
 
       expect(response).to redirect_to(check_your_answers_path)
     end
 
     it "redirects to check your answers if answer is Yes regardless of check your answers state" do
       session[:check_answers_seen] = true
-      post :submit, params: { offer_space: I18n.t("coronavirus_form.questions.offer_space.options.option_yes.label") }
+      post :submit, params: { offer_space: selected_yes }
 
       expect(response).to redirect_to(offer_space_type_path)
     end

--- a/spec/controllers/coronavirus_form/offer_staff_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/offer_staff_controller_spec.rb
@@ -27,6 +27,8 @@ RSpec.describe CoronavirusForm::OfferStaffController, type: :controller do
     let(:permitted_values) do
       I18n.t("coronavirus_form.questions.offer_staff.options").map { |_, item| item[:label] }
     end
+    let(:selected_yes) { I18n.t("coronavirus_form.questions.offer_staff.options.option_yes.label") }
+    let(:selected_no) { I18n.t("coronavirus_form.questions.offer_staff.options.option_no.label") }
 
     it "sets session variables" do
       post :submit, params: { offer_staff: selected }
@@ -34,25 +36,39 @@ RSpec.describe CoronavirusForm::OfferStaffController, type: :controller do
     end
 
     it "redirects to next step for a 'No' response" do
-      post :submit, params: { offer_staff: I18n.t("coronavirus_form.questions.offer_staff.options.option_no.label") }
+      post :submit, params: { offer_staff: selected_no }
       expect(response).to redirect_to(expert_advice_type_path)
     end
 
     it "redirects to next step for a 'Yes' response" do
-      post :submit, params: { offer_staff: I18n.t("coronavirus_form.questions.offer_staff.options.option_yes.label") }
+      post :submit, params: { offer_staff: selected_yes }
       expect(response).to redirect_to(offer_staff_type_path)
+    end
+
+    it "clears previously entered answers given a 'No' response" do
+      session[:offer_staff_type] = permitted_values
+      session[:offer_staff_description] = "Gludwch destun ar hap yma."
+      session[:offer_staff_number] = 1000
+      session[:offer_staff_charge] = I18n.t("coronavirus_form.how_much_charge.options").map { |_, item| item[:label] }.sample
+
+      post :submit, params: { offer_staff: selected_no }
+
+      expect(session[:offer_staff_type]).to be nil
+      expect(session[:offer_staff_description]).to be nil
+      expect(session[:offer_staff_number]).to be nil
+      expect(session[:offer_staff_charge]).to be nil
     end
 
     it "redirects to check your answers if check your answers previously seen" do
       session[:check_answers_seen] = true
-      post :submit, params: { offer_staff: I18n.t("coronavirus_form.questions.offer_staff.options.option_no.label") }
+      post :submit, params: { offer_staff: selected_no }
 
       expect(response).to redirect_to(check_your_answers_path)
     end
 
     it "redirects to check your answers if answer is Yes regardless of check your answers state" do
       session[:check_answers_seen] = true
-      post :submit, params: { offer_staff: I18n.t("coronavirus_form.questions.offer_staff.options.option_yes.label") }
+      post :submit, params: { offer_staff: selected_yes }
 
       expect(response).to redirect_to(offer_staff_type_path)
     end

--- a/spec/controllers/coronavirus_form/offer_transport_controller_spec.rb
+++ b/spec/controllers/coronavirus_form/offer_transport_controller_spec.rb
@@ -41,11 +41,15 @@ RSpec.describe CoronavirusForm::OfferTransportController, type: :controller do
       expect(response).to redirect_to(offer_space_path)
     end
 
-    it "clears previously entered transport cost for a NO response" do
+    it "clears previously entered answers given a 'No' response" do
+      session[:transport_type] = I18n.t("coronavirus_form.questions.transport_type.options").map { |_, item| item[:label] }.sample
+      session[:transport_description] = "Gludwch destun ar hap yma."
       session[:transport_cost] = I18n.t("coronavirus_form.how_much_charge.options").map { |_, item| item[:label] }.sample
 
       post :submit, params: { offer_transport: selected_no }
 
+      expect(session[:transport_type]).to be nil
+      expect(session[:transport_description]).to be nil
       expect(session[:transport_cost]).to be nil
     end
 


### PR DESCRIPTION
What
----

When going from a 'Yes' option to a 'No' option on some pages, the old values and data was not being cleared correctly.

This change resolves the issue.

Links
-----

[Trello cards](https://trello.com/c/eGsOEifg/488-update-check-your-answers-page)

