### PR TITLE
Use latest cli commands

### DIFF
--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -3,7 +3,7 @@ image_resource:
   type: docker-image
   source:
     repository: governmentpaas/cf-cli
-    tag: 5b44bd954693937ddd07ee6c9e113923bc620aed
+    tag: latest
 inputs:
   - name: git-master
     path: src

--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -39,12 +39,12 @@ run:
       cf api "$CF_API"
       cf auth
       cf t -o "$CF_ORG" -s "$CF_SPACE"
-      cf v3-create-app govuk-coronavirus-business-volunteer-form || true
-      cf v3-apply-manifest -f manifest.yml
+      cf create-app govuk-coronavirus-business-volunteer-form || true
+      cf apply-manifest -f manifest.yml
       cf set-env govuk-coronavirus-business-volunteer-form CF_STARTUP_TIMEOUT "$CF_STARTUP_TIMEOUT"
 
-      cf v3-scale --process web -i "$INSTANCES" govuk-coronavirus-business-volunteer-form
-      cf v3-scale --process worker -i "$WORKER_INSTANCES" govuk-coronavirus-business-volunteer-form
+      cf scale --process web -i "$INSTANCES" govuk-coronavirus-business-volunteer-form
+      cf scale --process worker -i "$WORKER_INSTANCES" govuk-coronavirus-business-volunteer-form
 
       cf set-env govuk-coronavirus-business-volunteer-form AWS_ASSETS_BUCKET_NAME "$AWS_ASSETS_BUCKET_NAME"
       cf set-env govuk-coronavirus-business-volunteer-form AWS_ERROR_PAGES_BUCKET_NAME "$AWS_ERROR_PAGES_BUCKET_NAME"

--- a/concourse/tasks/deploy-to-govuk-paas.yml
+++ b/concourse/tasks/deploy-to-govuk-paas.yml
@@ -63,5 +63,5 @@ run:
       cf set-env govuk-coronavirus-business-volunteer-form GOVUK_NOTIFY_TEMPLATE_ID "$GOVUK_NOTIFY_TEMPLATE_ID"
       cf set-env govuk-coronavirus-business-volunteer-form NOTIFY_API_KEY "$NOTIFY_API_KEY"
       cf set-env govuk-coronavirus-business-volunteer-form PAAS_ENV "$CF_SPACE"
-      cf v3-zdt-push govuk-coronavirus-business-volunteer-form --wait-for-deploy-complete --no-route
+      cf push govuk-coronavirus-business-volunteer-form --strategy rolling
       cf map-route govuk-coronavirus-business-volunteer-form cloudapps.digital --hostname "$HOSTNAME"


### PR DESCRIPTION
Follows on from: https://github.com/alphagov/govuk-coronavirus-find-support/pull/337

What
----

The pipeline failed when deploying to staging. 

```
'v3-create-app' is not a registered command. See 'cf help -a'
'v3-apply-manifest' is not a registered command. See 'cf help -a'
```

The reason for this is that PaaS changed the Docker image to use a newer version of the CLI.

As a quick fix, we tagged a version that we knew to work with the cli that we are currently using. 

This updates the CLI commands so that we can go back to using `tag: latest` 

https://hub.docker.com/r/governmentpaas/cf-cli/tags

The changes are taken from the [list of updated CLI v7 commands](https://docs.cloudfoundry.org/cf-cli/v7.html#table)

How to review
-------------

:ship: Since this service is continuously deployed, all testing must be done
before the pull request is merged. :ship:

NOTE: I'm not sure how to test this locally.
Install version 7 of the CLI:
```
brew install cloudfoundry/tap/cf-cli@7
```

Links
-----

[Trello cards](https://trello.com/c/o0LxKNog)

