### PR TITLE
Reduce the number of PaaS instances from 10 to 2.

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -183,7 +183,7 @@ jobs:
         file: git-master/concourse/tasks/deploy-to-govuk-paas.yml
         params:
           CF_SPACE: production
-          INSTANCES: 10
+          INSTANCES: 2
           WORKER_INSTANCES: 1
           CF_STARTUP_TIMEOUT: 15 # minutes
           REQUIRE_BASIC_AUTH:


### PR DESCRIPTION
This service is being retired. We need to reduce the number of instances in production but keep it alive in order to keep the redirect that we have in place. Staging instances will be kept the same so that we can continue to work on it if needs be.

## Before merge
* Wait for the go ahead to retire the service
* Merge https://github.com/alphagov/covid-engineering/pull/578